### PR TITLE
feat: optimize trip view for mobile and align plans panel interactions

### DIFF
--- a/components/ItineraryMap.tsx
+++ b/components/ItineraryMap.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { ITimelineItem, MapStyle, RouteMode } from '../types';
-import { Focus, Columns, Rows, Layers } from 'lucide-react';
+import { Focus, Columns, Rows, Layers, Maximize2, Minimize2 } from 'lucide-react';
 import { buildRouteCacheKey, findTravelBetweenCities, getHexFromColorClass, getNormalizedCityName } from '../utils';
 import { useGoogleMaps } from './GoogleMapsLoader';
 
@@ -9,12 +9,15 @@ interface ItineraryMapProps {
     selectedItemId?: string | null;
     layoutMode?: 'horizontal' | 'vertical';
     onLayoutChange?: (mode: 'horizontal' | 'vertical') => void;
+    showLayoutControls?: boolean;
     activeStyle?: MapStyle;
     onStyleChange?: (style: MapStyle) => void;
     routeMode?: RouteMode;
     onRouteModeChange?: (mode: RouteMode) => void;
     showCityNames?: boolean;
     onShowCityNamesChange?: (enabled: boolean) => void;
+    isExpanded?: boolean;
+    onToggleExpanded?: () => void;
     focusLocationQuery?: string;
     fitToRouteKey?: string;
     onRouteMetrics?: (travelItemId: string, metrics: { routeDistanceKm?: number; routeDurationHours?: number; mode?: string; routeKey?: string }) => void;
@@ -207,12 +210,15 @@ export const ItineraryMap: React.FC<ItineraryMapProps> = ({
     selectedItemId, 
     layoutMode, 
     onLayoutChange, 
+    showLayoutControls = true,
     activeStyle = 'standard',
     onStyleChange,
     routeMode = 'simple',
     onRouteModeChange,
     showCityNames = true,
     onShowCityNamesChange,
+    isExpanded = false,
+    onToggleExpanded,
     focusLocationQuery,
     fitToRouteKey,
     onRouteMetrics,
@@ -963,11 +969,22 @@ export const ItineraryMap: React.FC<ItineraryMapProps> = ({
             {/* Controls */}
             <div className="absolute top-4 right-4 z-[10] flex flex-col gap-2 pointer-events-none">
                 <div className="flex flex-col gap-2 pointer-events-auto">
-                    {onLayoutChange && (
+                    {showLayoutControls && onLayoutChange && (
                         <>
                             <button onClick={() => onLayoutChange('vertical')} className={`p-2 rounded-lg shadow-md border transition-colors ${layoutMode === 'vertical' ? 'bg-accent-600 text-white border-accent-700' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`}><Rows size={18} /></button>
                             <button onClick={() => onLayoutChange('horizontal')} className={`p-2 rounded-lg shadow-md border transition-colors ${layoutMode === 'horizontal' ? 'bg-accent-600 text-white border-accent-700' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`}><Columns size={18} /></button>
                         </>
+                    )}
+
+                    {onToggleExpanded && (
+                        <button
+                            onClick={onToggleExpanded}
+                            className="p-2 rounded-lg shadow-md border bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50 transition-colors flex items-center justify-center"
+                            title={isExpanded ? 'Shrink map' : 'Expand map'}
+                            aria-label={isExpanded ? 'Shrink map' : 'Expand map'}
+                        >
+                            {isExpanded ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
+                        </button>
                     )}
                     
                     <button onClick={handleFit} className="p-2 rounded-lg shadow-md border bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50 transition-colors flex items-center justify-center" title="Fit to Itinerary"><Focus size={18} /></button>

--- a/components/TripManager.tsx
+++ b/components/TripManager.tsx
@@ -1024,8 +1024,8 @@ export const TripManager: React.FC<TripManagerProps> = ({
       />
 
       <div
-        className={`fixed inset-y-0 left-0 w-[380px] max-w-[94vw] bg-white shadow-2xl z-[1200] transform transition-transform duration-300 ease-in-out flex flex-col ${isOpen ? 'translate-x-0' : '-translate-x-full'}`}
-        style={{ transform: isOpen ? 'translateX(0)' : 'translateX(-100%)' }}
+        className={`fixed inset-y-0 right-0 w-[380px] max-w-[94vw] bg-white shadow-2xl z-[1200] transform transition-transform duration-300 ease-in-out flex flex-col ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+        style={{ transform: isOpen ? 'translateX(0)' : 'translateX(100%)' }}
       >
         <div className="px-4 py-3 border-b border-gray-100 flex items-center justify-between">
           <h2 className="text-lg font-semibold text-gray-800">My Plans</h2>

--- a/content/updates/2026-02-08-mobile-trip-view-optimized-header-and-map.md
+++ b/content/updates/2026-02-08-mobile-trip-view-optimized-header-and-map.md
@@ -1,0 +1,19 @@
+---
+id: rel-2026-02-08-mobile-trip-view-optimized-header-and-map
+version: v0.15.0
+title: "Mobile trip view header and map optimization"
+date: 2026-02-08
+published_at: 2026-02-08T18:00:00Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "Trip view on mobile now prioritizes timeline readability with a simplified header, a details modal, and a map-first expand workflow."
+---
+
+## Changes
+- [x] [Improved] Simplified the mobile trip header by hiding secondary meta/source text and moving extra details into a dedicated information modal.
+- [x] [Improved] Added a mobile trip information modal with full title context, trip meta metrics, optional source link, destination info, and collapsible history access.
+- [x] [Improved] Forced mobile trip view into a timeline-first layout with the map always below and a pinch-to-zoom timeline interaction.
+- [x] [Improved] Replaced map layout toggles on mobile with an expand/shrink map control that opens a 70%-height bottom overlay.
+- [x] [Improved] Updated the My Plans trigger to use a route icon and changed the plans drawer to slide in from the right.
+- [ ] [Internal] Added viewport-aware rendering paths in `TripView` and optional map-control flags in `ItineraryMap` to isolate mobile behavior without altering desktop defaults.


### PR DESCRIPTION
## Summary
- optimize mobile trip view header by hiding secondary metadata controls and adding a dedicated trip info modal
- force mobile trip layout to timeline-first with map below, plus map expand/shrink overlay behavior and pinch zoom support hooks for timeline
- remove mobile map layout toggles and replace with expand/shrink control while preserving desktop map controls
- switch My Plans trigger to a route icon and move the plans drawer slide-in direction to the right
- add release note v0.15.0 for the mobile trip-view update batch

## Validation
- npm run build
