### PR TITLE
Global accent token system + shadcn checkboxes + tooltip map theme sync

### DIFF
--- a/components/AddActivityModal.tsx
+++ b/components/AddActivityModal.tsx
@@ -141,13 +141,13 @@ export const AddActivityModal: React.FC<AddActivityModalProps> = ({ isOpen, onCl
                 <div className="p-4 border-b border-gray-100 flex gap-2">
                     <button 
                         onClick={() => setMode('manual')}
-                        className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${mode === 'manual' ? 'bg-indigo-100 text-indigo-700' : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'}`}
+                        className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${mode === 'manual' ? 'bg-accent-100 text-accent-700' : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'}`}
                     >
                         Manual Entry
                     </button>
                     <button 
                         onClick={() => setMode('ai')}
-                        className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2 ${mode === 'ai' ? 'bg-purple-100 text-purple-700' : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'}`}
+                        className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2 ${mode === 'ai' ? 'bg-accent-100 text-accent-700' : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'}`}
                     >
                         <Sparkles size={14} /> AI Suggestion
                     </button>
@@ -162,7 +162,7 @@ export const AddActivityModal: React.FC<AddActivityModalProps> = ({ isOpen, onCl
                                     type="text" 
                                     value={title}
                                     onChange={e => setTitle(e.target.value)}
-                                    className="w-full p-2 bg-white text-gray-900 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none"
+                                    className="w-full p-2 bg-white text-gray-900 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent-500 outline-none"
                                     placeholder="e.g. Visit Louvre Museum"
                                     autoFocus
                                 />
@@ -187,14 +187,14 @@ export const AddActivityModal: React.FC<AddActivityModalProps> = ({ isOpen, onCl
                                 <textarea 
                                     value={description}
                                     onChange={e => setDescription(e.target.value)}
-                                    className="w-full p-2 bg-white text-gray-900 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none h-24 resize-none"
+                                    className="w-full p-2 bg-white text-gray-900 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent-500 outline-none h-24 resize-none"
                                     placeholder="Notes..."
                                 />
                             </div>
                             <button 
                                 onClick={handleManualAdd}
                                 disabled={!title}
-                                className="w-full py-3 bg-indigo-600 text-white font-bold rounded-xl hover:bg-indigo-700 transition-colors disabled:opacity-50"
+                                className="w-full py-3 bg-accent-600 text-white font-bold rounded-xl hover:bg-accent-700 transition-colors disabled:opacity-50"
                             >
                                 Add Activity
                             </button>
@@ -208,14 +208,14 @@ export const AddActivityModal: React.FC<AddActivityModalProps> = ({ isOpen, onCl
                                         type="text" 
                                         value={prompt}
                                         onChange={e => setPrompt(e.target.value)}
-                                        className="flex-1 p-2 bg-white text-gray-900 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 outline-none"
+                                        className="flex-1 p-2 bg-white text-gray-900 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent-500 outline-none"
                                         placeholder="e.g. Something romantic for dinner, or kid-friendly park"
                                         onKeyDown={(e) => e.key === 'Enter' && handleGenerate()}
                                     />
                                     <button 
                                         onClick={handleGenerate}
                                         disabled={!prompt || isGenerating}
-                                        className="px-4 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors disabled:opacity-50"
+                                        className="px-4 bg-accent-600 text-white rounded-lg hover:bg-accent-700 transition-colors disabled:opacity-50"
                                     >
                                         {isGenerating ? 'Thinking...' : 'Generate'}
                                     </button>
@@ -225,7 +225,7 @@ export const AddActivityModal: React.FC<AddActivityModalProps> = ({ isOpen, onCl
                             {proposals.length > 0 && (
                                 <div className="grid gap-3">
                                     {proposals.map((p, i) => (
-                                        <div key={i} className="bg-white border border-gray-200 rounded-xl p-4 hover:border-purple-300 hover:bg-purple-50 transition-all cursor-pointer group" onClick={() => handleSelectProposal(p)}>
+                                        <div key={i} className="bg-white border border-gray-200 rounded-xl p-4 hover:border-accent-300 hover:bg-accent-50 transition-all cursor-pointer group" onClick={() => handleSelectProposal(p)}>
                                             {(() => {
                                                 const activityTypes = normalizeActivityTypes(p.activityTypes ?? p.type);
                                                 return (
@@ -251,7 +251,7 @@ export const AddActivityModal: React.FC<AddActivityModalProps> = ({ isOpen, onCl
                                                 <span>💰 {p.cost}</span>
                                                 <span>🕒 {p.bestTime}</span>
                                             </div>
-                                            <div className="mt-2 text-xs text-purple-600 font-medium opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1">
+                                            <div className="mt-2 text-xs text-accent-600 font-medium opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1">
                                                 Click to add <Check size={12} />
                                             </div>
                                         </div>

--- a/components/AddCityModal.tsx
+++ b/components/AddCityModal.tsx
@@ -102,7 +102,7 @@ export const AddCityModal: React.FC<AddCityModalProps> = ({ isOpen, onClose, onA
             >
                 <div className="p-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
                     <h3 className="text-lg font-bold text-gray-900 flex items-center gap-2">
-                        <MapPin size={20} className="text-indigo-600" />
+                        <MapPin size={20} className="text-accent-600" />
                         Add New Destination
                     </h3>
                     <button onClick={onClose} className="p-1 hover:bg-gray-200 rounded-full text-gray-500">
@@ -130,7 +130,7 @@ export const AddCityModal: React.FC<AddCityModalProps> = ({ isOpen, onClose, onA
                                     value={inputValue}
                                     onChange={e => setInputValue(e.target.value)}
                                     onKeyDown={handleKeyDown}
-                                    className="w-full pl-10 pr-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:ring-2 focus:ring-indigo-500 outline-none text-gray-800 placeholder-gray-400"
+                                    className="w-full pl-10 pr-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:ring-2 focus:ring-accent-500 outline-none text-gray-800 placeholder-gray-400"
                                     placeholder="e.g. Kyoto, Japan"
                                     autoFocus
                                 />
@@ -141,7 +141,7 @@ export const AddCityModal: React.FC<AddCityModalProps> = ({ isOpen, onClose, onA
                                 {isManualMode && (
                                     <button 
                                         onClick={handleManualSubmit}
-                                        className="absolute right-2 top-2 p-1.5 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+                                        className="absolute right-2 top-2 p-1.5 bg-accent-600 text-white rounded-lg hover:bg-accent-700 transition-colors"
                                         disabled={!inputValue.trim()}
                                     >
                                         <ArrowRight size={16} />

--- a/components/AppDialogProvider.tsx
+++ b/components/AppDialogProvider.tsx
@@ -49,7 +49,7 @@ const focusableSelector = 'button, [href], input, select, textarea, [tabindex]:n
 
 const getToneButtonClass = (tone?: DialogTone): string => {
     if (tone === 'danger') return 'bg-red-600 hover:bg-red-700 focus:ring-red-400';
-    return 'bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-400';
+    return 'bg-accent-600 hover:bg-accent-700 focus:ring-accent-400';
 };
 
 export const AppDialogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -239,7 +239,7 @@ export const AppDialogProvider: React.FC<{ children: React.ReactNode }> = ({ chi
                                             setPromptValue(event.target.value);
                                             if (promptError) setPromptError(null);
                                         }}
-                                        className="w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm text-gray-800 focus:ring-2 focus:ring-indigo-300 focus:border-indigo-500 outline-none"
+                                        className="w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm text-gray-800 focus:ring-2 focus:ring-accent-300 focus:border-accent-500 outline-none"
                                         placeholder={activeRequest.options.placeholder}
                                         onKeyDown={(event) => {
                                             if (event.key === 'Enter') {

--- a/components/CountryInfo.tsx
+++ b/components/CountryInfo.tsx
@@ -51,7 +51,7 @@ export const CountryInfo: React.FC<CountryInfoProps> = ({ info }) => {
                 onClick={() => setIsExpanded(!isExpanded)}
             >
                 <h3 className="font-bold text-gray-800 text-sm uppercase tracking-wider flex items-center gap-2">
-                    <Globe size={16} className="text-indigo-600"/> Destination Info
+                    <Globe size={16} className="text-accent-600"/> Destination Info
                 </h3>
                 <button className="text-gray-400 hover:text-gray-600">
                     {isExpanded ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
@@ -79,7 +79,7 @@ export const CountryInfo: React.FC<CountryInfoProps> = ({ info }) => {
                             </div>
                             <button 
                                 onClick={(e) => { e.stopPropagation(); setDirection(direction === 'eurToLocal' ? 'localToEur' : 'eurToLocal'); }}
-                                className="p-1.5 bg-white shadow-sm border border-gray-200 rounded-full hover:bg-gray-100 text-indigo-600 flex-shrink-0"
+                                className="p-1.5 bg-white shadow-sm border border-gray-200 rounded-full hover:bg-gray-100 text-accent-600 flex-shrink-0"
                             >
                                 <ArrowRightLeft size={14} />
                             </button>
@@ -104,7 +104,7 @@ export const CountryInfo: React.FC<CountryInfoProps> = ({ info }) => {
                         </label>
                         <div className="flex flex-wrap gap-1">
                             {info.languages.map((lang, i) => (
-                                <span key={i} className="px-2 py-1 bg-indigo-50 text-indigo-700 text-xs font-medium rounded-md border border-indigo-100 whitespace-nowrap">
+                                <span key={i} className="px-2 py-1 bg-accent-50 text-accent-700 text-xs font-medium rounded-md border border-accent-100 whitespace-nowrap">
                                     {lang}
                                 </span>
                             ))}
@@ -128,12 +128,12 @@ export const CountryInfo: React.FC<CountryInfoProps> = ({ info }) => {
                         </label>
                         <div className="flex flex-col gap-2">
                             {info.visaInfoUrl && (
-                                <a href={info.visaInfoUrl} target="_blank" rel="noreferrer" className="text-xs text-indigo-600 hover:underline flex items-center gap-1 truncate">
+                                <a href={info.visaInfoUrl} target="_blank" rel="noreferrer" className="text-xs text-accent-600 hover:underline flex items-center gap-1 truncate">
                                     <ExternalLink size={10} className="flex-shrink-0" /> Visa Information
                                 </a>
                             )}
                             {info.auswaertigesAmtUrl && (
-                                <a href={info.auswaertigesAmtUrl} target="_blank" rel="noreferrer" className="text-xs text-indigo-600 hover:underline flex items-center gap-1 truncate">
+                                <a href={info.auswaertigesAmtUrl} target="_blank" rel="noreferrer" className="text-xs text-accent-600 hover:underline flex items-center gap-1 truncate">
                                     <ExternalLink size={10} className="flex-shrink-0" /> Auswärtiges Amt (DE)
                                 </a>
                             )}

--- a/components/CountrySelect.tsx
+++ b/components/CountrySelect.tsx
@@ -88,11 +88,11 @@ export const CountrySelect: React.FC<CountrySelectProps> = ({ value, onChange, d
     return (
         <div className="relative" ref={wrapperRef}>
              <label className="text-xs font-bold text-gray-500 uppercase tracking-wider flex items-center gap-1.5 mb-1.5">
-                <MapPin size={14} className="text-indigo-500"/> Destination(s)
+                <MapPin size={14} className="text-accent-500"/> Destination(s)
             </label>
             
             <div 
-                className={`w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-xl focus-within:ring-2 focus-within:ring-indigo-500 focus-within:bg-white transition-all flex flex-wrap items-center gap-2 cursor-text min-h-[3rem] ${disabled ? 'opacity-50 pointer-events-none' : ''}`}
+                className={`w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-xl focus-within:ring-2 focus-within:ring-accent-500 focus-within:bg-white transition-all flex flex-wrap items-center gap-2 cursor-text min-h-[3rem] ${disabled ? 'opacity-50 pointer-events-none' : ''}`}
                 onClick={openDropdown}
             >
                 {/* Selected Tags */}
@@ -148,7 +148,7 @@ export const CountrySelect: React.FC<CountrySelectProps> = ({ value, onChange, d
                                 <span className="text-2xl">{country.flag}</span>
                                 <span className="font-medium text-gray-700">{country.name}</span>
                             </div>
-                            <Plus size={16} className="text-gray-300 group-hover:text-indigo-500" />
+                            <Plus size={16} className="text-gray-300 group-hover:text-accent-500" />
                         </div>
                     )) : (
                         <div className="p-4 text-center text-gray-400 text-sm">

--- a/components/CreateTripForm.tsx
+++ b/components/CreateTripForm.tsx
@@ -29,6 +29,7 @@ import { DateRangePicker } from './DateRangePicker';
 import { CountryTag } from './CountryTag';
 import { IdealTravelTimeline } from './IdealTravelTimeline';
 import { MonthSeasonStrip } from './MonthSeasonStrip';
+import { Checkbox } from './ui/checkbox';
 import { generateItinerary, generateSurpriseItinerary, generateWizardItinerary } from '../services/geminiService';
 import { ITimelineItem, ITrip } from '../types';
 import { addDays, COUNTRIES, generateTripId, getDefaultTripDates, getDaysDifference } from '../utils';
@@ -190,7 +191,7 @@ const WIZARD_LOGISTIC_CARDS: SelectionCardConfig[] = [
 const NOOP = () => {};
 
 const createNavLinkClass = ({ isActive }: { isActive: boolean }) => {
-    const baseClass = 'relative font-semibold text-slate-500 transition-colors hover:text-slate-900 after:pointer-events-none after:absolute after:-bottom-4 sm:after:-bottom-6 after:left-0 after:h-0.5 after:w-full after:origin-center after:scale-x-0 after:rounded-full after:bg-indigo-600 after:transition-transform';
+    const baseClass = 'relative font-semibold text-slate-500 transition-colors hover:text-slate-900 after:pointer-events-none after:absolute after:-bottom-4 sm:after:-bottom-6 after:left-0 after:h-0.5 after:w-full after:origin-center after:scale-x-0 after:rounded-full after:bg-accent-600 after:transition-transform';
     if (isActive) return `${baseClass} text-slate-900 after:scale-x-100`;
     return baseClass;
 };
@@ -252,8 +253,8 @@ const SelectionCard: React.FC<{
             className={[
                 'text-left rounded-2xl border p-3.5 transition-all shadow-sm',
                 selected
-                    ? 'border-indigo-500 bg-indigo-50 shadow-indigo-100'
-                    : 'border-gray-200 bg-white hover:border-indigo-300 hover:bg-indigo-50/40',
+                    ? 'border-accent-500 bg-accent-50 shadow-accent-100'
+                    : 'border-gray-200 bg-white hover:border-accent-300 hover:bg-accent-50/40',
             ].join(' ')}
         >
             <div className="flex items-start justify-between gap-3">
@@ -267,7 +268,7 @@ const SelectionCard: React.FC<{
                 <span
                     className={[
                         'h-5 w-5 rounded-full border flex items-center justify-center shrink-0 mt-0.5',
-                        selected ? 'border-indigo-500 bg-indigo-500 text-white' : 'border-gray-300 text-transparent',
+                        selected ? 'border-accent-500 bg-accent-500 text-white' : 'border-gray-300 text-transparent',
                     ].join(' ')}
                 >
                     <Check size={12} />
@@ -723,13 +724,13 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                     initialMapFocusQuery={generationSummary.destination}
                 />
                 <div className="pointer-events-none absolute inset-0 z-[1800] flex items-center justify-center p-4 sm:p-6">
-                    <div className="w-full max-w-xl rounded-2xl border border-indigo-100 bg-white/95 shadow-xl backdrop-blur-sm px-5 py-4">
+                    <div className="w-full max-w-xl rounded-2xl border border-accent-100 bg-white/95 shadow-xl backdrop-blur-sm px-5 py-4">
                         <div className="flex items-center gap-3">
-                            <div className="h-9 w-9 rounded-full bg-indigo-100 text-indigo-600 flex items-center justify-center shrink-0">
+                            <div className="h-9 w-9 rounded-full bg-accent-100 text-accent-600 flex items-center justify-center shrink-0">
                                 <Loader2 size={18} className="animate-spin" />
                             </div>
                             <div className="min-w-0">
-                                <div className="text-sm font-semibold text-indigo-900 truncate">Planning Your Trip</div>
+                                <div className="text-sm font-semibold text-accent-900 truncate">Planning Your Trip</div>
                                 <div className="text-xs text-gray-600 truncate">{loadingMessage}</div>
                             </div>
                         </div>
@@ -737,7 +738,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                             {(generationSummary.destination || 'Destination')} • {formatDateRange(generationSummary.startDate, generationSummary.endDate)} • {getDaysDifference(generationSummary.startDate, generationSummary.endDate)} days
                         </div>
                         <div className="mt-3 h-1.5 rounded-full bg-gray-100 overflow-hidden">
-                            <div className="h-full w-1/2 bg-gradient-to-r from-indigo-500 to-blue-500 animate-pulse rounded-full" />
+                            <div className="h-full w-1/2 bg-gradient-to-r from-accent-500 to-accent-600 animate-pulse rounded-full" />
                         </div>
                     </div>
                 </div>
@@ -755,15 +756,15 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
         <div className="w-full min-h-screen flex flex-col relative isolate overflow-hidden bg-slate-50">
             <HeroWebGLBackground className="z-0" />
             <div className="pointer-events-none absolute inset-0 z-[1] bg-white/35" />
-            <div className="pointer-events-none absolute -left-24 top-20 z-[1] h-72 w-72 rounded-full bg-cyan-200/30 blur-3xl" />
-            <div className="pointer-events-none absolute -right-10 bottom-20 z-[1] h-80 w-80 rounded-full bg-indigo-300/30 blur-3xl" />
+            <div className="pointer-events-none absolute -left-24 top-20 z-[1] h-72 w-72 rounded-full bg-accent-200/30 blur-3xl" />
+            <div className="pointer-events-none absolute -right-10 bottom-20 z-[1] h-80 w-80 rounded-full bg-accent-300/30 blur-3xl" />
 
             <header className="absolute top-0 left-0 w-full p-4 sm:p-6 flex justify-between items-center z-20 gap-3">
                 <Link to="/" className="flex items-center gap-2">
-                    <div className="w-8 h-8 bg-indigo-600 rounded-lg flex items-center justify-center shadow-indigo-200 shadow-lg transform rotate-3">
+                    <div className="w-8 h-8 bg-accent-600 rounded-lg flex items-center justify-center shadow-accent-200 shadow-lg transform rotate-3">
                         <Plane className="text-white transform -rotate-3" size={18} fill="currentColor" />
                     </div>
-                    <span className="font-bold text-xl tracking-tight text-gray-900 hidden sm:block">Travel<span className="text-indigo-600">Flow</span></span>
+                    <span className="font-bold text-xl tracking-tight text-gray-900 hidden sm:block">Travel<span className="text-accent-600">Flow</span></span>
                 </Link>
                 <nav className="hidden md:flex items-center gap-5 text-sm bg-white/75 backdrop-blur px-4 py-2 rounded-full border border-slate-200">
                     <NavLink to="/features" className={createNavLinkClass}>Features</NavLink>
@@ -773,13 +774,13 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                 <div className="flex items-center gap-2">
                     <NavLink
                         to="/login"
-                        className="hidden sm:inline-flex px-3 py-2 bg-white/80 backdrop-blur border border-gray-200 hover:border-indigo-300 rounded-full text-sm font-medium text-gray-600 hover:text-indigo-600 transition-all"
+                        className="hidden sm:inline-flex px-3 py-2 bg-white/80 backdrop-blur border border-gray-200 hover:border-accent-300 rounded-full text-sm font-medium text-gray-600 hover:text-accent-600 transition-all"
                     >
                         Login
                     </NavLink>
                     <button
                         onClick={onOpenManager}
-                        className="flex items-center gap-2 px-4 py-2 bg-white/80 backdrop-blur border border-gray-200 hover:border-indigo-300 hover:text-indigo-600 rounded-full shadow-sm hover:shadow transition-all text-sm font-medium text-gray-600"
+                        className="flex items-center gap-2 px-4 py-2 bg-white/80 backdrop-blur border border-gray-200 hover:border-accent-300 hover:text-accent-600 rounded-full shadow-sm hover:shadow transition-all text-sm font-medium text-gray-600"
                     >
                         <Folder size={16} />
                         <span>My Trips</span>
@@ -794,7 +795,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                 </div>
 
                 <div className={`bg-white p-5 sm:p-6 rounded-3xl shadow-xl border border-gray-100 w-full ${formWidthClass} relative overflow-visible transition-all`}>
-                    <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500" />
+                    <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-accent-500 via-accent-600 to-accent-700" />
 
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-2 mb-4">
                         {TAB_ITEMS.map((tab) => {
@@ -810,12 +811,12 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                     className={[
                                         'rounded-2xl border px-4 py-3 text-left transition-all',
                                         isActive
-                                            ? 'border-indigo-500 bg-indigo-50 shadow-sm shadow-indigo-100'
-                                            : 'border-gray-200 bg-white hover:border-indigo-300 hover:bg-indigo-50/40'
+                                            ? 'border-accent-500 bg-accent-50 shadow-sm shadow-accent-100'
+                                            : 'border-gray-200 bg-white hover:border-accent-300 hover:bg-accent-50/40'
                                     ].join(' ')}
                                 >
                                     <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
-                                        <span className={isActive ? 'text-indigo-600' : 'text-gray-400'}>{tab.icon}</span>
+                                        <span className={isActive ? 'text-accent-600' : 'text-gray-400'}>{tab.icon}</span>
                                         <span>{tab.title}</span>
                                         {tab.beta && (
                                             <span className="rounded-full border border-amber-300 bg-amber-100 px-2 py-0.5 text-[10px] font-bold text-amber-700">
@@ -854,12 +855,10 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                 <div className="space-y-1.5 text-left">
                                     <label className="text-xs font-bold text-gray-500 uppercase tracking-wider">Route</label>
                                     <div className="flex items-center gap-2 px-1">
-                                        <input
-                                            type="checkbox"
+                                        <Checkbox
                                             id="roundtrip"
                                             checked={isRoundTrip}
-                                            onChange={(event) => setIsRoundTrip(event.target.checked)}
-                                            className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                            onCheckedChange={(checked) => setIsRoundTrip(checked === true)}
                                         />
                                         <label htmlFor="roundtrip" className="text-sm font-medium text-gray-600 cursor-pointer select-none">
                                             Roundtrip (end where you start)
@@ -885,7 +884,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                     <button
                                         type="button"
                                         onClick={() => setShowAdvanced(!showAdvanced)}
-                                        className="flex items-center gap-1.5 text-xs font-bold text-gray-500 uppercase tracking-wider hover:text-indigo-600 transition-colors"
+                                        className="flex items-center gap-1.5 text-xs font-bold text-gray-500 uppercase tracking-wider hover:text-accent-600 transition-colors"
                                     >
                                         <Settings size={14} />
                                         Advanced Options
@@ -901,7 +900,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                                     value={specificCities}
                                                     onChange={(event) => setSpecificCities(event.target.value)}
                                                     placeholder="Paris, Lyon, Nice..."
-                                                    className="w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-indigo-500 outline-none"
+                                                    className="w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-accent-500 outline-none"
                                                 />
                                             </div>
                                             <div className="space-y-1">
@@ -909,7 +908,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                                 <select
                                                     value={budget}
                                                     onChange={(event) => setBudget(event.target.value)}
-                                                    className="w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-indigo-500 outline-none"
+                                                    className="w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-accent-500 outline-none"
                                                 >
                                                     <option>Low</option>
                                                     <option>Medium</option>
@@ -922,7 +921,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                                 <select
                                                     value={pace}
                                                     onChange={(event) => setPace(event.target.value)}
-                                                    className="w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-indigo-500 outline-none"
+                                                    className="w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-accent-500 outline-none"
                                                 >
                                                     <option>Relaxed</option>
                                                     <option>Balanced</option>
@@ -938,7 +937,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                                     value={numCities}
                                                     onChange={(event) => setNumCities(event.target.value ? Number(event.target.value) : '')}
                                                     placeholder="Auto"
-                                                    className="w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-indigo-500 outline-none"
+                                                    className="w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-accent-500 outline-none"
                                                 />
                                             </div>
                                         </div>
@@ -947,14 +946,14 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
 
                                 <div className="space-y-1.5 text-left">
                                     <label className="text-xs font-bold text-gray-500 uppercase tracking-wider flex items-center gap-1.5">
-                                        <AlignLeft size={14} className="text-indigo-500" />
+                                        <AlignLeft size={14} className="text-accent-500" />
                                         Style & Preferences
                                     </label>
                                     <textarea
                                         value={notes}
                                         onChange={(event) => setNotes(event.target.value)}
                                         placeholder="e.g. Foodie tour, hiking focus, kid friendly..."
-                                        className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:ring-2 focus:ring-indigo-500 focus:bg-white transition-all outline-none h-20 resize-none text-gray-800 placeholder-gray-400 text-sm"
+                                        className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:ring-2 focus:ring-accent-500 focus:bg-white transition-all outline-none h-20 resize-none text-gray-800 placeholder-gray-400 text-sm"
                                         disabled={isGenerating}
                                     />
                                 </div>
@@ -963,7 +962,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                     <button
                                         type="submit"
                                         disabled={isGenerating || selectedCountries.length === 0}
-                                        className="flex-1 py-3 bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 text-white font-bold rounded-xl shadow-lg hover:shadow-xl transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                                        className="flex-1 py-3 bg-gradient-to-r from-accent-600 to-accent-700 hover:from-accent-700 hover:to-accent-800 text-white font-bold rounded-xl shadow-lg hover:shadow-xl transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                                     >
                                         {isGenerating ? <Loader2 className="animate-spin h-5 w-5" /> : <Sparkles className="fill-white/20 h-5 w-5" />}
                                         <span>Auto-Generate</span>
@@ -972,7 +971,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                         type="button"
                                         onClick={handleCreateBlank}
                                         disabled={isGenerating}
-                                        className="w-14 bg-white border border-gray-200 hover:border-gray-300 text-gray-500 hover:text-indigo-600 rounded-xl shadow-sm hover:shadow transition-all flex items-center justify-center disabled:opacity-50"
+                                        className="w-14 bg-white border border-gray-200 hover:border-gray-300 text-gray-500 hover:text-accent-600 rounded-xl shadow-sm hover:shadow transition-all flex items-center justify-center disabled:opacity-50"
                                         title="Start Blank Itinerary"
                                     >
                                         <FilePlus size={22} />
@@ -983,21 +982,21 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                             <div className="mt-5 flex flex-wrap gap-2 text-xs text-gray-500">
                                 <button
                                     type="button"
-                                    className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-indigo-300 hover:text-indigo-600 transition-all shadow-sm"
+                                    className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
                                     onClick={() => fillExample('Italy', 14, 'Rome, Florence, Venice. Art & Food.')}
                                 >
                                     🇮🇹 2 Weeks in Italy
                                 </button>
                                 <button
                                     type="button"
-                                    className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-indigo-300 hover:text-indigo-600 transition-all shadow-sm"
+                                    className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
                                     onClick={() => fillExample('Japan', 7, 'Anime, Tech, and Sushi.')}
                                 >
                                     🇯🇵 7 Days in Japan
                                 </button>
                                 <button
                                     type="button"
-                                    className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-indigo-300 hover:text-indigo-600 transition-all shadow-sm"
+                                    className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
                                     onClick={() => onTripGenerated(createThailandTrip(new Date().toISOString()))}
                                 >
                                     🇹🇭 Thailand (Test Plan)
@@ -1023,7 +1022,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                             type="button"
                                             className={[
                                                 'rounded-xl border px-3 py-2 text-left transition-all',
-                                                isActive ? 'border-indigo-500 bg-indigo-50' : 'border-gray-200 bg-white hover:border-indigo-300',
+                                                isActive ? 'border-accent-500 bg-accent-50' : 'border-gray-200 bg-white hover:border-accent-300',
                                             ].join(' ')}
                                             onClick={() => setWizardStep(step)}
                                         >
@@ -1044,7 +1043,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                 <section className="space-y-4">
                                     <div className="space-y-1">
                                         <div className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                                            <Compass size={16} className="text-indigo-600" />
+                                            <Compass size={16} className="text-accent-600" />
                                             Select destination countries
                                         </div>
                                         <p className="text-xs text-gray-500">These countries are shared automatically with Classic and Surprise Me.</p>
@@ -1052,7 +1051,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
 
                                     <div className="relative" ref={wizardSearchRef}>
                                         <div
-                                            className="rounded-2xl border border-gray-200 bg-gray-50 px-3 py-3 min-h-[64px] flex flex-wrap items-start gap-2 focus-within:ring-2 focus-within:ring-indigo-500 focus-within:bg-white"
+                                            className="rounded-2xl border border-gray-200 bg-gray-50 px-3 py-3 min-h-[64px] flex flex-wrap items-start gap-2 focus-within:ring-2 focus-within:ring-accent-500 focus-within:bg-white"
                                             onClick={openWizardSearch}
                                         >
                                             {selectedCountries.map((countryName) => (
@@ -1103,7 +1102,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                                                     <span>{country.name}</span>
                                                                 </div>
                                                             </div>
-                                                            <Plus size={14} className="text-indigo-500" />
+                                                            <Plus size={14} className="text-accent-500" />
                                                         </button>
                                                     ))
                                                 ) : (
@@ -1117,12 +1116,10 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                     <div className="space-y-1.5 text-left">
                                         <label className="text-xs font-bold text-gray-500 uppercase tracking-wider">Route</label>
                                         <div className="flex items-center gap-2 px-1">
-                                            <input
-                                                type="checkbox"
+                                            <Checkbox
                                                 id="wizard-roundtrip"
                                                 checked={wizardRoundTrip}
-                                                onChange={(event) => setWizardRoundTrip(event.target.checked)}
-                                                className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                                onCheckedChange={(checked) => setWizardRoundTrip(checked === true)}
                                             />
                                             <label htmlFor="wizard-roundtrip" className="text-sm font-medium text-gray-600 cursor-pointer select-none">
                                                 Roundtrip (return to starting city)
@@ -1224,14 +1221,14 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
 
                                         <div className="space-y-1.5 text-left pt-1">
                                             <label className="text-xs font-bold text-gray-500 uppercase tracking-wider flex items-center gap-1.5">
-                                                <AlignLeft size={14} className="text-indigo-500" />
+                                                <AlignLeft size={14} className="text-accent-500" />
                                                 Extra Notes for AI (optional)
                                             </label>
                                             <textarea
                                                 value={wizardNotes}
                                                 onChange={(event) => setWizardNotes(event.target.value)}
                                                 placeholder="Anything else we should optimize for?"
-                                                className="w-full px-3 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-indigo-500 outline-none h-20 resize-none text-gray-800 placeholder-gray-400 text-sm"
+                                                className="w-full px-3 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-accent-500 outline-none h-20 resize-none text-gray-800 placeholder-gray-400 text-sm"
                                             />
                                         </div>
                                     </div>
@@ -1243,7 +1240,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                     type="button"
                                     disabled={wizardStep === 1}
                                     onClick={() => setWizardStep((current) => Math.max(1, current - 1) as WizardStep)}
-                                    className="px-4 py-2 rounded-xl border border-gray-200 text-sm text-gray-600 hover:border-indigo-300 hover:text-indigo-600 transition-all disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1"
+                                    className="px-4 py-2 rounded-xl border border-gray-200 text-sm text-gray-600 hover:border-accent-300 hover:text-accent-600 transition-all disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1"
                                 >
                                     <ChevronLeft size={14} />
                                     Back
@@ -1258,7 +1255,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                             (wizardStep === 3 && !wizardStepChecks[3])
                                         }
                                         onClick={() => setWizardStep((current) => Math.min(4, current + 1) as WizardStep)}
-                                        className="px-4 py-2 rounded-xl bg-indigo-600 text-white text-sm font-semibold hover:bg-indigo-700 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1"
+                                        className="px-4 py-2 rounded-xl bg-accent-600 text-white text-sm font-semibold hover:bg-accent-700 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1"
                                     >
                                         Next
                                         <ChevronRight size={14} />
@@ -1268,7 +1265,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                         type="button"
                                         onClick={handleWizardGenerate}
                                         disabled={!wizardCanGenerate || isGenerating}
-                                        className="px-4 py-2 rounded-xl bg-gradient-to-r from-indigo-600 to-indigo-700 text-white text-sm font-semibold hover:from-indigo-700 hover:to-indigo-800 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1"
+                                        className="px-4 py-2 rounded-xl bg-gradient-to-r from-accent-600 to-accent-700 text-white text-sm font-semibold hover:from-accent-700 hover:to-accent-800 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1"
                                     >
                                         {isGenerating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
                                         Create Trip from Wizard
@@ -1287,8 +1284,8 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                     className={[
                                         'rounded-xl border px-3 py-2 text-left transition-all',
                                         surpriseInputMode === 'month-duration'
-                                            ? 'border-indigo-500 bg-indigo-50'
-                                            : 'border-gray-200 bg-white hover:border-indigo-300',
+                                            ? 'border-accent-500 bg-accent-50'
+                                            : 'border-gray-200 bg-white hover:border-accent-300',
                                     ].join(' ')}
                                 >
                                     <div className="text-sm font-semibold text-gray-900">Month + Weeks</div>
@@ -1300,8 +1297,8 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                     className={[
                                         'rounded-xl border px-3 py-2 text-left transition-all',
                                         surpriseInputMode === 'date-range'
-                                            ? 'border-indigo-500 bg-indigo-50'
-                                            : 'border-gray-200 bg-white hover:border-indigo-300',
+                                            ? 'border-accent-500 bg-accent-50'
+                                            : 'border-gray-200 bg-white hover:border-accent-300',
                                     ].join(' ')}
                                 >
                                     <div className="text-sm font-semibold text-gray-900">Start + End Dates</div>
@@ -1316,7 +1313,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                         <select
                                             value={surpriseMonth}
                                             onChange={(event) => setSurpriseMonth(Number(event.target.value))}
-                                            className="mt-1 w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-indigo-500 outline-none"
+                                            className="mt-1 w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-accent-500 outline-none"
                                         >
                                             {MONTH_LABELS.map((label, index) => (
                                                 <option key={label} value={index + 1}>{label}</option>
@@ -1328,7 +1325,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                         <select
                                             value={surpriseWeeks}
                                             onChange={(event) => setSurpriseWeeks(Number(event.target.value))}
-                                            className="mt-1 w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-indigo-500 outline-none"
+                                            className="mt-1 w-full p-2 bg-gray-50 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-accent-500 outline-none"
                                         >
                                             {[1, 2, 3, 4, 5, 6, 7, 8].map((week) => (
                                                 <option key={week} value={week}>{week} week{week > 1 ? 's' : ''}</option>
@@ -1379,8 +1376,8 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                                 className={[
                                                     'w-full rounded-xl border px-3 py-2 text-left transition-all',
                                                     selected
-                                                        ? 'border-indigo-500 bg-indigo-50 shadow-sm shadow-indigo-100'
-                                                        : 'border-gray-200 bg-white hover:border-indigo-300 hover:bg-indigo-50/40',
+                                                        ? 'border-accent-500 bg-accent-50 shadow-sm shadow-accent-100'
+                                                        : 'border-gray-200 bg-white hover:border-accent-300 hover:bg-accent-50/40',
                                                 ].join(' ')}
                                             >
                                                 <div className="flex items-center justify-between gap-3">
@@ -1412,7 +1409,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                     type="button"
                                     onClick={handleSurpriseGenerate}
                                     disabled={!selectedSurpriseOption || isGenerating}
-                                    className="px-4 py-2.5 rounded-xl bg-gradient-to-r from-indigo-600 to-indigo-700 text-white text-sm font-semibold hover:from-indigo-700 hover:to-indigo-800 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-2"
+                                    className="px-4 py-2.5 rounded-xl bg-gradient-to-r from-accent-600 to-accent-700 text-white text-sm font-semibold hover:from-accent-700 hover:to-accent-800 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-2"
                                 >
                                     {isGenerating ? <Loader2 size={15} className="animate-spin" /> : <Sparkles size={15} />}
                                     Generate Surprise Trip

--- a/components/DateRangePicker.tsx
+++ b/components/DateRangePicker.tsx
@@ -223,13 +223,13 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({ startDate, end
             base += "font-medium ";
 
             if (connectsRight || connectsLeft) {
-                base += "before:content-[''] before:absolute before:z-0 before:top-0 before:bottom-0 before:bg-indigo-50 before:pointer-events-none ";
+                base += "before:content-[''] before:absolute before:z-0 before:top-0 before:bottom-0 before:bg-accent-50 before:pointer-events-none ";
                 if (connectsRight) base += "before:right-0 before:w-1/2 ";
                 if (connectsLeft) base += "before:left-0 before:w-1/2 ";
             }
         } else if (inRange) {
              // Range State: Indigo text
-            base += "bg-indigo-50 text-indigo-700 rounded-none ";
+            base += "bg-accent-50 text-accent-700 rounded-none ";
              if (!isCurrent) base += "opacity-40 ";
         } else {
              // Default State
@@ -245,7 +245,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({ startDate, end
         const str = formatDate(date);
         const isSelected = str === startDate || str === endDate;
         if (!isSelected) return "";
-        return "relative z-10 h-9 w-9 flex items-center justify-center rounded-full bg-indigo-600 text-white shadow-md transition-colors group-hover:bg-indigo-700";
+        return "relative z-10 h-9 w-9 flex items-center justify-center rounded-full bg-accent-600 text-white shadow-md transition-colors group-hover:bg-accent-700";
     };
 
     const days = getDaysInMonth(viewDate.getFullYear(), viewDate.getMonth());
@@ -253,13 +253,13 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({ startDate, end
     return (
         <div className="relative" ref={containerRef}>
              <label className="text-xs font-bold text-gray-500 uppercase tracking-wider flex items-center gap-1.5 mb-1.5">
-                <Calendar size={14} className="text-indigo-500"/> Trip Dates
+                <Calendar size={14} className="text-accent-500"/> Trip Dates
             </label>
 
             {/* Input Trigger */}
-            <div className={`flex items-center bg-gray-50 border border-gray-200 rounded-xl px-4 py-2 transition-all ${isOpen ? 'ring-2 ring-indigo-500 bg-white' : ''} ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
+            <div className={`flex items-center bg-gray-50 border border-gray-200 rounded-xl px-4 py-2 transition-all ${isOpen ? 'ring-2 ring-accent-500 bg-white' : ''} ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
                  <div 
-                    className={`flex-1 cursor-pointer ${mode === 'start' && isOpen ? 'text-indigo-600' : ''}`}
+                    className={`flex-1 cursor-pointer ${mode === 'start' && isOpen ? 'text-accent-600' : ''}`}
                     onClick={() => { if(!disabled) { openCalendar('start'); } }}
                  >
                     <span className="text-xs text-gray-400 font-semibold block">Start</span>
@@ -273,7 +273,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({ startDate, end
                  </div>
                  
                  <div 
-                    className={`flex-1 text-right cursor-pointer ${mode === 'end' && isOpen ? 'text-indigo-600' : ''}`}
+                    className={`flex-1 text-right cursor-pointer ${mode === 'end' && isOpen ? 'text-accent-600' : ''}`}
                     onClick={() => { if(!disabled) { openCalendar('end'); } }}
                  >
                     <span className="text-xs text-gray-400 font-semibold block text-right">End</span>

--- a/components/DeleteCityModal.tsx
+++ b/components/DeleteCityModal.tsx
@@ -49,7 +49,7 @@ export const DeleteCityModal: React.FC<DeleteCityModalProps> = ({ isOpen, cityNa
                         className="flex items-center gap-2 mb-6 cursor-pointer select-none group"
                         onClick={() => setDeleteActivities(!deleteActivities)}
                     >
-                        <div className={`transition-colors ${deleteActivities ? 'text-indigo-600' : 'text-gray-300 group-hover:text-gray-400'}`}>
+                        <div className={`transition-colors ${deleteActivities ? 'text-accent-600' : 'text-gray-300 group-hover:text-gray-400'}`}>
                             {deleteActivities ? <CheckSquare size={20} /> : <Square size={20} />}
                         </div>
                         <span className="text-sm font-medium text-gray-700">Delete attached activities</span>
@@ -58,9 +58,9 @@ export const DeleteCityModal: React.FC<DeleteCityModalProps> = ({ isOpen, cityNa
                     <div className="space-y-3">
                         <button 
                             onClick={() => onConfirm('extend-prev', deleteActivities)}
-                            className="w-full flex items-center p-4 rounded-xl border border-gray-200 hover:border-indigo-500 hover:bg-indigo-50 transition-all group text-left"
+                            className="w-full flex items-center p-4 rounded-xl border border-gray-200 hover:border-accent-500 hover:bg-accent-50 transition-all group text-left"
                         >
-                            <div className="h-10 w-10 bg-white border border-gray-200 rounded-full flex items-center justify-center text-gray-500 group-hover:text-indigo-600 group-hover:border-indigo-200 mr-4 shadow-sm">
+                            <div className="h-10 w-10 bg-white border border-gray-200 rounded-full flex items-center justify-center text-gray-500 group-hover:text-accent-600 group-hover:border-accent-200 mr-4 shadow-sm">
                                 <ArrowRight size={20} />
                             </div>
                             <div>
@@ -71,9 +71,9 @@ export const DeleteCityModal: React.FC<DeleteCityModalProps> = ({ isOpen, cityNa
 
                         <button 
                             onClick={() => onConfirm('extend-next', deleteActivities)}
-                            className="w-full flex items-center p-4 rounded-xl border border-gray-200 hover:border-indigo-500 hover:bg-indigo-50 transition-all group text-left"
+                            className="w-full flex items-center p-4 rounded-xl border border-gray-200 hover:border-accent-500 hover:bg-accent-50 transition-all group text-left"
                         >
-                            <div className="h-10 w-10 bg-white border border-gray-200 rounded-full flex items-center justify-center text-gray-500 group-hover:text-indigo-600 group-hover:border-indigo-200 mr-4 shadow-sm">
+                            <div className="h-10 w-10 bg-white border border-gray-200 rounded-full flex items-center justify-center text-gray-500 group-hover:text-accent-600 group-hover:border-accent-200 mr-4 shadow-sm">
                                 <ArrowLeft size={20} />
                             </div>
                             <div>
@@ -84,9 +84,9 @@ export const DeleteCityModal: React.FC<DeleteCityModalProps> = ({ isOpen, cityNa
 
                         <button 
                             onClick={() => onConfirm('move-rest', deleteActivities)}
-                            className="w-full flex items-center p-4 rounded-xl border border-gray-200 hover:border-indigo-500 hover:bg-indigo-50 transition-all group text-left"
+                            className="w-full flex items-center p-4 rounded-xl border border-gray-200 hover:border-accent-500 hover:bg-accent-50 transition-all group text-left"
                         >
-                            <div className="h-10 w-10 bg-white border border-gray-200 rounded-full flex items-center justify-center text-gray-500 group-hover:text-indigo-600 group-hover:border-indigo-200 mr-4 shadow-sm">
+                            <div className="h-10 w-10 bg-white border border-gray-200 rounded-full flex items-center justify-center text-gray-500 group-hover:text-accent-600 group-hover:border-accent-200 mr-4 shadow-sm">
                                 <ArrowLeftRight size={20} />
                             </div>
                             <div>

--- a/components/DetailsPanel.tsx
+++ b/components/DetailsPanel.tsx
@@ -953,7 +953,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             <button
                                 onClick={() => { if (!canEdit) return; setIsColorPickerOpen(!isColorPickerOpen); }}
                                 disabled={!canEdit}
-                                className={`p-1 rounded-full text-gray-400 transition-colors ${canEdit ? 'hover:bg-gray-100 hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
+                                className={`p-1 rounded-full text-gray-400 transition-colors ${canEdit ? 'hover:bg-gray-100 hover:text-accent-600' : 'opacity-50 cursor-not-allowed'}`}
                             >
                                 <Palette size={14} />
                             </button>
@@ -1003,7 +1003,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
              
              <div className="flex flex-col gap-3 mt-4">
                  <div className="flex items-start text-gray-600">
-                    <Clock size={18} className="mr-3 text-indigo-500 mt-0.5" />
+                    <Clock size={18} className="mr-3 text-accent-500 mt-0.5" />
                     {isTransport ? (
                         <div className="flex flex-col gap-1">
                             <div className="flex items-center gap-2">
@@ -1014,7 +1014,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                                     value={Math.round(displayItem.duration * 24 * 10) / 10}
                                     onChange={canEdit ? ((e) => { const h = parseFloat(e.target.value); if (!isNaN(h) && h > 0) handleUpdate(displayItem.id, { duration: h / 24 }); }) : undefined}
                                     disabled={!canEdit}
-                                    className={`w-16 p-1 border-b border-gray-300 bg-transparent text-center font-bold text-gray-900 outline-none ${canEdit ? 'focus:border-indigo-500' : 'cursor-not-allowed opacity-70'}`}
+                                    className={`w-16 p-1 border-b border-gray-300 bg-transparent text-center font-bold text-gray-900 outline-none ${canEdit ? 'focus:border-accent-500' : 'cursor-not-allowed opacity-70'}`}
                                 />
                                 <span className="font-medium text-sm">hours</span>
                             </div>
@@ -1029,7 +1029,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                                 <button
                                     onClick={openDurationEditor}
                                     disabled={!canEdit}
-                                    className={`p-1 rounded text-gray-400 transition-colors ${canEdit ? 'hover:bg-gray-100 hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
+                                    className={`p-1 rounded text-gray-400 transition-colors ${canEdit ? 'hover:bg-gray-100 hover:text-accent-600' : 'opacity-50 cursor-not-allowed'}`}
                                     title="Edit duration"
                                 >
                                     <Pencil size={13} />
@@ -1040,7 +1040,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                  </div>
                  {isTransport && (
                     <div className="flex items-start text-gray-600">
-                        <MapPin size={18} className="mr-3 text-indigo-500 mt-0.5" />
+                        <MapPin size={18} className="mr-3 text-accent-500 mt-0.5" />
                         <div className="flex flex-col gap-0.5">
                             <span className="font-medium">Air distance: {airDistanceLabel ?? '—'}</span>
                             {showRouteDistance && (
@@ -1053,7 +1053,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                  )}
                  {(isCity || displayItem.location) && (
                     <div className="flex items-start text-gray-600">
-                        <MapPin size={18} className="mr-3 text-indigo-500 mt-0.5" />
+                        <MapPin size={18} className="mr-3 text-accent-500 mt-0.5" />
                         <div className="min-w-0">
                             <div className="flex items-center gap-2">
                                 {countryFlagForDisplay && (
@@ -1064,7 +1064,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                                     <button
                                         onClick={openCityEditor}
                                         disabled={!canEdit}
-                                        className={`p-1 rounded text-gray-400 transition-colors ${canEdit ? 'hover:bg-gray-100 hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
+                                        className={`p-1 rounded text-gray-400 transition-colors ${canEdit ? 'hover:bg-gray-100 hover:text-accent-600' : 'opacity-50 cursor-not-allowed'}`}
                                         title="Edit city"
                                     >
                                         <Pencil size={13} />
@@ -1087,12 +1087,12 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                     <div className="flex justify-between items-center pb-2 border-b border-gray-50">
                         <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider">Schedule</h3>
                         <div className="flex items-center gap-2">
-                            <div className="text-xs font-medium text-indigo-600 bg-indigo-50 px-2 py-0.5 rounded">{Number(previewDuration.toFixed(1))} Nights</div>
+                            <div className="text-xs font-medium text-accent-600 bg-accent-50 px-2 py-0.5 rounded">{Number(previewDuration.toFixed(1))} Nights</div>
                             {onForceFill && forceFillLabel && (
                                 <button
                                     onClick={() => { if (!canEdit) return; handleForceFillDraft(); }}
                                     disabled={!canEdit}
-                                    className={`px-2 py-1 rounded text-gray-500 flex items-center gap-1 text-[10px] font-semibold ${canEdit ? 'hover:bg-gray-100 hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
+                                    className={`px-2 py-1 rounded text-gray-500 flex items-center gap-1 text-[10px] font-semibold ${canEdit ? 'hover:bg-gray-100 hover:text-accent-600' : 'opacity-50 cursor-not-allowed'}`}
                                     title={forceFillLabel || 'Occupy available space'}
                                 >
                                     {(forceFillMode === 'shrink') ? <Minimize size={12} /> : <Maximize size={12} />}
@@ -1110,7 +1110,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             <button
                                 onClick={() => updateDurationStartDraft(-1)}
                                 disabled={!canEdit}
-                                className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
+                                className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-accent-600' : 'opacity-50 cursor-not-allowed'}`}
                             >
                                 <Minus size={14} />
                             </button>
@@ -1118,7 +1118,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             <button
                                 onClick={() => updateDurationStartDraft(1)}
                                 disabled={!canEdit}
-                                className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
+                                className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-accent-600' : 'opacity-50 cursor-not-allowed'}`}
                             >
                                 <Plus size={14} />
                             </button>
@@ -1133,7 +1133,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             <button
                                 onClick={() => updateDurationEndDraft(-1)}
                                 disabled={!canEdit}
-                                className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
+                                className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-accent-600' : 'opacity-50 cursor-not-allowed'}`}
                             >
                                 <Minus size={14} />
                             </button>
@@ -1141,7 +1141,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             <button
                                 onClick={() => updateDurationEndDraft(1)}
                                 disabled={!canEdit}
-                                className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-indigo-600' : 'opacity-50 cursor-not-allowed'}`}
+                                className={`p-1.5 rounded-md transition-all text-gray-500 ${canEdit ? 'hover:bg-white hover:shadow-sm hover:text-accent-600' : 'opacity-50 cursor-not-allowed'}`}
                             >
                                 <Plus size={14} />
                             </button>
@@ -1159,7 +1159,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             onClick={handleApplyDurationEdit}
                             className={`px-3 py-1.5 text-xs font-semibold rounded-md transition-colors ${
                                 canEdit && hasDurationDraftChanges
-                                    ? 'text-white bg-indigo-600 hover:bg-indigo-700'
+                                    ? 'text-white bg-accent-600 hover:bg-accent-700'
                                     : 'text-gray-400 bg-gray-100 cursor-not-allowed'
                             }`}
                             disabled={!canEdit || !hasDurationDraftChanges}
@@ -1190,7 +1190,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             onChange={canEdit ? ((e) => handleCityInputChange(e.target.value)) : undefined}
                             placeholder="e.g. Kyoto, Japan"
                             disabled={!canEdit}
-                            className={`w-full pl-10 pr-4 py-3 bg-gray-50 border border-gray-200 rounded-xl text-sm text-gray-900 outline-none ${canEdit ? 'focus:ring-1 focus:ring-indigo-500' : 'opacity-60 cursor-not-allowed'}`}
+                            className={`w-full pl-10 pr-4 py-3 bg-gray-50 border border-gray-200 rounded-xl text-sm text-gray-900 outline-none ${canEdit ? 'focus:ring-1 focus:ring-accent-500' : 'opacity-60 cursor-not-allowed'}`}
                         />
                         <Search size={14} className="absolute left-3 top-3.5 text-gray-400" />
                     </div>
@@ -1207,7 +1207,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                         </button>
                         <button
                             onClick={handleApplyCityEdit}
-                            className={`px-3 py-1.5 text-xs font-semibold text-white bg-indigo-600 rounded-md ${canEdit ? 'hover:bg-indigo-700' : 'opacity-50 cursor-not-allowed'}`}
+                            className={`px-3 py-1.5 text-xs font-semibold text-white bg-accent-600 rounded-md ${canEdit ? 'hover:bg-accent-700' : 'opacity-50 cursor-not-allowed'}`}
                             disabled={!canEdit || !(cityInputValue.trim() || cityDraft?.location || '').trim() || !hasCityDraftChanges}
                         >
                             Apply
@@ -1223,7 +1223,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                          <button
                              onClick={addHotel}
                              disabled={!canEdit}
-                             className={`text-indigo-600 p-1 rounded transition-colors text-xs font-medium ${canEdit ? 'hover:text-indigo-800 hover:bg-indigo-50' : 'opacity-50 cursor-not-allowed'}`}
+                             className={`text-accent-600 p-1 rounded transition-colors text-xs font-medium ${canEdit ? 'hover:text-accent-800 hover:bg-accent-50' : 'opacity-50 cursor-not-allowed'}`}
                          >
                              + Manual
                          </button>
@@ -1243,14 +1243,14 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                                             onKeyDown={canEdit ? ((e) => e.key === 'Enter' && handleHotelSearch()) : undefined}
                                             placeholder="Search hotels..."
                                             disabled={!canEdit}
-                                            className={`w-full pl-8 pr-4 py-2 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-900 outline-none ${canEdit ? 'focus:ring-1 focus:ring-indigo-500' : 'opacity-60 cursor-not-allowed'}`}
+                                            className={`w-full pl-8 pr-4 py-2 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-900 outline-none ${canEdit ? 'focus:ring-1 focus:ring-accent-500' : 'opacity-60 cursor-not-allowed'}`}
                                         />
                                         <Search size={14} className="absolute left-2.5 top-2.5 text-gray-400" />
                                     </div>
                                     <button
                                         onClick={handleHotelSearch}
                                         disabled={!canEdit || isSearchingHotels || !hotelQuery || !placesService}
-                                        className={`px-3 py-2 bg-indigo-600 text-white rounded-lg text-xs font-bold ${canEdit ? 'hover:bg-indigo-700' : 'opacity-50 cursor-not-allowed'} disabled:opacity-50`}
+                                        className={`px-3 py-2 bg-accent-600 text-white rounded-lg text-xs font-bold ${canEdit ? 'hover:bg-accent-700' : 'opacity-50 cursor-not-allowed'} disabled:opacity-50`}
                                     >
                                         {isSearchingHotels ? '...' : 'Find'}
                                     </button>
@@ -1261,7 +1261,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                                             <div
                                                 key={idx}
                                                 onClick={() => selectHotelResult(result)}
-                                                className={`bg-gray-50 border border-gray-200 rounded-lg p-2 transition-all ${canEdit ? 'hover:bg-indigo-50 hover:border-indigo-200 cursor-pointer' : 'cursor-not-allowed opacity-60'}`}
+                                                className={`bg-gray-50 border border-gray-200 rounded-lg p-2 transition-all ${canEdit ? 'hover:bg-accent-50 hover:border-accent-200 cursor-pointer' : 'cursor-not-allowed opacity-60'}`}
                                             >
                                                 <div className="font-bold text-sm text-gray-800">{result.name}</div>
                                                 <div className="text-xs text-gray-500 truncate">{result.address}</div>
@@ -1328,7 +1328,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                                  key={mode} 
                                  onClick={() => handleTransportConvert(mode)} 
                                  disabled={!canEdit}
-                                 className={`flex flex-col items-center justify-center w-full h-20 rounded-xl border-2 transition-all ${displayItem.transportMode === mode ? 'bg-indigo-50 border-indigo-500 text-indigo-700' : 'bg-gray-50 border-gray-100 text-gray-400'} ${canEdit ? 'hover:border-gray-200' : 'opacity-60 cursor-not-allowed'}`}
+                                 className={`flex flex-col items-center justify-center w-full h-20 rounded-xl border-2 transition-all ${displayItem.transportMode === mode ? 'bg-accent-50 border-accent-500 text-accent-700' : 'bg-gray-50 border-gray-100 text-gray-400'} ${canEdit ? 'hover:border-gray-200' : 'opacity-60 cursor-not-allowed'}`}
                              >
                                  <TransportModeIcon mode={mode} size={24} />
                                  <span className="text-[10px] font-bold mt-2 uppercase">{mode === 'na' ? 'N/A' : mode}</span>
@@ -1384,17 +1384,17 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                     </div>
                 )}
                 {isCity && pendingNotesProposal && (
-                    <div className="mt-4 border border-indigo-100 rounded-xl bg-indigo-50/40 overflow-hidden">
-                        <div className="px-4 py-3 border-b border-indigo-100 bg-white/80">
-                            <div className="text-xs font-semibold text-indigo-700">AI Draft Preview</div>
-                            <div className="text-[11px] text-indigo-600 mt-1">
+                    <div className="mt-4 border border-accent-100 rounded-xl bg-accent-50/40 overflow-hidden">
+                        <div className="px-4 py-3 border-b border-accent-100 bg-white/80">
+                            <div className="text-xs font-semibold text-accent-700">AI Draft Preview</div>
+                            <div className="text-[11px] text-accent-600 mt-1">
                                 Action: {pendingNotesProposal.actionLabel}
                             </div>
                         </div>
                         <div className="p-4 bg-white">
                             <MarkdownEditor value={proposedNotesPreview} readOnly />
                         </div>
-                        <div className="px-4 py-3 bg-indigo-50 border-t border-indigo-100 flex items-center justify-end gap-2">
+                        <div className="px-4 py-3 bg-accent-50 border-t border-accent-100 flex items-center justify-end gap-2">
                             <button
                                 onClick={handleDeclineNotesProposal}
                                 disabled={!canEdit}
@@ -1405,7 +1405,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             <button
                                 onClick={handleAcceptNotesProposal}
                                 disabled={!canEdit}
-                                className={`px-3 py-1.5 text-xs font-semibold text-white bg-indigo-600 rounded-md ${canEdit ? 'hover:bg-indigo-700' : 'opacity-50 cursor-not-allowed'}`}
+                                className={`px-3 py-1.5 text-xs font-semibold text-white bg-accent-600 rounded-md ${canEdit ? 'hover:bg-accent-700' : 'opacity-50 cursor-not-allowed'}`}
                             >
                                 Accept and Apply
                             </button>
@@ -1413,34 +1413,34 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                     </div>
                 )}
                 {(aiDetails || loading) && isActivity && (
-                    <div className="bg-gradient-to-br from-indigo-50 to-blue-50 border border-indigo-100 rounded-xl p-4 mt-6">
+                    <div className="bg-gradient-to-br from-accent-50 to-accent-100 border border-accent-100 rounded-xl p-4 mt-6">
                         <div className="flex items-center mb-3 justify-between">
                             <div className="flex items-center gap-2">
-                                <Sparkles size={16} className="text-indigo-500 animate-pulse" />
-                                <h3 className="text-sm font-semibold text-indigo-900">AI Insights</h3>
+                                <Sparkles size={16} className="text-accent-500 animate-pulse" />
+                                <h3 className="text-sm font-semibold text-accent-900">AI Insights</h3>
                             </div>
                             <button
                                 onClick={fetchDetails}
                                 disabled={!canEdit}
-                                className={`p-1.5 rounded-full text-indigo-500 ${loading ? 'animate-spin' : ''} ${canEdit ? 'hover:bg-white' : 'opacity-50 cursor-not-allowed'}`}
+                                className={`p-1.5 rounded-full text-accent-500 ${loading ? 'animate-spin' : ''} ${canEdit ? 'hover:bg-white' : 'opacity-50 cursor-not-allowed'}`}
                             >
                                 <RefreshCw size={16} />
                             </button>
                         </div>
                         {loading && !aiDetails ? (
-                            <div className="text-sm text-indigo-600/70 py-2">Loading...</div>
+                            <div className="text-sm text-accent-600/70 py-2">Loading...</div>
                         ) : (
                             <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))' }}>
-                                <div className="bg-white p-3 rounded-lg border border-indigo-100 shadow-sm">
-                                    <span className="text-[10px] font-bold text-indigo-400 uppercase">Cost</span>
+                                <div className="bg-white p-3 rounded-lg border border-accent-100 shadow-sm">
+                                    <span className="text-[10px] font-bold text-accent-400 uppercase">Cost</span>
                                     <span className="text-sm font-medium">{aiDetails?.cost || 'N/A'}</span>
                                 </div>
-                                <div className="bg-white p-3 rounded-lg border border-indigo-100 shadow-sm">
-                                    <span className="text-[10px] font-bold text-indigo-400 uppercase">Best Time</span>
+                                <div className="bg-white p-3 rounded-lg border border-accent-100 shadow-sm">
+                                    <span className="text-[10px] font-bold text-accent-400 uppercase">Best Time</span>
                                     <span className="text-sm font-medium">{aiDetails?.bestTime || 'N/A'}</span>
                                 </div>
-                                <div className="bg-white p-3 rounded-lg border border-indigo-100 shadow-sm" style={{ gridColumn: '1 / -1' }}>
-                                    <span className="text-[10px] font-bold text-indigo-400 uppercase">Tip</span>
+                                <div className="bg-white p-3 rounded-lg border border-accent-100 shadow-sm" style={{ gridColumn: '1 / -1' }}>
+                                    <span className="text-[10px] font-bold text-accent-400 uppercase">Tip</span>
                                     <span className="text-sm font-medium">{aiDetails?.tips || 'N/A'}</span>
                                 </div>
                             </div>

--- a/components/ItineraryMap.tsx
+++ b/components/ItineraryMap.tsx
@@ -523,7 +523,7 @@ export const ItineraryMap: React.FC<ItineraryMapProps> = ({
                         subEl.textContent = subLabel;
                         subEl.style.fontSize = '10px';
                         subEl.style.fontWeight = '600';
-                        subEl.style.color = '#4f46e5';
+                        subEl.style.color = 'var(--tf-primary)';
                         subEl.style.textTransform = 'uppercase';
                         subEl.style.letterSpacing = '0.08em';
                         subEl.style.textShadow = '0 1px 2px rgba(255,255,255,0.8)';
@@ -965,29 +965,29 @@ export const ItineraryMap: React.FC<ItineraryMapProps> = ({
                 <div className="flex flex-col gap-2 pointer-events-auto">
                     {onLayoutChange && (
                         <>
-                            <button onClick={() => onLayoutChange('vertical')} className={`p-2 rounded-lg shadow-md border transition-colors ${layoutMode === 'vertical' ? 'bg-indigo-600 text-white border-indigo-700' : 'bg-white border-gray-200 text-gray-600 hover:text-indigo-600 hover:bg-gray-50'}`}><Rows size={18} /></button>
-                            <button onClick={() => onLayoutChange('horizontal')} className={`p-2 rounded-lg shadow-md border transition-colors ${layoutMode === 'horizontal' ? 'bg-indigo-600 text-white border-indigo-700' : 'bg-white border-gray-200 text-gray-600 hover:text-indigo-600 hover:bg-gray-50'}`}><Columns size={18} /></button>
+                            <button onClick={() => onLayoutChange('vertical')} className={`p-2 rounded-lg shadow-md border transition-colors ${layoutMode === 'vertical' ? 'bg-accent-600 text-white border-accent-700' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`}><Rows size={18} /></button>
+                            <button onClick={() => onLayoutChange('horizontal')} className={`p-2 rounded-lg shadow-md border transition-colors ${layoutMode === 'horizontal' ? 'bg-accent-600 text-white border-accent-700' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`}><Columns size={18} /></button>
                         </>
                     )}
                     
-                    <button onClick={handleFit} className="p-2 rounded-lg shadow-md border bg-white border-gray-200 text-gray-600 hover:text-indigo-600 hover:bg-gray-50 transition-colors flex items-center justify-center" title="Fit to Itinerary"><Focus size={18} /></button>
+                    <button onClick={handleFit} className="p-2 rounded-lg shadow-md border bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50 transition-colors flex items-center justify-center" title="Fit to Itinerary"><Focus size={18} /></button>
                     
                     {/* Style Switcher */}
                     {onStyleChange && (
                       <div className="relative">
-                          <button onClick={() => setIsStyleMenuOpen(!isStyleMenuOpen)} className={`p-2 rounded-lg shadow-md border transition-colors flex items-center justify-center ${isStyleMenuOpen ? 'bg-indigo-50 border-indigo-300 text-indigo-600' : 'bg-white border-gray-200 text-gray-600 hover:text-indigo-600 hover:bg-gray-50'}`} title="Map Style"><Layers size={18} /></button>
+                          <button onClick={() => setIsStyleMenuOpen(!isStyleMenuOpen)} className={`p-2 rounded-lg shadow-md border transition-colors flex items-center justify-center ${isStyleMenuOpen ? 'bg-accent-50 border-accent-300 text-accent-600' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`} title="Map Style"><Layers size={18} /></button>
                           {isStyleMenuOpen && (
                               <div className="absolute top-0 right-full mr-2 bg-white rounded-lg shadow-xl border border-gray-100 w-36 overflow-hidden flex flex-col z-20">
-                                  <button onClick={() => { onStyleChange('minimal'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'minimal' ? 'text-indigo-600 bg-indigo-50' : 'text-gray-700'}`}>Minimal</button>
-                                  <button onClick={() => { onStyleChange('standard'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'standard' ? 'text-indigo-600 bg-indigo-50' : 'text-gray-700'}`}>Standard</button>
-                                  <button onClick={() => { onStyleChange('dark'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'dark' ? 'text-indigo-600 bg-indigo-50' : 'text-gray-700'}`}>Dark</button>
-                                  <button onClick={() => { onStyleChange('satellite'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'satellite' ? 'text-indigo-600 bg-indigo-50' : 'text-gray-700'}`}>Satellite</button>
-                                  <button onClick={() => { onStyleChange('clean'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'clean' ? 'text-indigo-600 bg-indigo-50' : 'text-gray-700'}`}>Clean</button>
+                                  <button onClick={() => { onStyleChange('minimal'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'minimal' ? 'text-accent-600 bg-accent-50' : 'text-gray-700'}`}>Minimal</button>
+                                  <button onClick={() => { onStyleChange('standard'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'standard' ? 'text-accent-600 bg-accent-50' : 'text-gray-700'}`}>Standard</button>
+                                  <button onClick={() => { onStyleChange('dark'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'dark' ? 'text-accent-600 bg-accent-50' : 'text-gray-700'}`}>Dark</button>
+                                  <button onClick={() => { onStyleChange('satellite'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'satellite' ? 'text-accent-600 bg-accent-50' : 'text-gray-700'}`}>Satellite</button>
+                                  <button onClick={() => { onStyleChange('clean'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'clean' ? 'text-accent-600 bg-accent-50' : 'text-gray-700'}`}>Clean</button>
                                   {onRouteModeChange && (
                                       <>
                                           <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 border-t border-gray-100">Routes</div>
-                                          <button onClick={() => { onRouteModeChange('simple'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${routeMode === 'simple' ? 'text-indigo-600 bg-indigo-50' : 'text-gray-700'}`}>Simple</button>
-                                          <button onClick={() => { onRouteModeChange('realistic'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${routeMode === 'realistic' ? 'text-indigo-600 bg-indigo-50' : 'text-gray-700'}`}>Realistic</button>
+                                          <button onClick={() => { onRouteModeChange('simple'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${routeMode === 'simple' ? 'text-accent-600 bg-accent-50' : 'text-gray-700'}`}>Simple</button>
+                                          <button onClick={() => { onRouteModeChange('realistic'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${routeMode === 'realistic' ? 'text-accent-600 bg-accent-50' : 'text-gray-700'}`}>Realistic</button>
                                       </>
                                   )}
                                   {onShowCityNamesChange && (
@@ -995,7 +995,7 @@ export const ItineraryMap: React.FC<ItineraryMapProps> = ({
                                           <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 border-t border-gray-100">Labels</div>
                                           <button
                                               onClick={() => { onShowCityNamesChange(!showCityNames); setIsStyleMenuOpen(false); }}
-                                              className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${showCityNames ? 'text-indigo-600 bg-indigo-50' : 'text-gray-700'}`}
+                                              className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${showCityNames ? 'text-accent-600 bg-accent-50' : 'text-gray-700'}`}
                                           >
                                               City names {showCityNames ? 'On' : 'Off'}
                                           </button>

--- a/components/LoadingSkeleton.tsx
+++ b/components/LoadingSkeleton.tsx
@@ -99,8 +99,8 @@ export const LoadingSkeleton: React.FC = () => {
                 <div className="absolute inset-0 bg-white/70 backdrop-blur-[2px] flex items-center justify-center z-50">
                     <div className="bg-white p-8 rounded-2xl shadow-2xl border border-gray-100 max-w-sm w-full text-center flex flex-col items-center gap-5 animate-in zoom-in-95 duration-500">
                         <div className="relative">
-                            <div className="absolute inset-0 bg-indigo-100 rounded-full animate-ping opacity-30" />
-                            <div className="bg-indigo-50 p-4 rounded-full text-indigo-600 relative z-10">
+                            <div className="absolute inset-0 bg-accent-100 rounded-full animate-ping opacity-30" />
+                            <div className="bg-accent-50 p-4 rounded-full text-accent-600 relative z-10">
                                 <Loader2 className="w-8 h-8 animate-spin" />
                             </div>
                         </div>
@@ -111,7 +111,7 @@ export const LoadingSkeleton: React.FC = () => {
                         
                         {/* Progress Bar (Fake but effective) */}
                         <div className="w-full h-1.5 bg-gray-100 rounded-full overflow-hidden mt-2">
-                            <div className="h-full bg-gradient-to-r from-indigo-500 to-purple-500 animate-[loading_15s_ease-out_forwards] w-full origin-left scale-x-0" />
+                            <div className="h-full bg-gradient-to-r from-accent-500 to-accent-600 animate-[loading_15s_ease-out_forwards] w-full origin-left scale-x-0" />
                         </div>
                         <style>{`
                             @keyframes loading {

--- a/components/MarkdownEditor.tsx
+++ b/components/MarkdownEditor.tsx
@@ -448,7 +448,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
                     remarkPlugins={[remarkGfm]}
                     components={{
                         a: ({node, ...props}) => (
-                            <a {...props} className="text-indigo-600 hover:underline" target="_blank" rel="noopener noreferrer" />
+                            <a {...props} className="text-accent-600 hover:underline" target="_blank" rel="noopener noreferrer" />
                         ),
                         input: ({node, ...props}) => (
                             <input
@@ -480,7 +480,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
                         <button
                             onClick={handleAiButtonClick}
                             disabled={isGenerating}
-                            className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-purple-600 hover:bg-purple-50 rounded-md transition-colors disabled:opacity-50"
+                            className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-accent-600 hover:bg-accent-50 rounded-md transition-colors disabled:opacity-50"
                             aria-haspopup={hasAiActions ? 'menu' : undefined}
                             aria-expanded={hasAiActions ? isAiPopoverOpen : undefined}
                         >
@@ -500,7 +500,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
                                                 onAiActionSelect?.(action.id);
                                                 setIsAiPopoverOpen(false);
                                             }}
-                                            className="w-full text-left px-2.5 py-2 rounded-md hover:bg-indigo-50 transition-colors"
+                                            className="w-full text-left px-2.5 py-2 rounded-md hover:bg-accent-50 transition-colors"
                                         >
                                             <div className="text-xs font-semibold text-gray-800">{action.label}</div>
                                             <div className="text-[11px] text-gray-500 mt-0.5 leading-relaxed">{action.description}</div>
@@ -514,7 +514,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             </div>
 
             {aiStatus && (
-                <div className="px-3 py-1.5 bg-purple-50/80 border-b border-purple-100 text-[11px] text-purple-700">
+                <div className="px-3 py-1.5 bg-accent-50/80 border-b border-accent-100 text-[11px] text-accent-700">
                     {aiStatus}
                 </div>
             )}
@@ -565,7 +565,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
                         syncMarkdownFromEditor();
                     }
                 }}
-                className="h-48 p-3 overflow-y-auto text-sm text-gray-800 leading-relaxed outline-none [&_h1]:mt-4 [&_h1]:mb-2 [&_h1]:pt-2 [&_h1]:text-base [&_h1]:font-black [&_h1]:tracking-tight [&_h1]:text-gray-800 [&_h1]:border-t [&_h1]:border-gray-100 [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:pt-2 [&_h2]:text-sm [&_h2]:font-extrabold [&_h2]:tracking-wide [&_h2]:text-gray-800 [&_h2]:border-t [&_h2]:border-gray-100 [&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:pt-2 [&_h3]:text-xs [&_h3]:font-extrabold [&_h3]:uppercase [&_h3]:tracking-wide [&_h3]:text-gray-700 [&_h3]:border-t [&_h3]:border-gray-100 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1 [&_a]:text-indigo-600 [&_a]:underline [&_input[type='checkbox']]:mr-2"
+                className="h-48 p-3 overflow-y-auto text-sm text-gray-800 leading-relaxed outline-none [&_h1]:mt-4 [&_h1]:mb-2 [&_h1]:pt-2 [&_h1]:text-base [&_h1]:font-black [&_h1]:tracking-tight [&_h1]:text-gray-800 [&_h1]:border-t [&_h1]:border-gray-100 [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:pt-2 [&_h2]:text-sm [&_h2]:font-extrabold [&_h2]:tracking-wide [&_h2]:text-gray-800 [&_h2]:border-t [&_h2]:border-gray-100 [&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:pt-2 [&_h3]:text-xs [&_h3]:font-extrabold [&_h3]:uppercase [&_h3]:tracking-wide [&_h3]:text-gray-700 [&_h3]:border-t [&_h3]:border-gray-100 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1 [&_a]:text-accent-600 [&_a]:underline [&_input[type='checkbox']]:mr-2"
             />
 
             <div className="px-3 py-1.5 bg-gray-50 border-t border-gray-200 text-[10px] text-gray-400 flex justify-between">

--- a/components/MonthSeasonStrip.tsx
+++ b/components/MonthSeasonStrip.tsx
@@ -37,7 +37,7 @@ export const MonthSeasonStrip: React.FC<MonthSeasonStripProps> = ({
                         className={[
                             'rounded-md border px-1 py-1 text-center font-medium leading-none select-none',
                             colorClass,
-                            isHighlighted ? 'ring-1 ring-indigo-400' : '',
+                            isHighlighted ? 'ring-1 ring-accent-400' : '',
                         ].join(' ').trim()}
                         title={`${label}${isIdeal ? ' • ideal' : isShoulder ? ' • shoulder' : ''}`}
                     >

--- a/components/PrintLayout.tsx
+++ b/components/PrintLayout.tsx
@@ -241,7 +241,7 @@ export const PrintLayout: React.FC<PrintLayoutProps> = ({ trip, onClose, onUpdat
                     </button>
                     <button 
                         onClick={() => window.print()} 
-                        className="px-4 py-2 bg-indigo-600 text-white hover:bg-indigo-700 rounded-lg text-sm font-medium shadow-sm flex items-center gap-2"
+                        className="px-4 py-2 bg-accent-600 text-white hover:bg-accent-700 rounded-lg text-sm font-medium shadow-sm flex items-center gap-2"
                     >
                         <ArrowRight size={16} /> Print List
                     </button>
@@ -371,7 +371,7 @@ export const PrintLayout: React.FC<PrintLayoutProps> = ({ trip, onClose, onUpdat
                                                     <div key={hIdx} className="border border-gray-200 rounded-lg overflow-hidden">
                                                         <div className="bg-gray-50 p-3 border-b border-gray-100 flex items-center justify-between">
                                                             <div className="font-bold text-sm text-gray-800 flex items-center gap-2">
-                                                                <Hotel size={14} className="text-indigo-600"/> {hotel.name}
+                                                                <Hotel size={14} className="text-accent-600"/> {hotel.name}
                                                             </div>
                                                         </div>
                                                         {hotel.address && (
@@ -435,7 +435,7 @@ export const PrintLayout: React.FC<PrintLayoutProps> = ({ trip, onClose, onUpdat
                                                                         {act.description && <div className="text-xs text-gray-500 mt-1 line-clamp-2">{act.description}</div>}
                                                                         {act.aiInsights && (
                                                                             <div className="mt-2 flex flex-wrap gap-2">
-                                                                                {act.aiInsights.bestTime && <span className="text-[10px] bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded">Time: {act.aiInsights.bestTime}</span>}
+                                                                                {act.aiInsights.bestTime && <span className="text-[10px] bg-accent-50 text-accent-600 px-1.5 py-0.5 rounded">Time: {act.aiInsights.bestTime}</span>}
                                                                                 {act.aiInsights.cost && <span className="text-[10px] bg-green-50 text-green-600 px-1.5 py-0.5 rounded">Cost: {act.aiInsights.cost}</span>}
                                                                             </div>
                                                                         )}

--- a/components/SelectedCitiesPanel.tsx
+++ b/components/SelectedCitiesPanel.tsx
@@ -52,7 +52,7 @@ export const SelectedCitiesPanel: React.FC<SelectedCitiesPanelProps> = ({
                     <X size={16} />
                 </button>
                 <div className="pr-10">
-                    <div className="text-xs font-bold uppercase tracking-wider text-indigo-600">Selected Cities</div>
+                    <div className="text-xs font-bold uppercase tracking-wider text-accent-600">Selected Cities</div>
                     <h2 className="text-xl font-bold text-gray-900 mt-1">{selectedCities.length} selected</h2>
                     <p className="text-xs text-gray-500 mt-2">
                         Reorder the selected stops, then apply. Activities move with their city, and changed routes are reset to N/A.
@@ -81,7 +81,7 @@ export const SelectedCitiesPanel: React.FC<SelectedCitiesPanelProps> = ({
                 <button
                     onClick={() => { if (!canEdit) return; onApplyOrder(orderedCityIds); }}
                     disabled={!hasCustomOrder || !canEdit}
-                    className={`ml-auto px-3 py-2 rounded-lg bg-indigo-600 text-white text-xs font-semibold ${canEdit ? 'hover:bg-indigo-700' : 'opacity-50 cursor-not-allowed'} disabled:opacity-40 disabled:cursor-not-allowed`}
+                    className={`ml-auto px-3 py-2 rounded-lg bg-accent-600 text-white text-xs font-semibold ${canEdit ? 'hover:bg-accent-700' : 'opacity-50 cursor-not-allowed'} disabled:opacity-40 disabled:cursor-not-allowed`}
                     title="Apply custom selected order"
                 >
                     Apply Order

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -58,19 +58,19 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                     <div className="w-48 bg-gray-50 border-r border-gray-100 p-2 space-y-1">
                         <button 
                             onClick={() => setActiveTab('layout')}
-                            className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${activeTab === 'layout' ? 'bg-white shadow-sm text-indigo-600' : 'text-gray-600 hover:bg-gray-100'}`}
+                            className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${activeTab === 'layout' ? 'bg-white shadow-sm text-accent-600' : 'text-gray-600 hover:bg-gray-100'}`}
                         >
                             <Layout size={16} /> Layout
                         </button>
                         <button 
                             onClick={() => setActiveTab('appearance')}
-                            className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${activeTab === 'appearance' ? 'bg-white shadow-sm text-indigo-600' : 'text-gray-600 hover:bg-gray-100'}`}
+                            className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${activeTab === 'appearance' ? 'bg-white shadow-sm text-accent-600' : 'text-gray-600 hover:bg-gray-100'}`}
                         >
                             <Map size={16} /> Appearance
                         </button>
                         <button 
                             onClick={() => setActiveTab('language')}
-                            className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${activeTab === 'language' ? 'bg-white shadow-sm text-indigo-600' : 'text-gray-600 hover:bg-gray-100'}`}
+                            className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${activeTab === 'language' ? 'bg-white shadow-sm text-accent-600' : 'text-gray-600 hover:bg-gray-100'}`}
                         >
                             <Globe size={16} /> Language
                         </button>
@@ -87,11 +87,11 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                                         <button 
                                             onClick={() => onToggleView?.('horizontal')}
                                             disabled={!onToggleView}
-                                            className={`p-4 rounded-xl border-2 text-left transition-all relative ${timelineView === 'horizontal' ? 'border-indigo-500 bg-indigo-50' : 'border-gray-200 hover:border-gray-300'} ${!onToggleView ? 'opacity-60 cursor-not-allowed' : ''}`}
+                                            className={`p-4 rounded-xl border-2 text-left transition-all relative ${timelineView === 'horizontal' ? 'border-accent-500 bg-accent-50' : 'border-gray-200 hover:border-gray-300'} ${!onToggleView ? 'opacity-60 cursor-not-allowed' : ''}`}
                                         >
                                             <div className="flex items-center justify-between mb-2">
-                                                <span className={`font-semibold ${timelineView === 'horizontal' ? 'text-indigo-900' : 'text-gray-700'}`}>Horizontal</span>
-                                                {timelineView === 'horizontal' && <Check size={16} className="text-indigo-600" />}
+                                                <span className={`font-semibold ${timelineView === 'horizontal' ? 'text-accent-900' : 'text-gray-700'}`}>Horizontal</span>
+                                                {timelineView === 'horizontal' && <Check size={16} className="text-accent-600" />}
                                             </div>
                                             <div className="h-2 w-full bg-gray-200 rounded-full mb-2 overflow-hidden">
                                                 <div className="h-full w-1/3 bg-gray-400"></div>
@@ -102,11 +102,11 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                                         <button 
                                             onClick={() => onToggleView?.('vertical')}
                                             disabled={!onToggleView}
-                                            className={`p-4 rounded-xl border-2 text-left transition-all relative ${timelineView === 'vertical' ? 'border-indigo-500 bg-indigo-50' : 'border-gray-200 hover:border-gray-300'} ${!onToggleView ? 'opacity-60 cursor-not-allowed' : ''}`}
+                                            className={`p-4 rounded-xl border-2 text-left transition-all relative ${timelineView === 'vertical' ? 'border-accent-500 bg-accent-50' : 'border-gray-200 hover:border-gray-300'} ${!onToggleView ? 'opacity-60 cursor-not-allowed' : ''}`}
                                         >
                                             <div className="flex items-center justify-between mb-2">
-                                                <span className={`font-semibold ${timelineView === 'vertical' ? 'text-indigo-900' : 'text-gray-700'}`}>Vertical</span>
-                                                {timelineView === 'vertical' && <Check size={16} className="text-indigo-600" />}
+                                                <span className={`font-semibold ${timelineView === 'vertical' ? 'text-accent-900' : 'text-gray-700'}`}>Vertical</span>
+                                                {timelineView === 'vertical' && <Check size={16} className="text-accent-600" />}
                                             </div>
                                             <div className="flex gap-2 h-8">
                                                 <div className="w-1 h-full bg-gray-300 rounded-full"></div>
@@ -130,7 +130,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                                         <button 
                                             onClick={() => onMapStyleChange?.('minimal')}
                                             disabled={!onMapStyleChange}
-                                            className={`aspect-video rounded-lg flex flex-col items-center justify-center p-2 border-2 transition-all ${mapStyle === 'minimal' ? 'border-indigo-500 bg-indigo-50' : 'border-transparent bg-gray-100 hover:bg-gray-200'} ${!onMapStyleChange ? 'opacity-60 cursor-not-allowed' : ''}`}
+                                            className={`aspect-video rounded-lg flex flex-col items-center justify-center p-2 border-2 transition-all ${mapStyle === 'minimal' ? 'border-accent-500 bg-accent-50' : 'border-transparent bg-gray-100 hover:bg-gray-200'} ${!onMapStyleChange ? 'opacity-60 cursor-not-allowed' : ''}`}
                                         >
                                             <span className="font-semibold text-gray-800 text-sm">Minimal</span>
                                             <span className="text-xs text-gray-500 mt-1">Clean & Focused</span>
@@ -138,7 +138,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                                         <button 
                                             onClick={() => onMapStyleChange?.('standard')}
                                             disabled={!onMapStyleChange}
-                                            className={`aspect-video rounded-lg flex flex-col items-center justify-center p-2 border-2 transition-all ${mapStyle === 'standard' ? 'border-indigo-500 bg-indigo-50' : 'border-transparent bg-gray-100 hover:bg-gray-200'} ${!onMapStyleChange ? 'opacity-60 cursor-not-allowed' : ''}`}
+                                            className={`aspect-video rounded-lg flex flex-col items-center justify-center p-2 border-2 transition-all ${mapStyle === 'standard' ? 'border-accent-500 bg-accent-50' : 'border-transparent bg-gray-100 hover:bg-gray-200'} ${!onMapStyleChange ? 'opacity-60 cursor-not-allowed' : ''}`}
                                         >
                                             <span className="font-semibold text-gray-800 text-sm">Standard</span>
                                             <span className="text-xs text-gray-500 mt-1">Google Default</span>
@@ -146,7 +146,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                                         <button 
                                             onClick={() => onMapStyleChange?.('dark')}
                                             disabled={!onMapStyleChange}
-                                            className={`aspect-video rounded-lg flex flex-col items-center justify-center p-2 border-2 transition-all ${mapStyle === 'dark' ? 'border-indigo-500 bg-gray-800' : 'border-transparent bg-gray-800 hover:bg-gray-700'} ${!onMapStyleChange ? 'opacity-60 cursor-not-allowed' : ''}`}
+                                            className={`aspect-video rounded-lg flex flex-col items-center justify-center p-2 border-2 transition-all ${mapStyle === 'dark' ? 'border-accent-500 bg-gray-800' : 'border-transparent bg-gray-800 hover:bg-gray-700'} ${!onMapStyleChange ? 'opacity-60 cursor-not-allowed' : ''}`}
                                         >
                                             <span className="font-semibold text-white text-sm">Dark</span>
                                             <span className="text-xs text-gray-400 mt-1">Night Mode</span>
@@ -154,7 +154,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                                         <button 
                                             onClick={() => onMapStyleChange?.('satellite')}
                                             disabled={!onMapStyleChange}
-                                            className={`aspect-video rounded-lg flex flex-col items-center justify-center p-2 border-2 transition-all ${mapStyle === 'satellite' ? 'border-indigo-500 bg-green-900' : 'border-transparent bg-green-900 hover:bg-green-800'} ${!onMapStyleChange ? 'opacity-60 cursor-not-allowed' : ''}`}
+                                            className={`aspect-video rounded-lg flex flex-col items-center justify-center p-2 border-2 transition-all ${mapStyle === 'satellite' ? 'border-accent-500 bg-green-900' : 'border-transparent bg-green-900 hover:bg-green-800'} ${!onMapStyleChange ? 'opacity-60 cursor-not-allowed' : ''}`}
                                         >
                                             <span className="font-semibold text-white text-sm">Satellite</span>
                                             <span className="text-xs text-gray-300 mt-1">Aerial View</span>
@@ -166,7 +166,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
 
                         {activeTab === 'language' && (
                             <div className="space-y-6">
-                                <div className="p-4 bg-blue-50 border border-blue-100 rounded-lg text-sm text-blue-800">
+                                <div className="p-4 bg-accent-50 border border-accent-100 rounded-lg text-sm text-accent-800">
                                     <strong>Map language</strong>
                                     <p className="mt-1">Map labels follow this setting. English is currently the only supported language.</p>
                                 </div>
@@ -187,7 +187,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                 </div>
                 
                 <div className="p-4 border-t border-gray-100 bg-gray-50 flex justify-end">
-                    <button onClick={onClose} className="px-4 py-2 bg-indigo-600 text-white font-medium rounded-lg hover:bg-indigo-700">
+                    <button onClick={onClose} className="px-4 py-2 bg-accent-600 text-white font-medium rounded-lg hover:bg-accent-700">
                         Done
                     </button>
                 </div>

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -592,11 +592,11 @@ export const Timeline: React.FC<TimelineProps> = ({
                     // Grouped View: Month Row + Day Row
                     <div className="flex flex-col h-full">
                         {/* Month Row */}
-                        <div className="flex border-b border-gray-100 h-8 overflow-hidden bg-indigo-50">
+                        <div className="flex border-b border-gray-100 h-8 overflow-hidden bg-accent-50">
                              {dateHeaders.months?.map((month, idx) => (
                                  <div 
                                     key={idx}
-                                    className="flex-shrink-0 flex items-center justify-center font-bold text-xs uppercase tracking-widest text-indigo-900 border-r border-indigo-100 bg-indigo-50 last:border-0"
+                                    className="flex-shrink-0 flex items-center justify-center font-bold text-xs uppercase tracking-widest text-accent-900 border-r border-accent-100 bg-accent-50 last:border-0"
                                     style={{ width: `${month.width * pixelsPerDay}px` }}
                                  >
                                      {month.name}
@@ -647,7 +647,7 @@ export const Timeline: React.FC<TimelineProps> = ({
                          <button 
                             onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddCity(); }}
                             disabled={!canEdit}
-                            className={`opacity-0 group-hover/cities:opacity-100 transition-opacity bg-indigo-100 text-indigo-700 rounded-full p-1 ${canEdit ? 'hover:bg-indigo-200' : 'opacity-50 cursor-not-allowed'}`}
+                            className={`opacity-0 group-hover/cities:opacity-100 transition-opacity bg-accent-100 text-accent-700 rounded-full p-1 ${canEdit ? 'hover:bg-accent-200' : 'opacity-50 cursor-not-allowed'}`}
                             title="Add City to end"
                         >
                              <Plus size={14} />
@@ -766,7 +766,7 @@ export const Timeline: React.FC<TimelineProps> = ({
                                     <button
                                         onClick={(e) => { e.stopPropagation(); handleSelectOrCreateTravel(link.fromCity, link.toCity, travel); }}
                                         className={`absolute top-1/2 -translate-y-1/2 px-3 py-1.5 rounded-full border text-xs font-semibold flex items-center gap-2 shadow-sm transition-colors
-                                            ${isSelected ? 'bg-indigo-50 border-indigo-300 text-indigo-700' : 'bg-white border-gray-200 text-gray-600'}
+                                            ${isSelected ? 'bg-accent-50 border-accent-300 text-accent-700' : 'bg-white border-gray-200 text-gray-600'}
                                             ${travel || canEdit ? 'hover:bg-gray-50 cursor-pointer' : 'cursor-not-allowed opacity-60'}
                                         `}
                                         style={{ left: chipLeft, width: chipWidth }}
@@ -808,7 +808,7 @@ export const Timeline: React.FC<TimelineProps> = ({
                                  <button
                                      onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddActivity(dateHeaders.days[i]?.dayOffset ?? i); }}
                                      disabled={!canEdit}
-                                     className={`w-full h-full mx-1 rounded-md border border-dashed border-transparent flex items-center justify-center text-gray-300 transition-all ${canEdit ? 'hover:border-gray-300 hover:bg-gray-50 hover:text-indigo-500' : 'cursor-not-allowed opacity-40'}`}
+                                     className={`w-full h-full mx-1 rounded-md border border-dashed border-transparent flex items-center justify-center text-gray-300 transition-all ${canEdit ? 'hover:border-gray-300 hover:bg-gray-50 hover:text-accent-500' : 'cursor-not-allowed opacity-40'}`}
                                      title={`Add activity for ${dateHeaders.days[i]?.date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) || `day ${i + 1}`}`}
                                  >
                                      <Plus size={16} />

--- a/components/TimelineBlock.tsx
+++ b/components/TimelineBlock.tsx
@@ -104,7 +104,7 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
         ${isLoadingItem ? 'bg-slate-100 border-slate-200 text-slate-400 animate-pulse' : resolvedColor}
         ${isCity ? 'opacity-80 rounded-sm border-r border-white/20 cursor-pointer' : 'rounded-lg border shadow-sm'} 
         ${!vertical && isCity ? 'top-0 bottom-0' : ''}
-        ${isSelected ? 'ring-2 ring-offset-1 ring-blue-500 z-30 opacity-100' : 'z-10'}
+        ${isSelected ? 'ring-2 ring-offset-1 ring-accent-500 z-30 opacity-100' : 'z-10'}
         ${(isTravel || isEmptyTravel) ? 'z-20' : 'overflow-hidden'}
         ${isEmptyTravel ? (canEdit ? 'border-dashed cursor-pointer hover:bg-gray-50' : 'border-dashed cursor-not-allowed opacity-70') : ''}
       `}
@@ -217,7 +217,7 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
                 <button
                     onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onSwapSelectedCities(); }}
                     disabled={!canEdit}
-                    className={`bg-white text-indigo-600 shadow-md border border-gray-200 p-1 rounded-full transition-transform ${canEdit ? 'hover:bg-indigo-50 hover:scale-110' : 'cursor-not-allowed opacity-60'}`}
+                    className={`bg-white text-accent-600 shadow-md border border-gray-200 p-1 rounded-full transition-transform ${canEdit ? 'hover:bg-accent-50 hover:scale-110' : 'cursor-not-allowed opacity-60'}`}
                     title={swapSelectedLabel || 'Reverse selected cities'}
                 >
                     <ArrowUpDown size={12} strokeWidth={3} />
@@ -227,7 +227,7 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
                 <button 
                     onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onForceFill(item.id); }}
                     disabled={!canEdit}
-                    className={`bg-white text-indigo-600 shadow-md border border-gray-200 p-1 rounded-full transition-transform ${canEdit ? 'hover:bg-indigo-50 hover:scale-110' : 'cursor-not-allowed opacity-60'}`}
+                    className={`bg-white text-accent-600 shadow-md border border-gray-200 p-1 rounded-full transition-transform ${canEdit ? 'hover:bg-accent-50 hover:scale-110' : 'cursor-not-allowed opacity-60'}`}
                     title={forceFillLabel || 'Occupy available space'}
                 >
                     {(forceFillMode === 'shrink') ? <Minimize size={12} strokeWidth={3} /> : <Maximize size={12} strokeWidth={3} />}
@@ -250,7 +250,7 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
         >
             <div className={`rounded-full transition-colors shadow-sm flex items-center justify-center
                 ${vertical ? 'w-8 h-1.5' : 'h-8 w-1.5'}
-                ${isSelected ? 'bg-white border border-gray-300' : 'bg-white/80 border border-gray-200 group-hover/handle:bg-indigo-500 group-hover/handle:border-indigo-600'}
+                ${isSelected ? 'bg-white border border-gray-300' : 'bg-white/80 border border-gray-200 group-hover/handle:bg-accent-500 group-hover/handle:border-accent-600'}
             `}>
                <div className={`flex gap-[2px] opacity-50 ${vertical ? 'flex-row' : 'flex-col'}`}>
                  <div className="w-0.5 h-0.5 bg-current rounded-full"></div>
@@ -275,7 +275,7 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
         >
             <div className={`rounded-full transition-colors shadow-sm flex items-center justify-center
                 ${vertical ? 'w-8 h-1.5' : 'h-8 w-1.5'}
-                ${isSelected ? 'bg-white border border-gray-300' : 'bg-white/80 border border-gray-200 group-hover/handle:bg-indigo-500 group-hover/handle:border-indigo-600'}
+                ${isSelected ? 'bg-white border border-gray-300' : 'bg-white/80 border border-gray-200 group-hover/handle:bg-accent-500 group-hover/handle:border-accent-600'}
             `}>
                <div className={`flex gap-[2px] opacity-50 ${vertical ? 'flex-row' : 'flex-col'}`}>
                  <div className="w-0.5 h-0.5 bg-current rounded-full"></div>

--- a/components/TripGenerationSkeleton.tsx
+++ b/components/TripGenerationSkeleton.tsx
@@ -99,8 +99,8 @@ export const TripGenerationSkeleton: React.FC = () => {
                 <div className="absolute inset-0 bg-white/70 backdrop-blur-[2px] flex items-center justify-center z-50">
                     <div className="bg-white p-8 rounded-2xl shadow-2xl border border-gray-100 max-w-sm w-full text-center flex flex-col items-center gap-5 animate-in zoom-in-95 duration-500">
                         <div className="relative">
-                            <div className="absolute inset-0 bg-indigo-100 rounded-full animate-ping opacity-30" />
-                            <div className="bg-indigo-50 p-4 rounded-full text-indigo-600 relative z-10">
+                            <div className="absolute inset-0 bg-accent-100 rounded-full animate-ping opacity-30" />
+                            <div className="bg-accent-50 p-4 rounded-full text-accent-600 relative z-10">
                                 <Loader2 className="w-8 h-8 animate-spin" />
                             </div>
                         </div>
@@ -111,7 +111,7 @@ export const TripGenerationSkeleton: React.FC = () => {
                         
                         {/* Progress Bar (Fake but effective) */}
                         <div className="w-full h-1.5 bg-gray-100 rounded-full overflow-hidden mt-2">
-                            <div className="h-full bg-gradient-to-r from-indigo-500 to-purple-500 animate-[loading_15s_ease-out_forwards] w-full origin-left scale-x-0" />
+                            <div className="h-full bg-gradient-to-r from-accent-500 to-accent-600 animate-[loading_15s_ease-out_forwards] w-full origin-left scale-x-0" />
                         </div>
                         <style>{`
                             @keyframes loading {

--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -69,10 +69,10 @@ const getToneMeta = (tone: ChangeTone) => {
         case 'update':
             return {
                 label: 'Updated',
-                iconClass: 'bg-blue-100 text-blue-700',
-                badgeClass: 'bg-blue-100 text-blue-700',
-                toastBorderClass: 'border-blue-200',
-                toastTitleClass: 'text-blue-700',
+                iconClass: 'bg-accent-100 text-accent-700',
+                badgeClass: 'bg-accent-100 text-accent-700',
+                toastBorderClass: 'border-accent-200',
+                toastTitleClass: 'text-accent-700',
                 Icon: Pencil,
             };
         case 'neutral':
@@ -1544,7 +1544,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
 
     return (
         <GoogleMapsLoader language={appLanguage}>
-            <div className="h-screen w-screen flex flex-col bg-gray-50 overflow-hidden text-gray-900 font-sans selection:bg-indigo-100 selection:text-indigo-900">
+            <div className="h-screen w-screen flex flex-col bg-gray-50 overflow-hidden text-gray-900 font-sans selection:bg-accent-100 selection:text-accent-900">
                 
                 {/* Header */}
                 <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-4 sm:px-6 z-30 shrink-0">
@@ -1554,10 +1554,10 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                             onClick={() => window.location.href = '/'}
                             title="Go to Homepage"
                         >
-                            <div className="w-8 h-8 bg-indigo-600 rounded-lg flex items-center justify-center shadow-indigo-200 shadow-lg transform rotate-3">
+                            <div className="w-8 h-8 bg-accent-600 rounded-lg flex items-center justify-center shadow-accent-200 shadow-lg transform rotate-3">
                                 <Plane className="text-white transform -rotate-3" size={18} fill="currentColor" />
                             </div>
-                            <span className="font-bold text-xl tracking-tight text-gray-900 hidden sm:block">Travel<span className="text-indigo-600">Flow</span></span>
+                            <span className="font-bold text-xl tracking-tight text-gray-900 hidden sm:block">Travel<span className="text-accent-600">Flow</span></span>
                         </div>
                         <div className="h-6 w-px bg-gray-200 mx-2 hidden sm:block" />
                         <div className="flex items-start gap-2">
@@ -1583,7 +1583,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                             } 
                                         }}
                                         autoFocus
-                                        className="font-bold text-lg text-gray-900 bg-transparent border-b-2 border-indigo-500 outline-none pb-0.5"
+                                        className="font-bold text-lg text-gray-900 bg-transparent border-b-2 border-accent-500 outline-none pb-0.5"
                                     />
                                 ) : (
                                     <div className="flex items-center gap-2 group cursor-pointer" onClick={() => { if (!requireEdit()) return; setEditTitleValue(trip.title); setIsEditingTitle(true); }}>
@@ -1591,14 +1591,14 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                         <Pencil size={14} className="text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
                                     </div>
                                 )}
-                                <div className="text-xs font-semibold text-purple-600 mt-0.5">{tripSummary}</div>
+                                <div className="text-xs font-semibold text-accent-600 mt-0.5">{tripSummary}</div>
                                 {forkMeta && (
                                     <div className="text-[11px] text-gray-400 mt-0.5 flex items-center gap-2">
                                         <span>{forkMeta.label}</span>
                                         {forkMeta.url && (
                                             <a
                                                 href={forkMeta.url}
-                                                className="text-[11px] text-indigo-500 hover:underline"
+                                                className="text-[11px] text-accent-500 hover:underline"
                                             >
                                                 View source
                                             </a>
@@ -1635,7 +1635,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                             <Folder size={18} /> <span className="hidden lg:inline">My Trips</span>
                         </button>
                         {canShare && (
-                            <button onClick={handleShare} className="px-4 py-2 bg-indigo-600 text-white rounded-lg shadow-sm hover:bg-indigo-700 flex items-center gap-2 text-sm font-medium">
+                            <button onClick={handleShare} className="px-4 py-2 bg-accent-600 text-white rounded-lg shadow-sm hover:bg-accent-700 flex items-center gap-2 text-sm font-medium">
                                 <Share2 size={16} /> <span className="hidden sm:inline">Share</span>
                             </button>
                         )}
@@ -1660,7 +1660,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                 )}
 
                 {shareSnapshotMeta && (
-                    <div className="px-4 sm:px-6 py-2 border-b border-blue-200 bg-blue-50 text-blue-900 text-xs flex items-center justify-between gap-3">
+                    <div className="px-4 sm:px-6 py-2 border-b border-accent-200 bg-accent-50 text-accent-900 text-xs flex items-center justify-between gap-3">
                         <span>
                             {shareSnapshotMeta.hasNewer
                                 ? 'You are viewing an older snapshot. This trip has newer updates.'
@@ -1670,7 +1670,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                             <button
                                 type="button"
                                 onClick={() => navigate(shareSnapshotMeta.latestUrl)}
-                                className="px-3 py-1 rounded-md bg-blue-100 text-blue-900 text-xs font-semibold hover:bg-blue-200"
+                                className="px-3 py-1 rounded-md bg-accent-100 text-accent-900 text-xs font-semibold hover:bg-accent-200"
                             >
                                 Open latest
                             </button>
@@ -1740,8 +1740,8 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                              </div>
 
                              {/* Resizer */}
-                             <div className="w-1 bg-gray-100 hover:bg-indigo-500 cursor-col-resize transition-colors z-30 flex items-center justify-center group" onMouseDown={() => startResizing('sidebar')}>
-                                <div className="h-8 w-1 group-hover:bg-indigo-400 rounded-full opacity-0 group-hover:opacity-100 transition-opacity" />
+                             <div className="w-1 bg-gray-100 hover:bg-accent-500 cursor-col-resize transition-colors z-30 flex items-center justify-center group" onMouseDown={() => startResizing('sidebar')}>
+                                <div className="h-8 w-1 group-hover:bg-accent-400 rounded-full opacity-0 group-hover:opacity-100 transition-opacity" />
                              </div>
 
                              {/* Details (Center/Inline) */}
@@ -1775,11 +1775,11 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                         />
                                     )}
                                     <div
-                                        className="absolute top-0 right-0 h-full w-2 cursor-col-resize z-30 flex items-center justify-center group hover:bg-indigo-50/60 transition-colors"
+                                        className="absolute top-0 right-0 h-full w-2 cursor-col-resize z-30 flex items-center justify-center group hover:bg-accent-50/60 transition-colors"
                                         onMouseDown={(e) => startResizing('details', e.clientX)}
                                         title="Resize details panel"
                                     >
-                                        <div className="h-10 w-0.5 rounded-full bg-gray-200 group-hover:bg-indigo-400 transition-colors" />
+                                        <div className="h-10 w-0.5 rounded-full bg-gray-200 group-hover:bg-accent-400 transition-colors" />
                                     </div>
                                 </div>
                              )}
@@ -1825,8 +1825,8 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                         fitToRouteKey={trip.id}
                                       />
                              </div>
-                             <div className="h-1 bg-gray-100 hover:bg-indigo-500 cursor-row-resize transition-colors z-30 flex justify-center items-center group w-full" onMouseDown={() => startResizing('timeline-h')}>
-                                  <div className="w-12 h-1 group-hover:bg-indigo-400 rounded-full opacity-0 group-hover:opacity-100 transition-opacity" />
+                             <div className="h-1 bg-gray-100 hover:bg-accent-500 cursor-row-resize transition-colors z-30 flex justify-center items-center group w-full" onMouseDown={() => startResizing('timeline-h')}>
+                                  <div className="w-12 h-1 group-hover:bg-accent-400 rounded-full opacity-0 group-hover:opacity-100 transition-opacity" />
                              </div>
                              <div style={{ height: timelineHeight }} className="w-full bg-white border-t border-gray-200 z-20 shrink-0 relative flex flex-row">
                                  <div ref={verticalLayoutTimelineRef} className="flex-1 h-full relative border-r border-gray-100 min-w-0">
@@ -1904,11 +1904,11 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                         />
                                     )}
                                         <div
-                                            className="absolute top-0 right-0 h-full w-2 cursor-col-resize z-30 flex items-center justify-center group hover:bg-indigo-50/60 transition-colors"
+                                            className="absolute top-0 right-0 h-full w-2 cursor-col-resize z-30 flex items-center justify-center group hover:bg-accent-50/60 transition-colors"
                                             onMouseDown={(e) => startResizing('details', e.clientX)}
                                             title="Resize details panel"
                                         >
-                                            <div className="h-10 w-0.5 rounded-full bg-gray-200 group-hover:bg-indigo-400 transition-colors" />
+                                            <div className="h-10 w-0.5 rounded-full bg-gray-200 group-hover:bg-accent-400 transition-colors" />
                                         </div>
                                     </div>
                                  )}
@@ -1942,9 +1942,9 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                 aria-label="Close release update"
                                 onClick={dismissReleaseNotice}
                             />
-                            <div className="relative w-full max-w-lg rounded-3xl border border-indigo-100 bg-white shadow-2xl">
-                                <div className="rounded-t-3xl border-b border-slate-100 bg-gradient-to-r from-indigo-50 to-cyan-50 px-6 py-5">
-                                    <p className="text-[11px] font-semibold uppercase tracking-wide text-indigo-700">
+                            <div className="relative w-full max-w-lg rounded-3xl border border-accent-100 bg-white shadow-2xl">
+                                <div className="rounded-t-3xl border-b border-slate-100 bg-gradient-to-r from-accent-50 to-accent-100 px-6 py-5">
+                                    <p className="text-[11px] font-semibold uppercase tracking-wide text-accent-700">
                                         Latest release · {latestInAppRelease.version}
                                     </p>
                                     <h2 id="release-update-title" className="mt-2 text-xl font-black text-slate-900">
@@ -1983,7 +1983,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                     <button
                                         type="button"
                                         onClick={dismissReleaseNotice}
-                                        className="rounded-lg bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-700"
+                                        className="rounded-lg bg-accent-600 px-3 py-2 text-xs font-semibold text-white hover:bg-accent-700"
                                     >
                                         Dismiss
                                     </button>
@@ -2061,7 +2061,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                     <button
                                         onClick={handleGenerateShare}
                                         disabled={isGeneratingShare}
-                                        className={`px-4 py-2 rounded-lg text-sm font-semibold text-white ${isGeneratingShare ? 'bg-indigo-300' : 'bg-indigo-600 hover:bg-indigo-700'}`}
+                                        className={`px-4 py-2 rounded-lg text-sm font-semibold text-white ${isGeneratingShare ? 'bg-accent-300' : 'bg-accent-600 hover:bg-accent-700'}`}
                                     >
                                         {isGeneratingShare ? 'Creating…' : (activeShareUrl ? 'Create new link' : 'Generate link')}
                                     </button>
@@ -2119,7 +2119,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                                 const meta = getToneMeta(tone);
                                                 const Icon = meta.Icon;
                                                 return (
-                                                <li key={entry.id} className={`p-4 flex items-start gap-3 ${isCurrent ? 'bg-indigo-50/70' : 'hover:bg-gray-50/80'}`}>
+                                                <li key={entry.id} className={`p-4 flex items-start gap-3 ${isCurrent ? 'bg-accent-50/70' : 'hover:bg-gray-50/80'}`}>
                                                     <div className={`h-8 w-8 rounded-lg shrink-0 flex items-center justify-center ${meta.iconClass}`}>
                                                         <Icon size={15} />
                                                     </div>
@@ -2127,7 +2127,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                                         <div className="flex flex-wrap items-center gap-2">
                                                             <span className={`text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full ${meta.badgeClass}`}>{meta.label}</span>
                                                             <span className="text-xs text-gray-500">{formatHistoryTime(entry.ts)}</span>
-                                                            {isCurrent && <span className="text-[10px] font-semibold text-indigo-600 bg-indigo-100 px-2 py-0.5 rounded-full">Current</span>}
+                                                            {isCurrent && <span className="text-[10px] font-semibold text-accent-600 bg-accent-100 px-2 py-0.5 rounded-full">Current</span>}
                                                         </div>
                                                         <div className="mt-1 text-sm font-semibold text-gray-900 leading-snug">{details}</div>
                                                     </div>

--- a/components/VerticalTimeline.tsx
+++ b/components/VerticalTimeline.tsx
@@ -565,7 +565,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
                          <button 
                              onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddCity(); }}
                              disabled={!canEdit}
-                             className={`opacity-0 group-hover/cities:opacity-100 transition-opacity ml-1 bg-indigo-50 text-indigo-600 rounded-full p-0.5 ${canEdit ? 'hover:bg-indigo-100' : 'opacity-50 cursor-not-allowed'}`}
+                             className={`opacity-0 group-hover/cities:opacity-100 transition-opacity ml-1 bg-accent-50 text-accent-600 rounded-full p-0.5 ${canEdit ? 'hover:bg-accent-100' : 'opacity-50 cursor-not-allowed'}`}
                          >
                              <Plus size={12} />
                          </button>
@@ -667,7 +667,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
                                      <button
                                          onClick={(e) => { e.stopPropagation(); handleSelectOrCreateTravel(link.fromCity, link.toCity, travel); }}
                                          className={`absolute left-1/2 -translate-x-1/2 px-2 py-1 rounded-lg border text-[10px] font-semibold flex flex-col items-center gap-1 shadow-sm transition-colors
-                                             ${isSelected ? 'bg-indigo-50 border-indigo-300 text-indigo-700' : 'bg-white border-gray-200 text-gray-600'}
+                                             ${isSelected ? 'bg-accent-50 border-accent-300 text-accent-700' : 'bg-white border-gray-200 text-gray-600'}
                                              ${travel || canEdit ? 'hover:bg-gray-50 cursor-pointer' : 'cursor-not-allowed opacity-60'}
                                          `}
                                          style={{ top: chipTop, height: chipHeight, width: 46 }}
@@ -694,7 +694,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
                          <button 
                              onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddActivity(visualStartOffset); }}
                              disabled={!canEdit}
-                             className={`opacity-0 group-hover/activities:opacity-100 transition-opacity ml-1 bg-indigo-50 text-indigo-600 rounded-full p-0.5 ${canEdit ? 'hover:bg-indigo-100' : 'opacity-50 cursor-not-allowed'}`}
+                             className={`opacity-0 group-hover/activities:opacity-100 transition-opacity ml-1 bg-accent-50 text-accent-600 rounded-full p-0.5 ${canEdit ? 'hover:bg-accent-100' : 'opacity-50 cursor-not-allowed'}`}
                              title="Add Activity"
                          >
                              <Plus size={12} />

--- a/components/marketing/CookieConsentBanner.tsx
+++ b/components/marketing/CookieConsentBanner.tsx
@@ -40,7 +40,7 @@ export const CookieConsentBanner: React.FC = () => {
             <div className="mx-auto flex w-full max-w-4xl flex-col gap-3 rounded-2xl border border-slate-200 bg-white/95 p-4 shadow-xl backdrop-blur sm:flex-row sm:items-center sm:justify-between sm:gap-6">
                 <p className="text-sm leading-6 text-slate-700">
                     We use essential cookies to keep TravelFlow stable and optional cookies to improve experience. See our{' '}
-                    <Link to="/cookies" className="font-semibold text-indigo-700 hover:text-indigo-800">
+                    <Link to="/cookies" className="font-semibold text-accent-700 hover:text-accent-800">
                         Cookie Policy
                     </Link>
                     .
@@ -56,7 +56,7 @@ export const CookieConsentBanner: React.FC = () => {
                     <button
                         type="button"
                         onClick={() => handleConsent('all')}
-                        className="rounded-lg bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-700"
+                        className="rounded-lg bg-accent-600 px-3 py-2 text-xs font-semibold text-white hover:bg-accent-700"
                     >
                         Accept all
                     </button>

--- a/components/marketing/MarketingLayout.tsx
+++ b/components/marketing/MarketingLayout.tsx
@@ -8,7 +8,7 @@ interface MarketingLayoutProps {
 }
 
 const navLinkClass = ({ isActive }: { isActive: boolean }) => {
-    const baseClass = 'relative font-semibold text-slate-500 transition-colors hover:text-slate-900 after:pointer-events-none after:absolute after:-bottom-4 after:left-0 after:h-0.5 after:w-full after:origin-center after:scale-x-0 after:rounded-full after:bg-indigo-600 after:transition-transform';
+    const baseClass = 'relative font-semibold text-slate-500 transition-colors hover:text-slate-900 after:pointer-events-none after:absolute after:-bottom-4 after:left-0 after:h-0.5 after:w-full after:origin-center after:scale-x-0 after:rounded-full after:bg-accent-600 after:transition-transform';
     if (isActive) {
         return `${baseClass} text-slate-900 after:scale-x-100`;
     }
@@ -22,7 +22,7 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
             <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur">
                 <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-5 py-4 md:px-8">
                     <NavLink to="/" className="flex items-center gap-2">
-                        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-600 text-white shadow-lg shadow-indigo-200">
+                        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent-600 text-white shadow-lg shadow-accent-200">
                             <Plane size={16} fill="currentColor" />
                         </span>
                         <span className="text-lg font-extrabold tracking-tight">TravelFlow</span>
@@ -43,7 +43,7 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
                         </NavLink>
                         <NavLink
                             to="/create-trip"
-                            className="rounded-lg bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-indigo-700"
+                            className="rounded-lg bg-accent-600 px-3 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
                         >
                             Create Trip
                         </NavLink>

--- a/components/marketing/ReleasePill.tsx
+++ b/components/marketing/ReleasePill.tsx
@@ -11,7 +11,7 @@ const PILL_CLASSES: Record<ReleaseNoteItem['typeKey'], string> = {
     improved: 'bg-sky-100 text-sky-800 border-sky-200',
     fixed: 'bg-amber-100 text-amber-800 border-amber-200',
     internal: 'bg-slate-100 text-slate-700 border-slate-200',
-    update: 'bg-violet-100 text-violet-800 border-violet-200',
+    update: 'bg-accent-100 text-accent-800 border-accent-200',
 };
 
 export const ReleasePill: React.FC<ReleasePillProps> = ({ item, className }) => {

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { Check } from 'lucide-react';
+
+const mergeClasses = (...classes: Array<string | undefined | null | false>) => classes.filter(Boolean).join(' ');
+
+export type CheckboxProps = React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>;
+
+export const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root>, CheckboxProps>(
+    ({ className, ...props }, ref) => (
+        <CheckboxPrimitive.Root
+            ref={ref}
+            className={mergeClasses(
+                'peer h-4 w-4 shrink-0 rounded-[4px] border border-gray-300 bg-white shadow-sm outline-none transition-colors',
+                'data-[state=checked]:border-accent-500 data-[state=checked]:bg-accent-500',
+                'focus-visible:ring-2 focus-visible:ring-accent-300 focus-visible:ring-offset-2',
+                'disabled:cursor-not-allowed disabled:opacity-50',
+                className
+            )}
+            {...props}
+        >
+            <CheckboxPrimitive.Indicator className="flex items-center justify-center text-white">
+                <Check className="h-3.5 w-3.5 stroke-[3]" />
+            </CheckboxPrimitive.Indicator>
+        </CheckboxPrimitive.Root>
+    )
+);
+
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;

--- a/content/updates/2026-02-08-global-accent-design-tokens.md
+++ b/content/updates/2026-02-08-global-accent-design-tokens.md
@@ -1,0 +1,19 @@
+---
+id: rel-2026-02-08-global-accent-design-tokens
+version: v0.9.0
+title: "Global accent color tokens and primary UI unification"
+date: 2026-02-08
+published_at: 2026-02-08T12:00:00Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "Accent color now comes from one global token system, with a bright orange default that updates UI states, glows, and highlights across the app."
+---
+
+## Changes
+- [x] [Improved] Added a global `accent`/`primary` design-token scale (`50-950`) in the shared CSS theme layer and switched the active default to a bright orange palette for branding tests.
+- [x] [Improved] Migrated planner and marketing surfaces to use token-based `accent-*` utilities for buttons, links, focus rings, selections, and hover/active states.
+- [x] [Improved] Added reusable accent glow utilities so soft emphasis and top-news highlights inherit from the same primary token values.
+- [x] [Fixed] Removed hardcoded primary accent values from markdown styles and map overlay labels so brand changes apply consistently.
+- [x] [Fixed] Roundtrip checkboxes in Create Trip now use accent-driven checkbox fill so they inherit the global primary color.
+- [ ] [Internal] Standardized semantic token aliases (`primary`, `primary-hover`, `primary-soft`, `primary-border`) to reduce future style drift.

--- a/content/updates/2026-02-08-indigo-accent-default.md
+++ b/content/updates/2026-02-08-indigo-accent-default.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-02-08-indigo-accent-default
+version: v0.12.0
+title: "Accent default reset to indigo"
+date: 2026-02-08
+published_at: 2026-02-08T15:00:00Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "The global accent default now uses the previous indigo/blue palette again while keeping the token-based theming system in place."
+---
+
+## Changes
+- [x] [Improved] Reset the global `accent` token scale to an indigo/blue default palette.
+- [x] [Improved] Kept all UI surfaces token-driven, so future brand color switches still apply globally from one place.
+- [x] [Fixed] Updated My Trips tooltip map fallback colors to indigo so map previews match the active accent theme.
+- [ ] [Internal] Retained token infrastructure and shadcn checkbox integration for future palette experiments.

--- a/content/updates/2026-02-08-shadcn-checkbox-adoption.md
+++ b/content/updates/2026-02-08-shadcn-checkbox-adoption.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-02-08-shadcn-checkbox-adoption
+version: v0.10.0
+title: "Shadcn checkbox adoption for trip setup"
+date: 2026-02-08
+published_at: 2026-02-08T13:00:00Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "Roundtrip toggles now use shadcn-style checkboxes with a softer orange checked state."
+---
+
+## Changes
+- [x] [Improved] Replaced Create Trip roundtrip native checkboxes with a shadcn-style checkbox component for consistent UI behavior.
+- [x] [Improved] Softened checkbox checked visuals to a less aggressive accent tone while preserving accessibility and focus states.
+- [ ] [Internal] Added a reusable Radix-based checkbox primitive in `components/ui` for broader adoption in future forms.

--- a/content/updates/2026-02-08-tooltip-map-accent-sync.md
+++ b/content/updates/2026-02-08-tooltip-map-accent-sync.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-02-08-tooltip-map-accent-sync
+version: v0.11.0
+title: "Trip tooltip map now follows accent tokens"
+date: 2026-02-08
+published_at: 2026-02-08T14:00:00Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "My Trips tooltip map previews now inherit the active accent color token instead of using hardcoded purple map styling."
+---
+
+## Changes
+- [x] [Fixed] Updated the My Trips tooltip Google Static Map route and markers to use global accent token colors.
+- [x] [Improved] Added runtime CSS-token color resolution for tooltip map styling so future accent changes propagate automatically.
+- [ ] [Internal] Added CSS-color normalization helpers for token-to-hex conversion in external map URL parameters.

--- a/index.css
+++ b/index.css
@@ -3,6 +3,63 @@
 
 :root {
   --tf-font-heading: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
+  /* Global accent currently uses an indigo palette. */
+  --tf-accent-50: #eef2ff;
+  --tf-accent-100: #e0e7ff;
+  --tf-accent-200: #c7d2fe;
+  --tf-accent-300: #a5b4fc;
+  --tf-accent-400: #818cf8;
+  --tf-accent-500: #6366f1;
+  --tf-accent-600: #4f46e5;
+  --tf-accent-700: #4338ca;
+  --tf-accent-800: #3730a3;
+  --tf-accent-900: #312e81;
+  --tf-accent-950: #1e1b4b;
+  --tf-accent-rgb: 79 70 229;
+
+  --tf-primary: var(--tf-accent-600);
+  --tf-primary-hover: var(--tf-accent-700);
+  --tf-primary-soft: var(--tf-accent-50);
+  --tf-primary-muted: var(--tf-accent-100);
+  --tf-primary-border: var(--tf-accent-200);
+  --tf-primary-strong: var(--tf-accent-800);
+  --tf-primary-contrast: #ffffff;
+  --tf-primary-glow-sm: rgb(var(--tf-accent-rgb) / 0.2);
+  --tf-primary-glow-md: rgb(var(--tf-accent-rgb) / 0.28);
+}
+
+@theme inline {
+  --color-accent-50: var(--tf-accent-50);
+  --color-accent-100: var(--tf-accent-100);
+  --color-accent-200: var(--tf-accent-200);
+  --color-accent-300: var(--tf-accent-300);
+  --color-accent-400: var(--tf-accent-400);
+  --color-accent-500: var(--tf-accent-500);
+  --color-accent-600: var(--tf-accent-600);
+  --color-accent-700: var(--tf-accent-700);
+  --color-accent-800: var(--tf-accent-800);
+  --color-accent-900: var(--tf-accent-900);
+  --color-accent-950: var(--tf-accent-950);
+
+  --color-primary: var(--tf-primary);
+  --color-primary-hover: var(--tf-primary-hover);
+  --color-primary-soft: var(--tf-primary-soft);
+  --color-primary-muted: var(--tf-primary-muted);
+  --color-primary-border: var(--tf-primary-border);
+  --color-primary-strong: var(--tf-primary-strong);
+  --color-primary-contrast: var(--tf-primary-contrast);
+}
+
+@utility shadow-accent-glow-sm {
+  box-shadow: 0 0 16px var(--tf-primary-glow-sm);
+}
+
+@utility shadow-accent-glow-md {
+  box-shadow: 0 0 34px var(--tf-primary-glow-md);
+}
+
+input[type="checkbox"] {
+  accent-color: var(--tf-accent-500);
 }
 
 h1,

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       /* Markdown Styles */
       .markdown-body ul { list-style-type: disc; padding-left: 1.5em; margin-bottom: 0.5em; }
       .markdown-body ol { list-style-type: decimal; padding-left: 1.5em; margin-bottom: 0.5em; }
-      .markdown-body a { color: #4f46e5; text-decoration: underline; }
+      .markdown-body a { color: var(--tf-primary); text-decoration: underline; }
       .markdown-body strong { font-weight: 700; color: #111827; }
       .markdown-body h3 { font-size: 1.1em; font-weight: 700; margin-top: 1em; margin-bottom: 0.5em; color: #374151; }
       
@@ -76,8 +76,8 @@
       }
       
       .markdown-body input[type="checkbox"]:checked {
-        background-color: #4f46e5 !important;
-        border-color: #4f46e5 !important;
+        background-color: var(--tf-accent-500) !important;
+        border-color: var(--tf-accent-500) !important;
         background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e") !important;
         background-size: 100% 100% !important;
         background-position: center !important;

--- a/index.tsx
+++ b/index.tsx
@@ -32,9 +32,9 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
           <pre className="bg-gray-100 p-4 rounded text-left text-sm overflow-auto max-w-2xl mx-auto">
             {this.state.error?.toString()}
           </pre>
-          <button 
-            onClick={() => window.location.reload()} 
-            className="mt-6 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          <button
+            onClick={() => window.location.reload()}
+            className="mt-6 px-4 py-2 bg-accent-600 text-white rounded hover:bg-accent-700"
           >
             Reload Application
           </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "latest",
+        "@radix-ui/react-checkbox": "^1.2.3",
         "@supabase/supabase-js": "^2.49.1",
         "@types/google.maps": "^3.58.1",
         "lucide-react": "0.378.0",
@@ -915,6 +916,222 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@google/genai": "latest",
+    "@radix-ui/react-checkbox": "^1.2.3",
     "@supabase/supabase-js": "^2.49.1",
     "@types/google.maps": "^3.58.1",
     "lucide-react": "0.378.0",

--- a/pages/AdminDashboardPage.tsx
+++ b/pages/AdminDashboardPage.tsx
@@ -16,7 +16,7 @@ export const AdminDashboardPage: React.FC = () => {
         <div className="min-h-screen bg-slate-50 px-6 py-10 md:px-10">
             <div className="mx-auto w-full max-w-7xl">
                 <section className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
-                    <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600">Admin planning scaffold</p>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-accent-600">Admin planning scaffold</p>
                     <h1 className="mt-3 text-3xl font-black tracking-tight text-slate-900 md:text-4xl">Admin Metrics Dashboard</h1>
                     <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600">
                         Placeholder for the future authenticated admin area. This page will aggregate user, trip, and infrastructure/API usage metrics so operational risks can be monitored in one place.

--- a/pages/MarketingHomePage.tsx
+++ b/pages/MarketingHomePage.tsx
@@ -30,11 +30,11 @@ export const MarketingHomePage: React.FC = () => {
     return (
         <MarketingLayout>
             <section className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white p-8 shadow-sm md:p-12">
-                <div className="pointer-events-none absolute -right-28 -top-24 h-72 w-72 rounded-full bg-cyan-200/40 blur-3xl" />
-                <div className="pointer-events-none absolute -bottom-28 left-8 h-72 w-72 rounded-full bg-indigo-200/50 blur-3xl" />
+                <div className="pointer-events-none absolute -right-28 -top-24 h-72 w-72 rounded-full bg-accent-300/40 blur-3xl" />
+                <div className="pointer-events-none absolute -bottom-28 left-8 h-72 w-72 rounded-full bg-accent-200/50 blur-3xl" />
 
                 <div className="relative max-w-3xl">
-                    <span className="inline-flex rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-700">
+                    <span className="inline-flex rounded-full border border-accent-200 bg-accent-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-accent-700">
                         Future-ready planning workspace
                     </span>
                     <h1 className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-5xl">
@@ -46,7 +46,7 @@ export const MarketingHomePage: React.FC = () => {
                     <div className="mt-8 flex flex-wrap items-center gap-3">
                         <Link
                             to="/create-trip"
-                            className="rounded-xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-indigo-700"
+                            className="rounded-xl bg-accent-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
                         >
                             Create Trip
                         </Link>

--- a/pages/UpdatesPage.tsx
+++ b/pages/UpdatesPage.tsx
@@ -47,7 +47,7 @@ export const UpdatesPage: React.FC = () => {
                             key={release.id}
                             className={
                                 isTopNews
-                                    ? 'rounded-2xl border border-indigo-200/80 bg-gradient-to-b from-indigo-50/40 to-white p-6 shadow-[0_0_34px_rgba(99,102,241,0.20)]'
+                                    ? 'rounded-2xl border border-accent-200/80 bg-gradient-to-b from-accent-50/40 to-white p-6 shadow-accent-glow-md'
                                     : 'rounded-2xl border border-slate-200 bg-white p-6 shadow-sm'
                             }
                         >
@@ -57,7 +57,7 @@ export const UpdatesPage: React.FC = () => {
                                     <span
                                         className={
                                             isTopNews
-                                                ? 'inline-flex rounded-full border border-indigo-300 bg-indigo-100 px-2.5 py-0.5 text-[11px] font-semibold text-indigo-800 shadow-[0_0_16px_rgba(99,102,241,0.28)]'
+                                                ? 'inline-flex rounded-full border border-accent-300 bg-accent-100 px-2.5 py-0.5 text-[11px] font-semibold text-accent-800 shadow-accent-glow-sm'
                                                 : 'inline-flex rounded-full border border-slate-300 bg-slate-50 px-2.5 py-0.5 text-[11px] font-semibold text-slate-700'
                                         }
                                     >


### PR DESCRIPTION
## Summary\n- introduce global accent/primary design tokens and migrate UI surfaces to token-based accent utilities\n- adopt a shadcn-style checkbox (Radix) for Create Trip roundtrip toggles with softer checked styling\n- sync My Trips tooltip static map marker/path colors with active accent tokens\n- reset active default palette back to indigo and keep tokenized theming in place\n- add release entries for v0.9.0 through v0.12.0 to document the rollout\n\n## Validation\n- npm run updates:validate\n- npm run build