### PR TITLE
feat(city-panel): stage city/schedule edits with adaptive timeline bo…

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import { saveTrip, getTripById } from './services/storageService';
 import { appendHistoryEntry, findHistoryEntryByUrl } from './services/historyService';
 import { buildShareUrl, buildTripUrl, decompressTrip, generateTripId, generateVersionId, getStoredAppLanguage, isUuid, setStoredAppLanguage } from './utils';
 import { DB_ENABLED, applyUserSettingsToLocalStorage, dbCreateTripVersion, dbGetSharedTrip, dbGetTrip, dbGetTripVersion, dbUpdateSharedTrip, dbUpsertTrip, dbGetUserSettings, dbUpsertUserSettings, ensureDbSession, syncTripsFromDb, uploadLocalTripsToDb } from './services/dbService';
+import { AppDialogProvider } from './components/AppDialogProvider';
 
 const createLocalHistoryEntry = (
     navigate: ReturnType<typeof useNavigate>,
@@ -480,7 +481,9 @@ const AppContent: React.FC = () => {
 const App: React.FC = () => {
     return (
         <Router>
-            <AppContent />
+            <AppDialogProvider>
+                <AppContent />
+            </AppDialogProvider>
         </Router>
     );
 };

--- a/components/AppDialogProvider.tsx
+++ b/components/AppDialogProvider.tsx
@@ -1,0 +1,289 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type DialogTone = 'default' | 'danger';
+
+export interface ConfirmDialogOptions {
+    title?: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    tone?: DialogTone;
+}
+
+export interface PromptDialogOptions {
+    title?: string;
+    message?: string;
+    label?: string;
+    placeholder?: string;
+    defaultValue?: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    tone?: DialogTone;
+    inputType?: 'text' | 'url' | 'email' | 'search';
+    validate?: (value: string) => string | null;
+}
+
+interface AppDialogApi {
+    confirm: (options: ConfirmDialogOptions) => Promise<boolean>;
+    prompt: (options: PromptDialogOptions) => Promise<string | null>;
+}
+
+type ConfirmRequest = {
+    kind: 'confirm';
+    options: ConfirmDialogOptions;
+    resolve: (value: boolean) => void;
+};
+
+type PromptRequest = {
+    kind: 'prompt';
+    options: PromptDialogOptions;
+    resolve: (value: string | null) => void;
+};
+
+type DialogRequest = ConfirmRequest | PromptRequest;
+
+const AppDialogContext = createContext<AppDialogApi | undefined>(undefined);
+
+const focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+const getToneButtonClass = (tone?: DialogTone): string => {
+    if (tone === 'danger') return 'bg-red-600 hover:bg-red-700 focus:ring-red-400';
+    return 'bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-400';
+};
+
+export const AppDialogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const queueRef = useRef<DialogRequest[]>([]);
+    const [activeRequest, setActiveRequest] = useState<DialogRequest | null>(null);
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const cancelButtonRef = useRef<HTMLButtonElement>(null);
+    const confirmButtonRef = useRef<HTMLButtonElement>(null);
+    const promptInputRef = useRef<HTMLInputElement>(null);
+    const lastFocusedRef = useRef<HTMLElement | null>(null);
+    const [promptValue, setPromptValue] = useState('');
+    const [promptError, setPromptError] = useState<string | null>(null);
+
+    const showNext = useCallback(() => {
+        if (queueRef.current.length === 0) return;
+        const next = queueRef.current.shift() || null;
+        setActiveRequest(next);
+    }, []);
+
+    useEffect(() => {
+        if (!activeRequest) {
+            showNext();
+        }
+    }, [activeRequest, showNext]);
+
+    const enqueue = useCallback((request: DialogRequest) => {
+        setActiveRequest((current) => {
+            if (!current) return request;
+            queueRef.current.push(request);
+            return current;
+        });
+    }, []);
+
+    const confirm = useCallback((options: ConfirmDialogOptions) => {
+        return new Promise<boolean>((resolve) => {
+            enqueue({ kind: 'confirm', options, resolve });
+        });
+    }, [enqueue]);
+
+    const prompt = useCallback((options: PromptDialogOptions) => {
+        return new Promise<string | null>((resolve) => {
+            enqueue({ kind: 'prompt', options, resolve });
+        });
+    }, [enqueue]);
+
+    const closeWithResult = useCallback((result: boolean | string | null) => {
+        if (!activeRequest) return;
+
+        if (activeRequest.kind === 'confirm') {
+            activeRequest.resolve(Boolean(result));
+        } else {
+            activeRequest.resolve(typeof result === 'string' ? result : null);
+        }
+
+        setActiveRequest(null);
+        setPromptError(null);
+    }, [activeRequest]);
+
+    useEffect(() => {
+        if (!activeRequest) return;
+
+        if (activeRequest.kind === 'prompt') {
+            setPromptValue(activeRequest.options.defaultValue || '');
+            setPromptError(null);
+        }
+
+        lastFocusedRef.current = document.activeElement as HTMLElement | null;
+        const focusTarget = window.setTimeout(() => {
+            if (activeRequest.kind === 'prompt') {
+                promptInputRef.current?.focus();
+                promptInputRef.current?.select();
+                return;
+            }
+            confirmButtonRef.current?.focus();
+        }, 0);
+
+        const originalOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            window.clearTimeout(focusTarget);
+            document.body.style.overflow = originalOverflow;
+            if (lastFocusedRef.current) {
+                lastFocusedRef.current.focus();
+            }
+        };
+    }, [activeRequest]);
+
+    useEffect(() => {
+        if (!activeRequest) return;
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeWithResult(activeRequest.kind === 'confirm' ? false : null);
+                return;
+            }
+
+            if (event.key !== 'Tab' || !dialogRef.current) return;
+            const focusables = Array.from(dialogRef.current.querySelectorAll<HTMLElement>(focusableSelector))
+                .filter((node) => !node.hasAttribute('disabled'));
+            if (focusables.length === 0) return;
+
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+            const current = document.activeElement as HTMLElement | null;
+
+            if (event.shiftKey) {
+                if (current === first || !dialogRef.current.contains(current)) {
+                    event.preventDefault();
+                    last.focus();
+                }
+                return;
+            }
+
+            if (current === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [activeRequest, closeWithResult]);
+
+    const handleConfirmClick = useCallback(() => {
+        if (!activeRequest) return;
+        if (activeRequest.kind === 'confirm') {
+            closeWithResult(true);
+            return;
+        }
+
+        const nextValue = promptValue.trim();
+        const error = activeRequest.options.validate?.(nextValue) || null;
+        if (error) {
+            setPromptError(error);
+            return;
+        }
+        closeWithResult(nextValue);
+    }, [activeRequest, closeWithResult, promptValue]);
+
+    const contextValue = useMemo<AppDialogApi>(() => ({ confirm, prompt }), [confirm, prompt]);
+    const descriptionText = activeRequest
+        ? (activeRequest.kind === 'confirm' ? activeRequest.options.message : (activeRequest.options.message || ''))
+        : '';
+
+    return (
+        <AppDialogContext.Provider value={contextValue}>
+            {children}
+            {activeRequest && createPortal(
+                <div className="fixed inset-0 z-[20000] flex items-center justify-center p-4">
+                    <div
+                        className="absolute inset-0 bg-black/45 backdrop-blur-[2px]"
+                        onClick={() => closeWithResult(activeRequest.kind === 'confirm' ? false : null)}
+                    />
+                    <div
+                        ref={dialogRef}
+                        role="dialog"
+                        aria-modal="true"
+                        aria-labelledby="app-dialog-title"
+                        aria-describedby={descriptionText ? 'app-dialog-description' : undefined}
+                        className="relative z-10 w-full max-w-md rounded-2xl bg-white shadow-2xl border border-gray-100 overflow-hidden"
+                    >
+                        <div className="px-5 py-4 border-b border-gray-100">
+                            <h2 id="app-dialog-title" className="text-base font-bold text-gray-900">
+                                {activeRequest.options.title || (activeRequest.kind === 'confirm' ? 'Confirm Action' : 'Input Required')}
+                            </h2>
+                        </div>
+                        <div className="px-5 py-4 space-y-3">
+                            {descriptionText && (
+                                <p id="app-dialog-description" className="text-sm text-gray-600 leading-relaxed">
+                                    {descriptionText}
+                                </p>
+                            )}
+                            {activeRequest.kind === 'prompt' && (
+                                <div className="space-y-1.5">
+                                    {activeRequest.options.label && (
+                                        <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                            {activeRequest.options.label}
+                                        </label>
+                                    )}
+                                    <input
+                                        ref={promptInputRef}
+                                        type={activeRequest.options.inputType || 'text'}
+                                        value={promptValue}
+                                        onChange={(event) => {
+                                            setPromptValue(event.target.value);
+                                            if (promptError) setPromptError(null);
+                                        }}
+                                        className="w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm text-gray-800 focus:ring-2 focus:ring-indigo-300 focus:border-indigo-500 outline-none"
+                                        placeholder={activeRequest.options.placeholder}
+                                        onKeyDown={(event) => {
+                                            if (event.key === 'Enter') {
+                                                event.preventDefault();
+                                                handleConfirmClick();
+                                            }
+                                        }}
+                                    />
+                                    {promptError && (
+                                        <p className="text-xs text-red-600">{promptError}</p>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                        <div className="px-5 py-3 bg-gray-50 border-t border-gray-100 flex items-center justify-end gap-2">
+                            <button
+                                ref={cancelButtonRef}
+                                type="button"
+                                onClick={() => closeWithResult(activeRequest.kind === 'confirm' ? false : null)}
+                                className="px-3 py-1.5 text-xs font-semibold text-gray-600 bg-white border border-gray-200 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-300"
+                            >
+                                {activeRequest.options.cancelLabel || 'Cancel'}
+                            </button>
+                            <button
+                                ref={confirmButtonRef}
+                                type="button"
+                                onClick={handleConfirmClick}
+                                className={`px-3 py-1.5 text-xs font-semibold text-white rounded-md focus:outline-none focus:ring-2 ${getToneButtonClass(activeRequest.options.tone)}`}
+                            >
+                                {activeRequest.options.confirmLabel || 'Confirm'}
+                            </button>
+                        </div>
+                    </div>
+                </div>,
+                document.body
+            )}
+        </AppDialogContext.Provider>
+    );
+};
+
+export const useAppDialog = (): AppDialogApi => {
+    const context = useContext(AppDialogContext);
+    if (!context) {
+        throw new Error('useAppDialog must be used within an AppDialogProvider');
+    }
+    return context;
+};

--- a/components/DetailsPanel.tsx
+++ b/components/DetailsPanel.tsx
@@ -1,21 +1,26 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { ITimelineItem, TransportMode, ActivityType, IHotel, RouteMode } from '../types';
-import { X, MapPin, Clock, Trash2, Hotel, PlusCircle, Search, AlertTriangle, ExternalLink, Sparkles, RefreshCw, Maximize, Minimize, Minus, Plus, Palette } from 'lucide-react';
+import { ITimelineItem, TransportMode, ActivityType, IHotel, RouteMode, ICoordinates } from '../types';
+import { X, MapPin, Clock, Trash2, Hotel, Search, AlertTriangle, ExternalLink, Sparkles, RefreshCw, Maximize, Minimize, Minus, Plus, Palette, Pencil } from 'lucide-react';
 import { suggestActivityDetails, generateCityNotesAddition } from '../services/geminiService';
 import type { CityNotesEnhancementMode } from '../services/geminiService';
-import { ALL_ACTIVITY_TYPES, TRAVEL_COLOR, addDays, formatDate, getStoredAppLanguage, PRESET_COLORS, getActivityColorByTypes, normalizeActivityTypes, DEFAULT_DISTANCE_UNIT, estimateTravelHours, formatDistance, formatDurationHours, getTravelLegMetricsForItem } from '../utils';
+import { ALL_ACTIVITY_TYPES, TRAVEL_COLOR, addDays, formatDate, getStoredAppLanguage, PRESET_COLORS, getActivityColorByTypes, normalizeActivityTypes, DEFAULT_DISTANCE_UNIT, estimateTravelHours, formatDistance, formatDurationHours, getTravelLegMetricsForItem, getNormalizedCityName, COUNTRIES } from '../utils';
 import { useGoogleMaps } from './GoogleMapsLoader';
 import { MarkdownEditor } from './MarkdownEditor';
 import type { MarkdownAiAction } from './MarkdownEditor';
 import { ActivityTypeIcon, formatActivityTypeLabel, getActivityTypeButtonClass } from './ActivityTypeVisuals';
 import { TransportModeIcon } from './TransportModeIcon';
+import { useAppDialog } from './AppDialogProvider';
 
 interface DetailsPanelProps {
   item: ITimelineItem | null;
   isOpen: boolean;
   onClose: () => void;
   onUpdate: (id: string, updates: Partial<ITimelineItem>) => void;
+  onBatchUpdate?: (
+      changes: Array<{ id: string; updates: Partial<ITimelineItem> }>,
+      options?: { label?: string; deferCommit?: boolean; skipPendingLabel?: boolean }
+  ) => void;
   onDelete: (id: string) => void;
   tripStartDate: string;
   tripItems?: ITimelineItem[];
@@ -31,6 +36,19 @@ interface DetailsPanelProps {
 interface PendingCityNotesProposal {
     actionLabel: string;
     addition: string;
+}
+
+interface DurationDraft {
+    startDateOffset: number;
+    duration: number;
+}
+
+interface CityDraft {
+    location: string;
+    title: string;
+    coordinates?: ICoordinates;
+    countryName?: string;
+    countryCode?: string;
 }
 
 const CITY_NOTES_AI_ACTIONS: MarkdownAiAction[] = [
@@ -60,11 +78,40 @@ const appendNotes = (existing: string, addition: string): string => {
     return `${existing.trimEnd()}\n\n${trimmedAddition}`;
 };
 
+const toFlagEmoji = (countryCode?: string): string | null => {
+    if (!countryCode) return null;
+    const upper = countryCode.trim().toUpperCase();
+    if (!/^[A-Z]{2}$/.test(upper)) return null;
+    return upper
+        .split('')
+        .map(char => String.fromCodePoint(127397 + char.charCodeAt(0)))
+        .join('');
+};
+
+const getCountryFromText = (text?: string): { countryName?: string; countryCode?: string } => {
+    if (!text) return {};
+    const parts = text.split(',').map(part => part.trim()).filter(Boolean);
+    if (parts.length < 2) return {};
+    const rawCountry = parts[parts.length - 1];
+    const matched = COUNTRIES.find(country => country.name.toLocaleLowerCase() === rawCountry.toLocaleLowerCase());
+    if (!matched) return {};
+    return {
+        countryName: matched.name,
+        countryCode: matched.code,
+    };
+};
+
+const getCityNameFromText = (text: string): string => {
+    const firstPart = text.split(',')[0]?.trim();
+    return firstPart || text.trim();
+};
+
 export const DetailsPanel: React.FC<DetailsPanelProps> = ({ 
     item, 
     isOpen, 
     onClose, 
     onUpdate, 
+    onBatchUpdate,
     onDelete, 
     tripStartDate, 
     tripItems = [],
@@ -83,6 +130,18 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
   const [aiError, setAiError] = useState<string | null>(null);
   const [pendingNotesProposal, setPendingNotesProposal] = useState<PendingCityNotesProposal | null>(null);
   const [cachedItem, setCachedItem] = useState<ITimelineItem | null>(item);
+  const [isDurationEditorOpen, setIsDurationEditorOpen] = useState(false);
+  const [durationDraft, setDurationDraft] = useState<DurationDraft | null>(null);
+  const [isCityEditorOpen, setIsCityEditorOpen] = useState(false);
+  const [cityDraft, setCityDraft] = useState<CityDraft | null>(null);
+  const [cityInputValue, setCityInputValue] = useState('');
+  const [citySearchError, setCitySearchError] = useState<string | null>(null);
+  const cityInputRef = useRef<HTMLInputElement>(null);
+  const cityAutocompleteRef = useRef<any>(null);
+  const lastItemIdRef = useRef<string | null>(item?.id || null);
+  const durationBaselineRef = useRef<DurationDraft | null>(null);
+  const cityBaselineRef = useRef<CityDraft | null>(null);
+  const cityRoundTripContextRef = useRef<{ isRoundTrip: boolean; isFirstCity: boolean; lastCityId: string | null } | null>(null);
 
   // Search State for Hotels
   const [hotelQuery, setHotelQuery] = useState('');
@@ -103,7 +162,64 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
 
   const { isLoaded } = useGoogleMaps();
+  const { confirm: confirmDialog } = useAppDialog();
   const mapLanguage = getStoredAppLanguage();
+
+  const applyItemChanges = (
+      changes: Array<{ id: string; updates: Partial<ITimelineItem> }>,
+      options?: { label?: string; deferCommit?: boolean; skipPendingLabel?: boolean }
+  ) => {
+      if (!canEdit || changes.length === 0) return;
+      if (changes.length === 1 && !onBatchUpdate) {
+          if (options?.deferCommit) return;
+          onUpdate(changes[0].id, changes[0].updates);
+          return;
+      }
+      if (onBatchUpdate) {
+          onBatchUpdate(changes, options);
+          return;
+      }
+      changes.forEach(change => onUpdate(change.id, change.updates));
+  };
+
+  const closeDurationEditor = (options?: { revertPreview?: boolean }) => {
+      if (options?.revertPreview !== false && displayItem?.type === 'city' && durationBaselineRef.current) {
+          applyItemChanges(
+              [{
+                  id: displayItem.id,
+                  updates: {
+                      startDateOffset: durationBaselineRef.current.startDateOffset,
+                      duration: durationBaselineRef.current.duration,
+                  },
+              }],
+              { deferCommit: true, skipPendingLabel: true }
+          );
+      }
+      setIsDurationEditorOpen(false);
+      setDurationDraft(null);
+      durationBaselineRef.current = null;
+  };
+
+  const closeCityEditor = (_options?: { revertPreview?: boolean }) => {
+      setIsCityEditorOpen(false);
+      setCityDraft(null);
+      setCityInputValue('');
+      setCitySearchError(null);
+      cityAutocompleteRef.current = null;
+      cityBaselineRef.current = null;
+      cityRoundTripContextRef.current = null;
+  };
+
+  const discardDraftEdits = () => {
+      closeDurationEditor();
+      closeCityEditor();
+      setIsColorPickerOpen(false);
+  };
+
+  const handleClosePanel = () => {
+      discardDraftEdits();
+      onClose();
+  };
 
   // Initialize Google Places Service (TextSearch)
   useEffect(() => {
@@ -141,6 +257,15 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
     } else {
         setIsVisible(false);
         setIsColorPickerOpen(false); 
+        setIsDurationEditorOpen(false);
+        setDurationDraft(null);
+        setIsCityEditorOpen(false);
+        setCityDraft(null);
+        setCityInputValue('');
+        setCitySearchError(null);
+        durationBaselineRef.current = null;
+        cityBaselineRef.current = null;
+        cityRoundTripContextRef.current = null;
         timerId = setTimeout(() => {
             setIsRendered(false);
             setDragOffset(0);
@@ -157,26 +282,106 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
         if (isOpen && e.key === 'Escape') {
-            if (isColorPickerOpen) setIsColorPickerOpen(false);
-            else onClose();
+            if (isColorPickerOpen) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                setIsColorPickerOpen(false);
+                return;
+            }
+            if (isDurationEditorOpen) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                closeDurationEditor();
+                return;
+            }
+            if (isCityEditorOpen) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                closeCityEditor();
+                return;
+            }
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            handleClosePanel();
         }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose, isColorPickerOpen]);
+  }, [isOpen, isColorPickerOpen, isDurationEditorOpen, isCityEditorOpen, onClose, closeDurationEditor, closeCityEditor, handleClosePanel]);
 
   // Cache Item logic
   useEffect(() => {
-    if (item) {
-        setCachedItem(item);
+    if (!item) {
+        lastItemIdRef.current = null;
+        return;
+    }
+
+    const switchedItem = lastItemIdRef.current !== item.id;
+    setCachedItem(item);
+
+    if (switchedItem) {
         setHotelQuery('');
         setHotelResults([]);
         setIsColorPickerOpen(false);
+        setIsDurationEditorOpen(false);
+        setDurationDraft(null);
+        setIsCityEditorOpen(false);
+        setCityDraft(null);
+        setCityInputValue('');
+        setCitySearchError(null);
+        durationBaselineRef.current = null;
+        cityBaselineRef.current = null;
+        cityRoundTripContextRef.current = null;
         setAiStatus(null);
         setAiError(null);
         setPendingNotesProposal(null);
     }
+
+    lastItemIdRef.current = item.id;
   }, [item]);
+
+  useEffect(() => {
+      if (!isCityEditorOpen) return;
+      if (!isLoaded || !cityInputRef.current || !(window as any).google?.maps?.places) return;
+
+      let listener: { remove: () => void } | null = null;
+
+      try {
+          const autocomplete = new (window as any).google.maps.places.Autocomplete(cityInputRef.current, {
+              types: ['(cities)'],
+              fields: ['geometry', 'name', 'formatted_address'],
+          });
+          cityAutocompleteRef.current = autocomplete;
+
+          listener = autocomplete.addListener('place_changed', () => {
+              const place = autocomplete.getPlace();
+              if (!place) return;
+              const name = place.name || place.formatted_address?.split(',')[0] || cityInputRef.current?.value || '';
+              const geometry = place.geometry?.location;
+              const coordinates = geometry
+                  ? { lat: geometry.lat(), lng: geometry.lng() }
+                  : undefined;
+              const parsedCountry = getCountryFromText(place.formatted_address || '');
+              const nextDraft = buildCityDraft(name, {
+                  coordinates,
+                  countryName: parsedCountry.countryName,
+                  countryCode: parsedCountry.countryCode,
+              });
+
+              setCityInputValue(name);
+              setCityDraft(nextDraft);
+              setCitySearchError(null);
+          });
+      } catch (error) {
+          console.error('City autocomplete init failed', error);
+          setCitySearchError('City search is unavailable. You can still type manually.');
+      }
+
+      return () => {
+          if (listener) listener.remove();
+          cityAutocompleteRef.current = null;
+      };
+  }, [isCityEditorOpen, isLoaded]);
 
   useEffect(() => {
       if (!aiStatus || isEnhancing) return;
@@ -194,6 +399,276 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
   const handleDeleteItem = (id: string) => {
       if (!canEdit) return;
       onDelete(id);
+  };
+
+  const sortedCityItems = React.useMemo(
+      () => tripItems
+          .filter(entry => entry.type === 'city')
+          .sort((a, b) => a.startDateOffset - b.startDateOffset),
+      [tripItems]
+  );
+  const firstCityItem = sortedCityItems[0] || null;
+  const lastCityItem = sortedCityItems.length > 1 ? sortedCityItems[sortedCityItems.length - 1] : null;
+  const isRoundTripSequence = !!(
+      firstCityItem &&
+      lastCityItem &&
+      getNormalizedCityName(firstCityItem.title || firstCityItem.location) ===
+          getNormalizedCityName(lastCityItem.title || lastCityItem.location)
+  );
+  const isEditingFirstCity = !!(displayItem && displayItem.type === 'city' && firstCityItem && displayItem.id === firstCityItem.id);
+
+  const areCoordinatesEqual = (a?: ICoordinates, b?: ICoordinates): boolean => {
+      if (!a && !b) return true;
+      if (!a || !b) return false;
+      return Math.abs(a.lat - b.lat) < 0.000001 && Math.abs(a.lng - b.lng) < 0.000001;
+  };
+
+  const areCityDraftEqual = (a: CityDraft, b: CityDraft): boolean => {
+      return (
+          getNormalizedCityName(a.location) === getNormalizedCityName(b.location) &&
+          getNormalizedCityName(a.title) === getNormalizedCityName(b.title) &&
+          (a.countryName || '') === (b.countryName || '') &&
+          (a.countryCode || '') === (b.countryCode || '') &&
+          areCoordinatesEqual(a.coordinates, b.coordinates)
+      );
+  };
+
+  const buildCityDraft = (
+      location: string,
+      options?: Partial<Pick<CityDraft, 'coordinates' | 'countryName' | 'countryCode' | 'title'>>
+  ): CityDraft => {
+      const locationValue = location.trim();
+      const parsedCountry = getCountryFromText(locationValue);
+      return {
+          location: locationValue,
+          title: (options?.title || getCityNameFromText(locationValue || options?.title || '')).trim() || locationValue,
+          coordinates: options?.coordinates,
+          countryName: options?.countryName ?? parsedCountry.countryName,
+          countryCode: options?.countryCode ?? parsedCountry.countryCode,
+      };
+  };
+
+  const resolveCityApplyPayload = (cityItem: ITimelineItem, draft: CityDraft): Partial<ITimelineItem> => {
+      const normalizedCurrent = getNormalizedCityName(cityItem.location || cityItem.title);
+      const normalizedNext = getNormalizedCityName(draft.location || draft.title);
+      const cityChanged = normalizedCurrent !== normalizedNext;
+
+      return {
+          title: draft.title || getCityNameFromText(draft.location || cityItem.title),
+          location: draft.location || cityItem.location || cityItem.title,
+          coordinates: draft.coordinates ?? (cityChanged ? undefined : cityItem.coordinates),
+          countryName: draft.countryName ?? (cityChanged ? undefined : cityItem.countryName),
+          countryCode: draft.countryCode ?? (cityChanged ? undefined : cityItem.countryCode),
+      };
+  };
+
+  const applyDurationPreview = (next: DurationDraft) => {
+      if (!displayItem || displayItem.type !== 'city') return;
+      applyItemChanges(
+          [{ id: displayItem.id, updates: { startDateOffset: next.startDateOffset, duration: next.duration } }],
+          { deferCommit: true, skipPendingLabel: true }
+      );
+  };
+
+  const openDurationEditor = () => {
+      if (!canEdit || !displayItem || displayItem.type !== 'city') return;
+      closeCityEditor();
+      durationBaselineRef.current = {
+          startDateOffset: displayItem.startDateOffset,
+          duration: displayItem.duration,
+      };
+      setIsDurationEditorOpen(true);
+      setDurationDraft({
+          startDateOffset: displayItem.startDateOffset,
+          duration: displayItem.duration,
+      });
+  };
+
+  const updateDurationStartDraft = (delta: number) => {
+      setDurationDraft(prev => {
+          if (!prev) return prev;
+          const next = {
+              startDateOffset: prev.startDateOffset + delta,
+              duration: Math.max(0.5, prev.duration - delta),
+          };
+          applyDurationPreview(next);
+          return next;
+      });
+  };
+
+  const updateDurationEndDraft = (delta: number) => {
+      setDurationDraft(prev => {
+          if (!prev) return prev;
+          const next = {
+              ...prev,
+              duration: Math.max(0.5, prev.duration + delta),
+          };
+          applyDurationPreview(next);
+          return next;
+      });
+  };
+
+  const handleForceFillDraft = () => {
+      if (!displayItem || displayItem.type !== 'city') return;
+      const cityItems = sortedCityItems;
+      const targetIndex = cityItems.findIndex(entry => entry.id === displayItem.id);
+      if (targetIndex === -1) return;
+
+      const targetCity = cityItems[targetIndex];
+      const prevCity = targetIndex > 0 ? cityItems[targetIndex - 1] : null;
+      const nextCity = targetIndex < cityItems.length - 1 ? cityItems[targetIndex + 1] : null;
+
+      const prevEnd = prevCity ? prevCity.startDateOffset + prevCity.duration : 0;
+      const newStart = prevCity ? prevEnd : 0;
+      let newDuration = targetCity.duration;
+
+      if (nextCity) {
+          const availableDuration = nextCity.startDateOffset - newStart;
+          newDuration = Math.max(0.5, availableDuration);
+      }
+
+      const nextDraft = {
+          startDateOffset: newStart,
+          duration: Math.max(0.5, newDuration),
+      };
+      setDurationDraft(nextDraft);
+      applyDurationPreview(nextDraft);
+  };
+
+  const handleApplyDurationEdit = () => {
+      if (!canEdit || !displayItem || displayItem.type !== 'city' || !durationDraft) return;
+      const baseline = durationBaselineRef.current;
+      if (!baseline) {
+          closeDurationEditor({ revertPreview: false });
+          return;
+      }
+      const hasChange =
+          Math.abs(durationDraft.startDateOffset - baseline.startDateOffset) > 0.001 ||
+          Math.abs(durationDraft.duration - baseline.duration) > 0.001;
+      if (hasChange) {
+          applyItemChanges(
+              [{ id: displayItem.id, updates: { startDateOffset: durationDraft.startDateOffset, duration: durationDraft.duration } }],
+              { label: `Data: Changed city duration in ${displayItem.title}` }
+          );
+      }
+      closeDurationEditor({ revertPreview: false });
+  };
+
+  const openCityEditor = () => {
+      if (!canEdit || !displayItem || displayItem.type !== 'city') return;
+      closeDurationEditor({ revertPreview: true });
+      const baseLocation = displayItem.location || displayItem.title;
+      const baselineDraft = buildCityDraft(baseLocation, {
+          title: displayItem.title,
+          coordinates: displayItem.coordinates,
+          countryName: displayItem.countryName,
+          countryCode: displayItem.countryCode,
+      });
+      cityBaselineRef.current = baselineDraft;
+      cityRoundTripContextRef.current = {
+          isRoundTrip: isRoundTripSequence,
+          isFirstCity: isEditingFirstCity,
+          lastCityId: lastCityItem?.id || null,
+      };
+      setIsCityEditorOpen(true);
+      setCityDraft(baselineDraft);
+      setCityInputValue(baseLocation);
+      setCitySearchError(null);
+      window.setTimeout(() => cityInputRef.current?.focus(), 30);
+  };
+
+  const hasCityUpdateChanges = (cityItem: ITimelineItem, updates: Partial<ITimelineItem>): boolean => {
+      if (updates.title !== undefined && updates.title !== cityItem.title) return true;
+      if (updates.location !== undefined && updates.location !== cityItem.location) return true;
+      if (updates.countryName !== undefined && updates.countryName !== cityItem.countryName) return true;
+      if (updates.countryCode !== undefined && updates.countryCode !== cityItem.countryCode) return true;
+      if (!areCoordinatesEqual(cityItem.coordinates, updates.coordinates)) return true;
+      return false;
+  };
+
+  const handleApplyCityEdit = async () => {
+      if (!canEdit || !displayItem || displayItem.type !== 'city' || !cityDraft) return;
+      const baseline = cityBaselineRef.current;
+      if (!baseline) {
+          closeCityEditor({ revertPreview: false });
+          return;
+      }
+      const nextLocation = cityInputValue.trim() || cityDraft.location.trim();
+      if (!nextLocation) {
+          setCitySearchError('Please choose a city name.');
+          return;
+      }
+
+      const normalizedCurrent = getNormalizedCityName(baseline.location || baseline.title);
+      const normalizedNext = getNormalizedCityName(nextLocation);
+      const isUnchanged = normalizedCurrent === normalizedNext;
+      const nextDraft = buildCityDraft(nextLocation, {
+          title: getCityNameFromText(nextLocation),
+          coordinates: cityDraft.coordinates,
+          countryName: cityDraft.countryName,
+          countryCode: cityDraft.countryCode,
+      });
+      const changes: Array<{ id: string; updates: Partial<ITimelineItem> }> = [];
+      const primaryUpdates = resolveCityApplyPayload(displayItem, nextDraft);
+      if (!areCityDraftEqual(nextDraft, baseline) || hasCityUpdateChanges(displayItem, primaryUpdates)) {
+          changes.push({ id: displayItem.id, updates: primaryUpdates });
+      }
+
+      const roundTripContext = cityRoundTripContextRef.current;
+      if (roundTripContext?.isRoundTrip && roundTripContext.isFirstCity && roundTripContext.lastCityId && !isUnchanged) {
+          const shouldSyncLastCity = await confirmDialog({
+              title: 'Update Roundtrip Endpoint?',
+              message: `This trip looks like a roundtrip. Also change the final city to "${nextDraft.title}"?`,
+              confirmLabel: 'Yes, Update Last City',
+              cancelLabel: 'No, Keep As Is',
+          });
+          if (shouldSyncLastCity) {
+              const roundTripLastCity = tripItems.find(entry => entry.id === roundTripContext.lastCityId && entry.type === 'city') || null;
+              if (roundTripLastCity && roundTripLastCity.id !== displayItem.id) {
+                  const lastCityUpdates = resolveCityApplyPayload(roundTripLastCity, nextDraft);
+                  if (hasCityUpdateChanges(roundTripLastCity, lastCityUpdates)) {
+                      changes.push({
+                          id: roundTripLastCity.id,
+                          updates: lastCityUpdates,
+                      });
+                  }
+              }
+          }
+      }
+
+      if (changes.length === 0) {
+          closeCityEditor({ revertPreview: false });
+          return;
+      }
+
+      applyItemChanges(changes, {
+          label: changes.length > 1
+              ? `Data: Updated roundtrip city and title to ${nextDraft.title}`
+              : `Data: Changed city and title to ${nextDraft.title}`,
+      });
+      closeCityEditor({ revertPreview: false });
+  };
+
+  const handleCityInputChange = (rawValue: string) => {
+      const input = rawValue;
+      const explicitCountry = getCountryFromText(input);
+      setCityInputValue(input);
+      setCityDraft(prev => {
+          const previous = prev || buildCityDraft(displayItem?.location || displayItem?.title || input, {
+              title: displayItem?.title || getCityNameFromText(input),
+              coordinates: displayItem?.coordinates,
+              countryName: displayItem?.countryName,
+              countryCode: displayItem?.countryCode,
+          });
+          const isSameLocation = getNormalizedCityName(previous.location) === getNormalizedCityName(input);
+          const next = buildCityDraft(input, {
+              coordinates: isSameLocation ? previous.coordinates : undefined,
+              countryName: explicitCountry.countryName ?? (isSameLocation ? previous.countryName : undefined),
+              countryCode: explicitCountry.countryCode ?? (isSameLocation ? previous.countryCode : undefined),
+          });
+          return next;
+      });
+      setCitySearchError(null);
   };
 
   // -- Data Fetching & Helpers (Same as before) --
@@ -336,7 +811,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
   // Touch Handlers (Overlay Mobile)
   const handleTouchStart = (e: React.TouchEvent) => { if (variant === 'overlay' && window.innerWidth < 640) { dragStartY.current = e.touches[0].clientY; setIsDragging(true); }};
   const handleTouchMove = (e: React.TouchEvent) => { if (variant === 'overlay' && window.innerWidth < 640 && dragStartY.current !== null) { const delta = e.touches[0].clientY - dragStartY.current; if (delta > 0) setDragOffset(delta); }};
-  const handleTouchEnd = () => { if (variant === 'overlay' && window.innerWidth < 640) { setIsDragging(false); dragStartY.current = null; if (dragOffset > 100) onClose(); else setDragOffset(0); }};
+  const handleTouchEnd = () => { if (variant === 'overlay' && window.innerWidth < 640) { setIsDragging(false); dragStartY.current = null; if (dragOffset > 100) handleClosePanel(); else setDragOffset(0); }};
 
 
   if (!isRendered || !displayItem) return null;
@@ -371,8 +846,13 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
   };
   const tripStart = new Date(tripStartDate);
   const isValidDate = !isNaN(tripStart.getTime());
-  const itemStartDate = isValidDate ? addDays(tripStart, displayItem.startDateOffset) : new Date();
-  const itemEndDate = isValidDate ? addDays(tripStart, displayItem.startDateOffset + displayItem.duration) : new Date();
+  const cityDurationPreview = isCity && isDurationEditorOpen && durationDraft
+      ? durationDraft
+      : null;
+  const previewStartOffset = cityDurationPreview?.startDateOffset ?? displayItem.startDateOffset;
+  const previewDuration = cityDurationPreview?.duration ?? displayItem.duration;
+  const itemStartDate = isValidDate ? addDays(tripStart, previewStartOffset) : new Date();
+  const itemEndDate = isValidDate ? addDays(tripStart, previewStartOffset + previewDuration) : new Date();
   const travelLegMetrics = React.useMemo(() => {
       if (!isTransport || !displayItem.id || tripItems.length === 0) return null;
       return getTravelLegMetricsForItem(tripItems, displayItem.id);
@@ -410,8 +890,37 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
   const estimatedLabel = React.useMemo(() => {
       return formatDurationHours(estimatedHours);
   }, [estimatedHours]);
-  const handleUpdateStart = (delta: number) => handleUpdate(displayItem.id, { startDateOffset: Math.max(0, displayItem.startDateOffset + delta), duration: Math.max(0.5, displayItem.duration - delta) });
-  const handleUpdateEnd = (delta: number) => handleUpdate(displayItem.id, { duration: Math.max(0.5, displayItem.duration + delta) });
+  const displayedDurationDays = isCity ? previewDuration : displayItem.duration;
+  const durationBaseline = durationBaselineRef.current;
+  const hasDurationDraftChanges = !!(
+      isCity &&
+      durationBaseline &&
+      durationDraft &&
+      (Math.abs(durationDraft.startDateOffset - durationBaseline.startDateOffset) > 0.001 ||
+          Math.abs(durationDraft.duration - durationBaseline.duration) > 0.001)
+  );
+  const displayedCityLocation = isCity && isCityEditorOpen
+      ? (cityInputValue || cityDraft?.location || displayItem.location || displayItem.title)
+      : (displayItem.location || displayItem.title);
+  const cityBaseline = cityBaselineRef.current;
+  const hasCityDraftChanges = !!(
+      isCity &&
+      cityBaseline &&
+      cityDraft &&
+      !areCityDraftEqual(cityDraft, cityBaseline)
+  );
+  const cityDisplayName = getCityNameFromText(displayedCityLocation || displayItem.title || '');
+  const countryNameForDisplay = (
+      (isCity && isCityEditorOpen ? cityDraft?.countryName : undefined) ||
+      displayItem.countryName ||
+      getCountryFromText(displayedCityLocation).countryName
+  );
+  const countryCodeForDisplay = (
+      (isCity && isCityEditorOpen ? cityDraft?.countryCode : undefined) ||
+      displayItem.countryCode ||
+      getCountryFromText(displayedCityLocation).countryCode
+  );
+  const countryFlagForDisplay = toFlagEmoji(countryCodeForDisplay);
   
   const effectiveColor = isActivity ? getActivityColorByTypes(displayItem.activityType) : displayItem.color;
   const colorParts = effectiveColor ? effectiveColor.split(' ') : ['bg-gray-100'];
@@ -424,6 +933,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
 
   const Content = (
       <div className={`flex flex-col h-full w-full min-w-0 bg-gray-50 ${variant === 'sidebar' ? 'border-l border-gray-200' : 'rounded-t-[20px] sm:rounded-2xl'}`}>
+          <style>{`.pac-container { z-index: 10000 !important; }`}</style>
           {/* Header */}
           <div className="bg-white p-4 sm:p-6 border-b border-gray-100 pb-6 relative flex-shrink-0">
              {variant === 'overlay' && (
@@ -465,21 +975,21 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                       )}
                   </div>
                   <button
-                      onClick={() => { if (!canEdit) return; handleDeleteItem(displayItem.id); onClose(); }}
+                      onClick={() => { if (!canEdit) return; handleDeleteItem(displayItem.id); handleClosePanel(); }}
                       disabled={!canEdit}
                       className={`p-2 bg-red-50 text-red-500 rounded-full transition-colors sm:hidden ${canEdit ? 'hover:bg-red-100' : 'opacity-50 cursor-not-allowed'}`}
                   >
                       <Trash2 size={20} />
                   </button>
                   <button
-                      onClick={() => { if (!canEdit) return; handleDeleteItem(displayItem.id); onClose(); }}
+                      onClick={() => { if (!canEdit) return; handleDeleteItem(displayItem.id); handleClosePanel(); }}
                       disabled={!canEdit}
                       className={`hidden sm:block text-red-400 transition-colors text-xs font-medium px-2 py-1 ${canEdit ? 'hover:text-red-600' : 'opacity-50 cursor-not-allowed'}`}
                   >
                       Delete
                   </button>
-                  {variant === 'overlay' && <div className="hidden sm:flex absolute top-4 right-4 z-10"><button onClick={onClose} className="p-2 bg-gray-200 hover:bg-gray-300 rounded-full text-gray-600"><X size={18} /></button></div>}
-                  {variant === 'sidebar' && <button onClick={onClose} className="absolute top-4 right-4 p-2 bg-gray-100 hover:bg-gray-200 rounded-full text-gray-500"><X size={16} /></button>}
+                  {variant === 'overlay' && <div className="hidden sm:flex absolute top-4 right-4 z-10"><button onClick={handleClosePanel} className="p-2 bg-gray-200 hover:bg-gray-300 rounded-full text-gray-600"><X size={18} /></button></div>}
+                  {variant === 'sidebar' && <button onClick={handleClosePanel} className="absolute top-4 right-4 p-2 bg-gray-100 hover:bg-gray-200 rounded-full text-gray-500"><X size={16} /></button>}
              </div>
              
              <textarea 
@@ -513,7 +1023,19 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             </span>
                         </div>
                     ) : (
-                        <span className="font-medium">{Number(displayItem.duration.toFixed(1))} day{displayItem.duration !== 1 ? 's' : ''}</span>
+                        <div className="flex items-center gap-2">
+                            <span className="font-medium">{Number(displayedDurationDays.toFixed(1))} day{displayedDurationDays !== 1 ? 's' : ''}</span>
+                            {isCity && (
+                                <button
+                                    onClick={openDurationEditor}
+                                    disabled={!canEdit}
+                                    className={`p-1 rounded text-gray-400 transition-colors ${canEdit ? 'hover:bg-gray-100 hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
+                                    title="Edit duration"
+                                >
+                                    <Pencil size={13} />
+                                </button>
+                            )}
+                        </div>
                     )}
                  </div>
                  {isTransport && (
@@ -529,21 +1051,46 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                         </div>
                     </div>
                  )}
-                 {displayItem.location && ( <div className="flex items-center text-gray-600"><MapPin size={18} className="mr-3 text-indigo-500" /><span className="font-medium">{displayItem.location}</span></div> )}
+                 {(isCity || displayItem.location) && (
+                    <div className="flex items-start text-gray-600">
+                        <MapPin size={18} className="mr-3 text-indigo-500 mt-0.5" />
+                        <div className="min-w-0">
+                            <div className="flex items-center gap-2">
+                                {countryFlagForDisplay && (
+                                    <span className="text-base leading-none" aria-hidden="true">{countryFlagForDisplay}</span>
+                                )}
+                                <span className="font-medium">{isCity ? (cityDisplayName || 'No city selected') : displayItem.location}</span>
+                                {isCity && (
+                                    <button
+                                        onClick={openCityEditor}
+                                        disabled={!canEdit}
+                                        className={`p-1 rounded text-gray-400 transition-colors ${canEdit ? 'hover:bg-gray-100 hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
+                                        title="Edit city"
+                                    >
+                                        <Pencil size={13} />
+                                    </button>
+                                )}
+                            </div>
+                            {isCity && countryNameForDisplay && (
+                                <div className="text-xs text-gray-500 mt-0.5">{countryNameForDisplay}</div>
+                            )}
+                        </div>
+                    </div>
+                 )}
              </div>
           </div>
 
           {/* Body */}
           <div className="p-4 sm:p-6 space-y-6 flex-1 overflow-y-auto min-w-0">
-             {isCity && isValidDate && (
+             {isCity && isValidDate && isDurationEditorOpen && (
                 <div className="bg-white rounded-2xl p-5 shadow-sm border border-gray-100 space-y-4">
                     <div className="flex justify-between items-center pb-2 border-b border-gray-50">
                         <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider">Schedule</h3>
                         <div className="flex items-center gap-2">
-                            <div className="text-xs font-medium text-indigo-600 bg-indigo-50 px-2 py-0.5 rounded">{Number(displayItem.duration.toFixed(1))} Nights</div>
+                            <div className="text-xs font-medium text-indigo-600 bg-indigo-50 px-2 py-0.5 rounded">{Number(previewDuration.toFixed(1))} Nights</div>
                             {onForceFill && forceFillLabel && (
                                 <button
-                                    onClick={() => { if (!canEdit) return; onForceFill(displayItem.id); }}
+                                    onClick={() => { if (!canEdit) return; handleForceFillDraft(); }}
                                     disabled={!canEdit}
                                     className={`px-2 py-1 rounded text-gray-500 flex items-center gap-1 text-[10px] font-semibold ${canEdit ? 'hover:bg-gray-100 hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
                                     title={forceFillLabel || 'Occupy available space'}
@@ -561,7 +1108,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                         </div>
                         <div className="flex items-center gap-1 bg-gray-50 rounded-lg p-1">
                             <button
-                                onClick={() => handleUpdateStart(-1)}
+                                onClick={() => updateDurationStartDraft(-1)}
                                 disabled={!canEdit}
                                 className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
                             >
@@ -569,7 +1116,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             </button>
                             <span className="text-[10px] font-bold text-gray-400 px-1 select-none">START</span>
                             <button
-                                onClick={() => handleUpdateStart(1)}
+                                onClick={() => updateDurationStartDraft(1)}
                                 disabled={!canEdit}
                                 className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
                             >
@@ -584,7 +1131,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                         </div>
                         <div className="flex items-center gap-1 bg-gray-50 rounded-lg p-1">
                             <button
-                                onClick={() => handleUpdateEnd(-1)}
+                                onClick={() => updateDurationEndDraft(-1)}
                                 disabled={!canEdit}
                                 className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
                             >
@@ -592,13 +1139,79 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             </button>
                             <span className="text-[10px] font-bold text-gray-400 px-1 select-none">END</span>
                             <button
-                                onClick={() => handleUpdateEnd(1)}
+                                onClick={() => updateDurationEndDraft(1)}
                                 disabled={!canEdit}
                                 className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
                             >
                                 <Plus size={14} />
                             </button>
                         </div>
+                    </div>
+                    <div className="pt-2 border-t border-gray-50 flex items-center justify-end gap-2">
+                        <button
+                            onClick={closeDurationEditor}
+                            className={`px-3 py-1.5 text-xs font-semibold text-gray-600 bg-white border border-gray-200 rounded-md ${canEdit ? 'hover:bg-gray-50' : 'opacity-50 cursor-not-allowed'}`}
+                            disabled={!canEdit}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            onClick={handleApplyDurationEdit}
+                            className={`px-3 py-1.5 text-xs font-semibold rounded-md transition-colors ${
+                                canEdit && hasDurationDraftChanges
+                                    ? 'text-white bg-indigo-600 hover:bg-indigo-700'
+                                    : 'text-gray-400 bg-gray-100 cursor-not-allowed'
+                            }`}
+                            disabled={!canEdit || !hasDurationDraftChanges}
+                        >
+                            Apply
+                        </button>
+                    </div>
+                </div>
+             )}
+
+             {isCity && isCityEditorOpen && (
+                <div className="bg-white rounded-2xl p-5 shadow-sm border border-gray-100 space-y-4">
+                    <div className="flex justify-between items-center pb-2 border-b border-gray-50">
+                        <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider">City</h3>
+                        <div className="text-xs text-gray-500">Search with Google Places</div>
+                    </div>
+                    {citySearchError && (
+                        <div className="p-3 bg-amber-50 border border-amber-100 rounded-lg text-xs text-amber-700 flex items-start gap-2">
+                            <AlertTriangle size={14} className="mt-0.5 flex-shrink-0" />
+                            <div>{citySearchError}</div>
+                        </div>
+                    )}
+                    <div className="relative">
+                        <input
+                            ref={cityInputRef}
+                            type="text"
+                            value={cityInputValue}
+                            onChange={canEdit ? ((e) => handleCityInputChange(e.target.value)) : undefined}
+                            placeholder="e.g. Kyoto, Japan"
+                            disabled={!canEdit}
+                            className={`w-full pl-10 pr-4 py-3 bg-gray-50 border border-gray-200 rounded-xl text-sm text-gray-900 outline-none ${canEdit ? 'focus:ring-1 focus:ring-indigo-500' : 'opacity-60 cursor-not-allowed'}`}
+                        />
+                        <Search size={14} className="absolute left-3 top-3.5 text-gray-400" />
+                    </div>
+                    <p className="text-xs text-gray-500">
+                        Start typing and pick a city from the autocomplete list, then apply.
+                    </p>
+                    <div className="pt-2 border-t border-gray-50 flex items-center justify-end gap-2">
+                        <button
+                            onClick={closeCityEditor}
+                            className={`px-3 py-1.5 text-xs font-semibold text-gray-600 bg-white border border-gray-200 rounded-md ${canEdit ? 'hover:bg-gray-50' : 'opacity-50 cursor-not-allowed'}`}
+                            disabled={!canEdit}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            onClick={handleApplyCityEdit}
+                            className={`px-3 py-1.5 text-xs font-semibold text-white bg-indigo-600 rounded-md ${canEdit ? 'hover:bg-indigo-700' : 'opacity-50 cursor-not-allowed'}`}
+                            disabled={!canEdit || !(cityInputValue.trim() || cityDraft?.location || '').trim() || !hasCityDraftChanges}
+                        >
+                            Apply
+                        </button>
                     </div>
                 </div>
              )}
@@ -847,7 +1460,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
   // Else Overlay mode (Portal)
   return createPortal(
     <div className="fixed inset-0 z-[9999] flex justify-end pointer-events-none">
-        <div className={`absolute inset-0 bg-black/30 backdrop-blur-[2px] transition-opacity duration-300 pointer-events-auto ${isVisible ? 'opacity-100' : 'opacity-0'}`} onClick={onClose} />
+        <div className={`absolute inset-0 bg-black/30 backdrop-blur-[2px] transition-opacity duration-300 pointer-events-auto ${isVisible ? 'opacity-100' : 'opacity-0'}`} onClick={handleClosePanel} />
         <div 
             className={`bg-gray-100 shadow-2xl flex flex-col pointer-events-auto will-change-transform absolute w-full h-[85vh] bottom-0 rounded-t-[20px] left-0 right-0 sm:top-2 sm:bottom-2 sm:right-2 sm:w-[450px] sm:h-auto sm:rounded-2xl sm:left-auto`}
             style={{ transform: window.innerWidth < 640 ? `translateY(${!isVisible ? '100%' : `${dragOffset}px`})` : `translateX(${!isVisible ? '110%' : '0%'})`, transition: isDragging ? 'none' : 'transform 300ms cubic-bezier(0.32, 0.72, 0, 1)' }}

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { ITrip, ITimelineItem, IDragState } from '../types';
-import { addDays, findTravelBetweenCities, getTripDuration, TRAVEL_COLOR, TRAVEL_EMPTY_COLOR } from '../utils';
+import { addDays, findTravelBetweenCities, getTimelineBounds, TRAVEL_COLOR, TRAVEL_EMPTY_COLOR } from '../utils';
 import { TimelineBlock } from './TimelineBlock';
 import { Plus } from 'lucide-react';
 import { TransportModeIcon } from './TransportModeIcon';
@@ -55,7 +55,9 @@ export const Timeline: React.FC<TimelineProps> = ({
 
   const [hoverTravelStart, setHoverTravelStart] = useState<number | null>(null);
 
-  const tripLength = getTripDuration(trip.items);
+  const timelineBounds = React.useMemo(() => getTimelineBounds(trip.items), [trip.items]);
+  const visualStartOffset = timelineBounds.startOffset;
+  const tripLength = timelineBounds.dayCount;
   const totalWidth = tripLength * pixelsPerDay;
   
   // Separate items into lanes
@@ -181,7 +183,7 @@ export const Timeline: React.FC<TimelineProps> = ({
 
       const rect = travelLaneRef.current.getBoundingClientRect();
       const offsetX = e.clientX - rect.left;
-      const rawDay = offsetX / pixelsPerDay;
+      const rawDay = visualStartOffset + (offsetX / pixelsPerDay);
       
       // Calculate start time so that the block (duration=1.0) is centered on mouse
       // Center = Start + 0.5  =>  Start = Center - 0.5
@@ -191,7 +193,7 @@ export const Timeline: React.FC<TimelineProps> = ({
       const snapStep = 0.5;
       start = Math.round(start / snapStep) * snapStep;
       
-      if (start < 0) start = 0;
+      if (start < visualStartOffset) start = visualStartOffset;
       
       setHoverTravelStart(start);
   };
@@ -400,9 +402,11 @@ export const Timeline: React.FC<TimelineProps> = ({
   // Process Dates for Headers
   const dateHeaders = React.useMemo(() => {
     const days = Array.from({ length: tripLength }).map((_, i) => {
-        const date = addDays(new Date(trip.startDate), i);
+        const dayOffset = visualStartOffset + i;
+        const date = addDays(new Date(trip.startDate), dayOffset);
         return { 
             index: i,
+            dayOffset,
             date,
             isWeekend: date.getDay() === 0 || date.getDay() === 6,
             dayName: date.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase(),
@@ -442,7 +446,7 @@ export const Timeline: React.FC<TimelineProps> = ({
     }
 
     return { view: 'grouped', days, months };
-  }, [trip.startDate, tripLength, isZoomedOut]);
+  }, [trip.startDate, tripLength, isZoomedOut, visualStartOffset]);
 
   useEffect(() => {
     if (!selectedItemId) return;
@@ -452,7 +456,7 @@ export const Timeline: React.FC<TimelineProps> = ({
     if (!targetItem || !containerRef.current) return;
 
     const container = containerRef.current;
-    const targetCenter = ((targetItem.startDateOffset + (targetItem.duration / 2)) * pixelsPerDay) + 32;
+    const targetCenter = ((targetItem.startDateOffset - visualStartOffset + (targetItem.duration / 2)) * pixelsPerDay) + 32;
     const visibleStart = container.scrollLeft + 80;
     const visibleEnd = container.scrollLeft + container.clientWidth - 80;
 
@@ -466,7 +470,7 @@ export const Timeline: React.FC<TimelineProps> = ({
         behavior: 'smooth',
     });
     lastAutoScrollSelectionRef.current = selectedItemId;
-  }, [selectedItemId, trip.items, pixelsPerDay]);
+  }, [selectedItemId, trip.items, pixelsPerDay, visualStartOffset]);
 
   return (
     <div 
@@ -609,6 +613,7 @@ export const Timeline: React.FC<TimelineProps> = ({
                                     showSwapSelectedButton={selectedCityIds.length > 1 && selectedCityIds.includes(city.id)}
                                     swapSelectedLabel="Reverse selected cities"
                                     pixelsPerDay={pixelsPerDay}
+                                    timelineStartOffset={visualStartOffset}
                                     canEdit={canEdit}
                                 />
                             );
@@ -636,8 +641,8 @@ export const Timeline: React.FC<TimelineProps> = ({
                         {travelLinks.map(link => {
                             const fromEnd = link.fromCity.startDateOffset + link.fromCity.duration;
                             const toStart = link.toCity.startDateOffset;
-                            const left = fromEnd * pixelsPerDay;
-                            const right = toStart * pixelsPerDay;
+                            const left = (fromEnd - visualStartOffset) * pixelsPerDay;
+                            const right = (toStart - visualStartOffset) * pixelsPerDay;
                             const width = Math.max(16, right - left);
                             const mid = left + width / 2;
                             const chipWidth = 140;
@@ -716,10 +721,10 @@ export const Timeline: React.FC<TimelineProps> = ({
                                 }}
                              >
                                  <button
-                                     onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddActivity(i); }}
+                                     onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddActivity(dateHeaders.days[i]?.dayOffset ?? i); }}
                                      disabled={!canEdit}
                                      className={`w-full h-full mx-1 rounded-md border border-dashed border-transparent flex items-center justify-center text-gray-300 transition-all ${canEdit ? 'hover:border-gray-300 hover:bg-gray-50 hover:text-indigo-500' : 'cursor-not-allowed opacity-40'}`}
-                                     title={`Add activity for day ${i + 1}`}
+                                     title={`Add activity for ${dateHeaders.days[i]?.date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) || `day ${i + 1}`}`}
                                  >
                                      <Plus size={16} />
                                  </button>
@@ -739,6 +744,7 @@ export const Timeline: React.FC<TimelineProps> = ({
                                         onResizeStart={handleResizeStart}
                                         onMoveStart={handleMoveStart}
                                         pixelsPerDay={pixelsPerDay}
+                                        timelineStartOffset={visualStartOffset}
                                         canEdit={canEdit}
                                     />
                                 ))}

--- a/components/TimelineBlock.tsx
+++ b/components/TimelineBlock.tsx
@@ -20,6 +20,7 @@ interface TimelineBlockProps {
   showSwapSelectedButton?: boolean;
   swapSelectedLabel?: string;
   pixelsPerDay: number;
+  timelineStartOffset?: number;
   vertical?: boolean;
   canEdit?: boolean;
 }
@@ -39,6 +40,7 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
   showSwapSelectedButton = false,
   swapSelectedLabel,
   pixelsPerDay,
+  timelineStartOffset = 0,
   vertical = false,
   canEdit = true,
 }) => {
@@ -52,7 +54,7 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
   // Visual Dimensions
   const dimensionCheck = item.duration * pixelsPerDay;
   const size = Math.max(dimensionCheck, (isTravel || isEmptyTravel) ? 40 : 20); 
-  const position = item.startDateOffset * pixelsPerDay;
+  const position = (item.startDateOffset - timelineStartOffset) * pixelsPerDay;
 
   // Buffer calculations (Minutes -> Days -> Pixels)
   const bufferBeforePx = item.bufferBefore ? (item.bufferBefore / 1440) * pixelsPerDay : 0;

--- a/components/VerticalTimeline.tsx
+++ b/components/VerticalTimeline.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { ITrip, ITimelineItem, IDragState } from '../types';
-import { addDays, findTravelBetweenCities, getTripDuration, TRAVEL_COLOR, TRAVEL_EMPTY_COLOR } from '../utils';
+import { addDays, findTravelBetweenCities, getTimelineBounds, TRAVEL_COLOR, TRAVEL_EMPTY_COLOR } from '../utils';
 import { TimelineBlock } from './TimelineBlock';
 import { Plus } from 'lucide-react';
 import { TransportModeIcon } from './TransportModeIcon';
@@ -55,7 +55,9 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
 
   const [hoverTravelStart, setHoverTravelStart] = useState<number | null>(null);
 
-  const tripLength = getTripDuration(trip.items);
+  const timelineBounds = React.useMemo(() => getTimelineBounds(trip.items), [trip.items]);
+  const visualStartOffset = timelineBounds.startOffset;
+  const tripLength = timelineBounds.dayCount;
   const totalHeight = tripLength * pixelsPerDay;
   
   const cities = trip.items.filter(i => i.type === 'city').sort((a, b) => a.startDateOffset - b.startDateOffset);
@@ -174,12 +176,12 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
 
       const rect = travelLaneRef.current.getBoundingClientRect();
       const offsetY = e.clientY - rect.top; // Vertical offset
-      const rawDay = offsetY / pixelsPerDay;
+      const rawDay = visualStartOffset + (offsetY / pixelsPerDay);
       
       let start = rawDay - 0.5;
       const snapStep = 0.5;
       start = Math.round(start / snapStep) * snapStep;
-      if (start < 0) start = 0;
+      if (start < visualStartOffset) start = visualStartOffset;
       
       setHoverTravelStart(start);
   };
@@ -379,7 +381,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
     if (!targetItem || !containerRef.current) return;
 
     const container = containerRef.current;
-    const targetCenter = ((targetItem.startDateOffset + (targetItem.duration / 2)) * pixelsPerDay) + 32;
+    const targetCenter = ((targetItem.startDateOffset - visualStartOffset + (targetItem.duration / 2)) * pixelsPerDay) + 32;
     const visibleStart = container.scrollTop + 80;
     const visibleEnd = container.scrollTop + container.clientHeight - 80;
 
@@ -393,7 +395,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
         behavior: 'smooth',
     });
     lastAutoScrollSelectionRef.current = selectedItemId;
-  }, [selectedItemId, trip.items, pixelsPerDay]);
+  }, [selectedItemId, trip.items, pixelsPerDay, visualStartOffset]);
 
   return (
     <div 
@@ -412,7 +414,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
 
                 <div className="relative w-full flex-1">
                     {Array.from({ length: tripLength }).map((_, i) => {
-                        const date = addDays(new Date(trip.startDate), i);
+                        const date = addDays(new Date(trip.startDate), visualStartOffset + i);
                         const isWeekend = date.getDay() === 0 || date.getDay() === 6;
                         
                         return (
@@ -526,6 +528,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
                                      showSwapSelectedButton={selectedCityIds.length > 1 && selectedCityIds.includes(city.id)}
                                      swapSelectedLabel="Reverse selected cities"
                                      pixelsPerDay={pixelsPerDay}
+                                     timelineStartOffset={visualStartOffset}
                                      vertical={true}
                                      canEdit={canEdit}
                                  />
@@ -551,8 +554,8 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
                          {travelLinks.map(link => {
                              const fromEnd = link.fromCity.startDateOffset + link.fromCity.duration;
                              const toStart = link.toCity.startDateOffset;
-                             const top = fromEnd * pixelsPerDay;
-                             const bottom = toStart * pixelsPerDay;
+                             const top = (fromEnd - visualStartOffset) * pixelsPerDay;
+                             const bottom = (toStart - visualStartOffset) * pixelsPerDay;
                              const height = Math.max(16, bottom - top);
                              const mid = top + height / 2;
                              const chipHeight = 36;
@@ -605,7 +608,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
                      <div className="sticky top-0 h-8 flex items-center justify-center z-30 bg-white/90 backdrop-blur w-full border-b border-gray-100">
                          <span className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">Activities</span>
                          <button 
-                             onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddActivity(0); }}
+                             onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddActivity(visualStartOffset); }}
                              disabled={!canEdit}
                              className={`opacity-0 group-hover/activities:opacity-100 transition-opacity ml-1 bg-indigo-50 text-indigo-600 rounded-full p-0.5 ${canEdit ? 'hover:bg-indigo-100' : 'opacity-50 cursor-not-allowed'}`}
                              title="Add Activity"
@@ -631,6 +634,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
                                          onResizeStart={handleResizeStart}
                                          onMoveStart={handleMoveStart}
                                          pixelsPerDay={pixelsPerDay}
+                                         timelineStartOffset={visualStartOffset}
                                          vertical={true}
                                          canEdit={canEdit}
                                      />

--- a/data/exampleTrips.ts
+++ b/data/exampleTrips.ts
@@ -239,12 +239,12 @@ export const THAILAND_TEMPLATE: Partial<ITrip> = {
         {
             id: 'city-bkk-end',
             type: 'city',
-            title: 'Bangkok (Shopping)',
+            title: 'Bangkok',
             startDateOffset: 24,
             duration: 2,
             color: 'bg-rose-200 border-rose-300 text-rose-900',
-            location: 'Siam, Bangkok',
-            coordinates: { lat: 13.7469, lng: 100.5349 },
+            location: 'Bangkok, Thailand',
+            coordinates: { lat: 13.7563, lng: 100.5018 },
             description: "Last minute shopping at MBK and Siam Paragon."
         }
     ]

--- a/utils.ts
+++ b/utils.ts
@@ -168,6 +168,44 @@ export const getTripDuration = (items: any[]): number => {
   return Math.max(maxEnd + 2, 10); // Add some buffer
 };
 
+export interface TimelineBounds {
+    startOffset: number;
+    endOffset: number;
+    dayCount: number;
+}
+
+export const getTimelineBounds = (
+    items: ITimelineItem[],
+    options: { minDays?: number } = {}
+): TimelineBounds => {
+    const minDays = Math.max(1, Math.floor(options.minDays ?? 1));
+    let minStart = Number.POSITIVE_INFINITY;
+    let maxEnd = Number.NEGATIVE_INFINITY;
+
+    items.forEach(item => {
+        if (!Number.isFinite(item.startDateOffset) || !Number.isFinite(item.duration)) return;
+        minStart = Math.min(minStart, item.startDateOffset);
+        maxEnd = Math.max(maxEnd, item.startDateOffset + Math.max(item.duration, 0));
+    });
+
+    if (!Number.isFinite(minStart) || !Number.isFinite(maxEnd)) {
+        return {
+            startOffset: 0,
+            endOffset: minDays,
+            dayCount: minDays,
+        };
+    }
+
+    const startOffset = Math.floor(minStart);
+    const endOffset = Math.max(startOffset + minDays, Math.ceil(maxEnd));
+
+    return {
+        startOffset,
+        endOffset,
+        dayCount: endOffset - startOffset,
+    };
+};
+
 export const findTravelBetweenCities = (
     items: ITimelineItem[],
     fromCity: ITimelineItem,


### PR DESCRIPTION
…unds

- add apply/cancel draft workflows for duration and city edits with ESC/close revert

- add Google Places city editing, country flag/name display, and roundtrip endpoint confirmation

- batch city+title updates into single history commits and support deferred preview updates

- replace native browser prompt/confirm usages with accessible AppDialogProvider modals

- compute timeline bounds from actual items so views auto-fit after edits and undo/redo

- update Thailand template roundtrip endpoints for testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core trip editing flows (timeline offsets, trip `startDate` normalization, and city edit batching), so regressions could affect scheduling/undo history even though changes are localized to UI/state management.
> 
> **Overview**
> Adds a global, queued `AppDialogProvider` modal system (focus trap, ESC/overlay close, validation) and replaces native `window.confirm`/`window.prompt` usages in `TripManager` (delete trip) and `MarkdownEditor` (insert link).
> 
> Revamps `DetailsPanel` city editing: city duration and city/location changes are now *drafted with live preview* and explicit Apply/Cancel, with ESC/close reverting drafts; adds Google Places city autocomplete, country name/flag display, and an optional roundtrip endpoint sync confirmation that can batch-update first/last cities in one commit.
> 
> Timeline rendering now computes bounds via new `getTimelineBounds` and passes a `timelineStartOffset` to blocks so views auto-fit and correctly position/scroll when items start at non-zero/negative offsets; `TripView` normalizes negative offsets by shifting items and adjusting `trip.startDate`, and introduces batch item updates plus improved history labeling for location/coordinate edits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3773d7b3b638911ba2474a40db42756a2a246b53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->