### PR TITLE
Improve My Plans sorting and stabilize icon tooltips

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,7 @@ import { appendHistoryEntry, findHistoryEntryByUrl } from './services/historySer
 import { buildShareUrl, buildTripUrl, decompressTrip, generateTripId, generateVersionId, getStoredAppLanguage, isUuid, setStoredAppLanguage } from './utils';
 import { DB_ENABLED, applyUserSettingsToLocalStorage, dbCreateTripVersion, dbGetSharedTrip, dbGetSharedTripVersion, dbGetTrip, dbGetTripVersion, dbUpdateSharedTrip, dbUpsertTrip, dbGetUserSettings, dbUpsertUserSettings, ensureDbSession, syncTripsFromDb, uploadLocalTripsToDb } from './services/dbService';
 import { AppDialogProvider } from './components/AppDialogProvider';
+import { GlobalTooltipLayer } from './components/GlobalTooltipLayer';
 
 const createLocalHistoryEntry = (
     navigate: ReturnType<typeof useNavigate>,
@@ -544,6 +545,7 @@ const AppContent: React.FC = () => {
             />
 
             <CookieConsentBanner />
+            <GlobalTooltipLayer />
         </>
     );
 };

--- a/components/AddActivityModal.tsx
+++ b/components/AddActivityModal.tsx
@@ -133,7 +133,10 @@ export const AddActivityModal: React.FC<AddActivityModalProps> = ({ isOpen, onCl
             >
                 <div className="p-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
                     <h3 className="text-lg font-bold text-gray-900">Add Activity for Day {Math.floor(dayOffset) + 1}</h3>
-                    <button onClick={onClose} className="p-1 hover:bg-gray-200 rounded-full text-gray-500">
+                    <button
+                        onClick={onClose}
+                        className="p-1 hover:bg-gray-200 rounded-full text-gray-500" aria-label="Close"
+                    >
                         <X size={20} />
                     </button>
                 </div>

--- a/components/AddCityModal.tsx
+++ b/components/AddCityModal.tsx
@@ -105,7 +105,10 @@ export const AddCityModal: React.FC<AddCityModalProps> = ({ isOpen, onClose, onA
                         <MapPin size={20} className="text-accent-600" />
                         Add New Destination
                     </h3>
-                    <button onClick={onClose} className="p-1 hover:bg-gray-200 rounded-full text-gray-500">
+                    <button
+                        onClick={onClose}
+                        className="p-1 hover:bg-gray-200 rounded-full text-gray-500" aria-label="Close"
+                    >
                         <X size={20} />
                     </button>
                 </div>
@@ -142,7 +145,7 @@ export const AddCityModal: React.FC<AddCityModalProps> = ({ isOpen, onClose, onA
                                     <button 
                                         onClick={handleManualSubmit}
                                         className="absolute right-2 top-2 p-1.5 bg-accent-600 text-white rounded-lg hover:bg-accent-700 transition-colors"
-                                        disabled={!inputValue.trim()}
+                                        disabled={!inputValue.trim()} aria-label="Add destination"
                                     >
                                         <ArrowRight size={16} />
                                     </button>

--- a/components/CountryInfo.tsx
+++ b/components/CountryInfo.tsx
@@ -63,7 +63,7 @@ export const CountryInfo: React.FC<CountryInfoProps> = ({ info, isExpanded: isEx
                 <h3 className="font-bold text-gray-800 text-sm uppercase tracking-wider flex items-center gap-2">
                     <Globe size={16} className="text-accent-600"/> Destination Info
                 </h3>
-                <button type="button" className="text-gray-400 hover:text-gray-600">
+                <button type="button" className="text-gray-400 hover:text-gray-600" aria-label={isExpanded ? 'Collapse destination info' : 'Expand destination info'}>
                     {isExpanded ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
                 </button>
             </div>
@@ -89,7 +89,7 @@ export const CountryInfo: React.FC<CountryInfoProps> = ({ info, isExpanded: isEx
                             </div>
                             <button 
                                 onClick={(e) => { e.stopPropagation(); setDirection(direction === 'eurToLocal' ? 'localToEur' : 'eurToLocal'); }}
-                                className="p-1.5 bg-white shadow-sm border border-gray-200 rounded-full hover:bg-gray-100 text-accent-600 flex-shrink-0"
+                                className="p-1.5 bg-white shadow-sm border border-gray-200 rounded-full hover:bg-gray-100 text-accent-600 flex-shrink-0" aria-label="Swap conversion direction"
                             >
                                 <ArrowRightLeft size={14} />
                             </button>

--- a/components/CountryTag.tsx
+++ b/components/CountryTag.tsx
@@ -40,6 +40,7 @@ export const CountryTag: React.FC<CountryTagProps> = ({
                     }}
                     className="ml-1 rounded-full p-0.5 text-gray-400 hover:bg-red-50 hover:text-red-500"
                     aria-label={`Remove ${countryName}`}
+                    title={`Remove ${countryName}`}
                 >
                     <X size={12} />
                 </button>

--- a/components/CreateTripForm.tsx
+++ b/components/CreateTripForm.tsx
@@ -841,7 +841,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                         <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm flex items-start gap-3">
                             <AlertTriangle size={16} className="mt-0.5 flex-shrink-0" />
                             <div className="flex-1"><span className="font-bold block mb-1">Planning Failed</span>{generationError}</div>
-                            <button onClick={() => setGenerationError(null)} className="text-red-400 hover:text-red-700">
+                            <button onClick={() => setGenerationError(null)} className="text-red-400 hover:text-red-700" aria-label="Dismiss error">
                                 <Check size={16} />
                             </button>
                         </div>

--- a/components/DateRangePicker.tsx
+++ b/components/DateRangePicker.tsx
@@ -293,13 +293,13 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({ startDate, end
                     
                     {/* Header */}
                     <div className="flex items-center justify-between mb-4">
-                        <button onClick={() => changeMonth(-1)} className="p-1 hover:bg-gray-100 rounded-full text-gray-500">
+                        <button onClick={() => changeMonth(-1)} className="p-1 hover:bg-gray-100 rounded-full text-gray-500" aria-label="Previous month">
                             <ChevronLeft size={20} />
                         </button>
                         <span className="font-bold text-gray-800">
                             {MONTHS[viewDate.getMonth()]} {viewDate.getFullYear()}
                         </span>
-                        <button onClick={() => changeMonth(1)} className="p-1 hover:bg-gray-100 rounded-full text-gray-500">
+                        <button onClick={() => changeMonth(1)} className="p-1 hover:bg-gray-100 rounded-full text-gray-500" aria-label="Next month">
                             <ChevronRight size={20} />
                         </button>
                     </div>

--- a/components/DeleteCityModal.tsx
+++ b/components/DeleteCityModal.tsx
@@ -35,7 +35,10 @@ export const DeleteCityModal: React.FC<DeleteCityModalProps> = ({ isOpen, cityNa
             >
                 <div className="p-6 border-b border-gray-100 flex justify-between items-center bg-gray-50">
                     <h3 className="text-lg font-bold text-gray-800">Delete {cityName}</h3>
-                    <button onClick={onClose} className="p-1 hover:bg-gray-200 rounded-full text-gray-500">
+                    <button
+                        onClick={onClose}
+                        className="p-1 hover:bg-gray-200 rounded-full text-gray-500" aria-label="Close"
+                    >
                         <X size={20} />
                     </button>
                 </div>

--- a/components/DetailsPanel.tsx
+++ b/components/DetailsPanel.tsx
@@ -954,6 +954,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                                 onClick={() => { if (!canEdit) return; setIsColorPickerOpen(!isColorPickerOpen); }}
                                 disabled={!canEdit}
                                 className={`p-1 rounded-full text-gray-400 transition-colors ${canEdit ? 'hover:bg-gray-100 hover:text-accent-600' : 'opacity-50 cursor-not-allowed'}`}
+                                aria-label={isColorPickerOpen ? 'Close color picker' : 'Open color picker'}
                             >
                                 <Palette size={14} />
                             </button>
@@ -977,7 +978,7 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                   <button
                       onClick={() => { if (!canEdit) return; handleDeleteItem(displayItem.id); handleClosePanel(); }}
                       disabled={!canEdit}
-                      className={`p-2 bg-red-50 text-red-500 rounded-full transition-colors sm:hidden ${canEdit ? 'hover:bg-red-100' : 'opacity-50 cursor-not-allowed'}`}
+                      className={`p-2 bg-red-50 text-red-500 rounded-full transition-colors sm:hidden ${canEdit ? 'hover:bg-red-100' : 'opacity-50 cursor-not-allowed'}`} aria-label="Delete item"
                   >
                       <Trash2 size={20} />
                   </button>
@@ -988,8 +989,8 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                   >
                       Delete
                   </button>
-                  {variant === 'overlay' && <div className="hidden sm:flex absolute top-4 right-4 z-10"><button onClick={handleClosePanel} className="p-2 bg-gray-200 hover:bg-gray-300 rounded-full text-gray-600"><X size={18} /></button></div>}
-                  {variant === 'sidebar' && <button onClick={handleClosePanel} className="absolute top-4 right-4 p-2 bg-gray-100 hover:bg-gray-200 rounded-full text-gray-500"><X size={16} /></button>}
+                  {variant === 'overlay' && <div className="hidden sm:flex absolute top-4 right-4 z-10"><button onClick={handleClosePanel} className="p-2 bg-gray-200 hover:bg-gray-300 rounded-full text-gray-600" aria-label="Close details"><X size={18} /></button></div>}
+                  {variant === 'sidebar' && <button onClick={handleClosePanel} className="absolute top-4 right-4 p-2 bg-gray-100 hover:bg-gray-200 rounded-full text-gray-500" aria-label="Close details"><X size={16} /></button>}
              </div>
              
              <textarea 

--- a/components/GlobalTooltipLayer.tsx
+++ b/components/GlobalTooltipLayer.tsx
@@ -1,0 +1,236 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+
+type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+interface TooltipPosition {
+  x: number;
+  y: number;
+  placement: TooltipPlacement;
+}
+
+const SHOW_DELAY_MS = 550;
+const OFFSET_PX = 10;
+const VIEWPORT_MARGIN_PX = 8;
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(value, max));
+
+const getTooltipTarget = (target: EventTarget | null): HTMLButtonElement | null => {
+  if (!(target instanceof Element)) return null;
+  const button = target.closest(
+    'button:not([data-no-global-tooltip="true"])[aria-label], button:not([data-no-global-tooltip="true"])[title]'
+  );
+  if (!button || !(button instanceof HTMLButtonElement)) return null;
+  if (button.disabled) return null;
+  return button;
+};
+
+const getPlacement = (
+  rect: DOMRect,
+  tooltipWidth: number,
+  tooltipHeight: number,
+  viewportWidth: number,
+  viewportHeight: number
+): TooltipPlacement => {
+  const topSpace = rect.top - VIEWPORT_MARGIN_PX;
+  const bottomSpace = viewportHeight - rect.bottom - VIEWPORT_MARGIN_PX;
+  const leftSpace = rect.left - VIEWPORT_MARGIN_PX;
+  const rightSpace = viewportWidth - rect.right - VIEWPORT_MARGIN_PX;
+
+  const fitsTop = topSpace >= tooltipHeight + OFFSET_PX;
+  const fitsBottom = bottomSpace >= tooltipHeight + OFFSET_PX;
+  const fitsRight = rightSpace >= tooltipWidth + OFFSET_PX;
+  const fitsLeft = leftSpace >= tooltipWidth + OFFSET_PX;
+
+  if (fitsTop) return 'top';
+  if (fitsBottom) return 'bottom';
+  if (fitsRight) return 'right';
+  if (fitsLeft) return 'left';
+
+  if (bottomSpace >= topSpace) return 'bottom';
+  return 'top';
+};
+
+const computeTooltipPosition = (
+  rect: DOMRect,
+  tooltipWidth: number,
+  tooltipHeight: number,
+  viewportWidth: number,
+  viewportHeight: number
+): TooltipPosition => {
+  const placement = getPlacement(rect, tooltipWidth, tooltipHeight, viewportWidth, viewportHeight);
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+
+  if (placement === 'top') {
+    return {
+      placement,
+      x: clamp(centerX - tooltipWidth / 2, VIEWPORT_MARGIN_PX, viewportWidth - tooltipWidth - VIEWPORT_MARGIN_PX),
+      y: Math.max(VIEWPORT_MARGIN_PX, rect.top - tooltipHeight - OFFSET_PX),
+    };
+  }
+
+  if (placement === 'bottom') {
+    return {
+      placement,
+      x: clamp(centerX - tooltipWidth / 2, VIEWPORT_MARGIN_PX, viewportWidth - tooltipWidth - VIEWPORT_MARGIN_PX),
+      y: Math.min(viewportHeight - tooltipHeight - VIEWPORT_MARGIN_PX, rect.bottom + OFFSET_PX),
+    };
+  }
+
+  if (placement === 'left') {
+    return {
+      placement,
+      x: Math.max(VIEWPORT_MARGIN_PX, rect.left - tooltipWidth - OFFSET_PX),
+      y: clamp(centerY - tooltipHeight / 2, VIEWPORT_MARGIN_PX, viewportHeight - tooltipHeight - VIEWPORT_MARGIN_PX),
+    };
+  }
+
+  return {
+    placement: 'right',
+    x: Math.min(viewportWidth - tooltipWidth - VIEWPORT_MARGIN_PX, rect.right + OFFSET_PX),
+    y: clamp(centerY - tooltipHeight / 2, VIEWPORT_MARGIN_PX, viewportHeight - tooltipHeight - VIEWPORT_MARGIN_PX),
+  };
+};
+
+export const GlobalTooltipLayer: React.FC = () => {
+  const [label, setLabel] = React.useState<string | null>(null);
+  const [position, setPosition] = React.useState<TooltipPosition | null>(null);
+  const [isVisible, setIsVisible] = React.useState(false);
+  const tooltipRef = React.useRef<HTMLDivElement | null>(null);
+  const activeButtonRef = React.useRef<HTMLButtonElement | null>(null);
+  const showTimerRef = React.useRef<number | null>(null);
+
+  const clearTimers = React.useCallback(() => {
+    if (showTimerRef.current !== null) {
+      window.clearTimeout(showTimerRef.current);
+      showTimerRef.current = null;
+    }
+  }, []);
+
+  const hideTooltip = React.useCallback(() => {
+    clearTimers();
+    activeButtonRef.current = null;
+    setIsVisible(false);
+    setLabel(null);
+    setPosition(null);
+  }, [clearTimers]);
+
+  const updatePosition = React.useCallback(() => {
+    const activeButton = activeButtonRef.current;
+    const tooltipEl = tooltipRef.current;
+    if (!activeButton || !tooltipEl) return;
+
+    const rect = activeButton.getBoundingClientRect();
+    const tooltipWidth = tooltipEl.offsetWidth;
+    const tooltipHeight = tooltipEl.offsetHeight;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    const nextPosition = computeTooltipPosition(rect, tooltipWidth, tooltipHeight, viewportWidth, viewportHeight);
+    setPosition(nextPosition);
+  }, []);
+
+  const scheduleShow = React.useCallback((button: HTMLButtonElement, delayMs: number) => {
+    const nextLabel = (button.getAttribute('aria-label') || button.getAttribute('title') || '').trim();
+    if (!nextLabel) return;
+
+    clearTimers();
+    activeButtonRef.current = button;
+    setIsVisible(false);
+    setLabel(null);
+    setPosition(null);
+    showTimerRef.current = window.setTimeout(() => {
+      setLabel(nextLabel);
+    }, delayMs);
+  }, [clearTimers]);
+
+  React.useLayoutEffect(() => {
+    if (!label) return;
+    updatePosition();
+    setIsVisible(true);
+  }, [label, updatePosition]);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const onMouseOver = (event: MouseEvent) => {
+      const targetButton = getTooltipTarget(event.target);
+      if (!targetButton) return;
+      // Ignore nested pointerover events while hovering the same button.
+      if (activeButtonRef.current === targetButton) return;
+      scheduleShow(targetButton, SHOW_DELAY_MS);
+    };
+
+    const onMouseOut = (event: MouseEvent) => {
+      const activeButton = activeButtonRef.current;
+      if (!activeButton) return;
+      const relatedTarget = event.relatedTarget;
+      if (relatedTarget instanceof Node && activeButton.contains(relatedTarget)) return;
+      hideTooltip();
+    };
+
+    const onFocusIn = (event: FocusEvent) => {
+      const targetButton = getTooltipTarget(event.target);
+      if (!targetButton) return;
+      scheduleShow(targetButton, 350);
+    };
+
+    const onFocusOut = () => {
+      hideTooltip();
+    };
+
+    const onScrollOrResize = () => {
+      if (!activeButtonRef.current) return;
+      if (!label) return;
+      updatePosition();
+    };
+
+    const onMouseDown = () => {
+      hideTooltip();
+    };
+
+    window.addEventListener('mouseover', onMouseOver, true);
+    window.addEventListener('mouseout', onMouseOut, true);
+    window.addEventListener('focusin', onFocusIn, true);
+    window.addEventListener('focusout', onFocusOut, true);
+    window.addEventListener('mousedown', onMouseDown, true);
+    window.addEventListener('scroll', onScrollOrResize, true);
+    window.addEventListener('resize', onScrollOrResize);
+
+    return () => {
+      window.removeEventListener('mouseover', onMouseOver, true);
+      window.removeEventListener('mouseout', onMouseOut, true);
+      window.removeEventListener('focusin', onFocusIn, true);
+      window.removeEventListener('focusout', onFocusOut, true);
+      window.removeEventListener('mousedown', onMouseDown, true);
+      window.removeEventListener('scroll', onScrollOrResize, true);
+      window.removeEventListener('resize', onScrollOrResize);
+      clearTimers();
+    };
+  }, [clearTimers, hideTooltip, label, scheduleShow, updatePosition]);
+
+  if (typeof document === 'undefined' || !label) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      ref={tooltipRef}
+      className="pointer-events-none fixed rounded-md bg-gray-900 px-2 py-1 text-[10px] font-semibold text-white shadow-xl"
+      style={{
+        left: position?.x ?? 0,
+        top: position?.y ?? 0,
+        opacity: isVisible ? 1 : 0,
+        transform: isVisible ? 'translateY(0)' : 'translateY(2px)',
+        transition: 'opacity 120ms ease, transform 120ms ease',
+        zIndex: 2147483600,
+      }}
+      role="tooltip"
+      aria-hidden={!isVisible}
+    >
+      {label}
+    </div>,
+    document.body
+  );
+};

--- a/components/ItineraryMap.tsx
+++ b/components/ItineraryMap.tsx
@@ -971,8 +971,14 @@ export const ItineraryMap: React.FC<ItineraryMapProps> = ({
                 <div className="flex flex-col gap-2 pointer-events-auto">
                     {showLayoutControls && onLayoutChange && (
                         <>
-                            <button onClick={() => onLayoutChange('vertical')} className={`p-2 rounded-lg shadow-md border transition-colors ${layoutMode === 'vertical' ? 'bg-accent-600 text-white border-accent-700' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`}><Rows size={18} /></button>
-                            <button onClick={() => onLayoutChange('horizontal')} className={`p-2 rounded-lg shadow-md border transition-colors ${layoutMode === 'horizontal' ? 'bg-accent-600 text-white border-accent-700' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`}><Columns size={18} /></button>
+                            <button
+                                onClick={() => onLayoutChange('vertical')}
+                                className={`p-2 rounded-lg shadow-md border transition-colors ${layoutMode === 'vertical' ? 'bg-accent-600 text-white border-accent-700' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`} aria-label="Vertical layout"
+                            ><Rows size={18} /></button>
+                            <button
+                                onClick={() => onLayoutChange('horizontal')}
+                                className={`p-2 rounded-lg shadow-md border transition-colors ${layoutMode === 'horizontal' ? 'bg-accent-600 text-white border-accent-700' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`} aria-label="Horizontal layout"
+                            ><Columns size={18} /></button>
                         </>
                     )}
 
@@ -987,12 +993,18 @@ export const ItineraryMap: React.FC<ItineraryMapProps> = ({
                         </button>
                     )}
                     
-                    <button onClick={handleFit} className="p-2 rounded-lg shadow-md border bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50 transition-colors flex items-center justify-center" title="Fit to Itinerary"><Focus size={18} /></button>
+                    <button
+                        onClick={handleFit}
+                        className="p-2 rounded-lg shadow-md border bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50 transition-colors flex items-center justify-center" aria-label="Fit to itinerary"
+                    ><Focus size={18} /></button>
                     
                     {/* Style Switcher */}
                     {onStyleChange && (
                       <div className="relative">
-                          <button onClick={() => setIsStyleMenuOpen(!isStyleMenuOpen)} className={`p-2 rounded-lg shadow-md border transition-colors flex items-center justify-center ${isStyleMenuOpen ? 'bg-accent-50 border-accent-300 text-accent-600' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`} title="Map Style"><Layers size={18} /></button>
+                          <button
+                              onClick={() => setIsStyleMenuOpen(!isStyleMenuOpen)}
+                              className={`p-2 rounded-lg shadow-md border transition-colors flex items-center justify-center ${isStyleMenuOpen ? 'bg-accent-50 border-accent-300 text-accent-600' : 'bg-white border-gray-200 text-gray-600 hover:text-accent-600 hover:bg-gray-50'}`} aria-label="Map style"
+                          ><Layers size={18} /></button>
                           {isStyleMenuOpen && (
                               <div className="absolute top-0 right-full mr-2 bg-white rounded-lg shadow-xl border border-gray-100 w-36 overflow-hidden flex flex-col z-20">
                                   <button onClick={() => { onStyleChange('minimal'); setIsStyleMenuOpen(false); }} className={`px-3 py-2 text-xs font-medium text-left hover:bg-gray-50 ${activeStyle === 'minimal' ? 'text-accent-600 bg-accent-50' : 'text-gray-700'}`}>Minimal</button>

--- a/components/MarkdownEditor.tsx
+++ b/components/MarkdownEditor.tsx
@@ -520,30 +520,30 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             )}
 
             <div className="px-2 py-1.5 bg-white border-b border-gray-100 flex items-center gap-1 overflow-x-auto">
-                <button type="button" onClick={() => handleHeading(1)} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" title="Heading 1">
+                <button type="button" onClick={() => handleHeading(1)} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" aria-label="Heading 1">
                     <Heading1 size={14} />
                 </button>
-                <button type="button" onClick={() => handleHeading(2)} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" title="Heading 2">
+                <button type="button" onClick={() => handleHeading(2)} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" aria-label="Heading 2">
                     <Heading2 size={14} />
                 </button>
-                <button type="button" onClick={() => handleHeading(3)} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" title="Heading 3">
+                <button type="button" onClick={() => handleHeading(3)} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" aria-label="Heading 3">
                     <Heading3 size={14} />
                 </button>
                 <div className="w-px h-5 bg-gray-200 mx-0.5" />
-                <button type="button" onClick={() => runCommand('bold')} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" title="Bold">
+                <button type="button" onClick={() => runCommand('bold')} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" aria-label="Bold">
                     <Bold size={14} />
                 </button>
-                <button type="button" onClick={() => runCommand('italic')} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" title="Italic">
+                <button type="button" onClick={() => runCommand('italic')} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" aria-label="Italic">
                     <Italic size={14} />
                 </button>
                 <div className="w-px h-5 bg-gray-200 mx-0.5" />
-                <button type="button" onClick={() => runCommand('insertUnorderedList')} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" title="Bullet list">
+                <button type="button" onClick={() => runCommand('insertUnorderedList')} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" aria-label="Bullet list">
                     <List size={14} />
                 </button>
-                <button type="button" onClick={handleChecklist} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" title="Checklist">
+                <button type="button" onClick={handleChecklist} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" aria-label="Checklist">
                     <CheckSquare size={14} />
                 </button>
-                <button type="button" onClick={handleLink} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" title="Link">
+                <button type="button" onClick={handleLink} className="p-1.5 rounded hover:bg-gray-100 text-gray-600" aria-label="Link">
                     <Link2 size={14} />
                 </button>
             </div>

--- a/components/SelectedCitiesPanel.tsx
+++ b/components/SelectedCitiesPanel.tsx
@@ -50,7 +50,7 @@ export const SelectedCitiesPanel: React.FC<SelectedCitiesPanelProps> = ({
                 <button
                     onClick={onClose}
                     className="absolute top-4 right-4 p-2 bg-gray-100 hover:bg-gray-200 rounded-full text-gray-500"
-                    title="Close selection"
+                    aria-label="Close selection"
                 >
                     <X size={16} />
                 </button>
@@ -112,7 +112,7 @@ export const SelectedCitiesPanel: React.FC<SelectedCitiesPanelProps> = ({
                                     onClick={() => moveCity(index, index - 1)}
                                     disabled={index === 0 || !canEdit}
                                     className={`p-1.5 rounded-md border border-gray-200 text-gray-500 ${canEdit ? 'hover:bg-gray-50' : 'opacity-50 cursor-not-allowed'} disabled:opacity-40 disabled:cursor-not-allowed`}
-                                    title="Move up"
+                                    aria-label="Move up"
                                 >
                                     <ArrowUp size={13} />
                                 </button>
@@ -120,7 +120,7 @@ export const SelectedCitiesPanel: React.FC<SelectedCitiesPanelProps> = ({
                                     onClick={() => moveCity(index, index + 1)}
                                     disabled={index === orderedCityIds.length - 1 || !canEdit}
                                     className={`p-1.5 rounded-md border border-gray-200 text-gray-500 ${canEdit ? 'hover:bg-gray-50' : 'opacity-50 cursor-not-allowed'} disabled:opacity-40 disabled:cursor-not-allowed`}
-                                    title="Move down"
+                                    aria-label="Move down"
                                 >
                                     <ArrowDown size={13} />
                                 </button>

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -48,7 +48,10 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                 {/* Header */}
                 <div className="p-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
                     <h3 className="text-lg font-bold text-gray-900">Settings</h3>
-                    <button onClick={onClose} className="p-1 hover:bg-gray-200 rounded-full text-gray-500">
+                    <button
+                        onClick={onClose}
+                        className="p-1 hover:bg-gray-200 rounded-full text-gray-500" aria-label="Close"
+                    >
                         <X size={20} />
                     </button>
                 </div>

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -648,7 +648,7 @@ export const Timeline: React.FC<TimelineProps> = ({
                             onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddCity(); }}
                             disabled={!canEdit}
                             className={`opacity-0 group-hover/cities:opacity-100 transition-opacity bg-accent-100 text-accent-700 rounded-full p-1 ${canEdit ? 'hover:bg-accent-200' : 'opacity-50 cursor-not-allowed'}`}
-                            title="Add City to end"
+                            aria-label="Add city to end"
                         >
                              <Plus size={14} />
                         </button>
@@ -716,7 +716,7 @@ export const Timeline: React.FC<TimelineProps> = ({
                             onClick={(e) => { e.stopPropagation(); if (!canEdit) return; handleAddTravel(); }}
                             disabled={!canEdit}
                             className={`opacity-0 group-hover/travel:opacity-100 transition-opacity bg-stone-100 text-stone-700 rounded-full p-1 ${canEdit ? 'hover:bg-stone-200' : 'opacity-50 cursor-not-allowed'}`}
-                            title="Add Travel"
+                            aria-label="Add travel"
                         >
                              <Plus size={14} />
                         </button>
@@ -809,7 +809,7 @@ export const Timeline: React.FC<TimelineProps> = ({
                                      onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddActivity(dateHeaders.days[i]?.dayOffset ?? i); }}
                                      disabled={!canEdit}
                                      className={`w-full h-full mx-1 rounded-md border border-dashed border-transparent flex items-center justify-center text-gray-300 transition-all ${canEdit ? 'hover:border-gray-300 hover:bg-gray-50 hover:text-accent-500' : 'cursor-not-allowed opacity-40'}`}
-                                     title={`Add activity for ${dateHeaders.days[i]?.date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) || `day ${i + 1}`}`}
+                                     aria-label={`Add activity for ${dateHeaders.days[i]?.date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) || `day ${i + 1}`}`}
                                  >
                                      <Plus size={16} />
                                  </button>

--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -1753,11 +1753,11 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                         {!isMobile && (
                             <>
                                 <div className="bg-gray-100 p-1 rounded-lg flex items-center mr-1">
-                                    <button onClick={() => setViewMode('print')} className="p-1.5 text-gray-500 hover:text-gray-700 rounded-md" title="Print View">
+                                    <button onClick={() => setViewMode('print')} className="p-1.5 text-gray-500 hover:text-gray-700 rounded-md" aria-label="Print view">
                                         <Printer size={18} />
                                     </button>
                                 </div>
-                                <button onClick={() => setIsHistoryOpen(true)} className="p-2 bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-lg" title="History">
+                                <button onClick={() => setIsHistoryOpen(true)} className="p-2 bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-lg" aria-label="History">
                                     <History size={18} />
                                 </button>
                             </>
@@ -1766,9 +1766,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                             <button
                                 type="button"
                                 onClick={() => setIsTripInfoOpen(true)}
-                                className="p-2 bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-lg"
-                                title="Trip information"
-                                aria-label="Trip information"
+                                className="p-2 bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-lg" aria-label="Trip information"
                             >
                                 <Info size={18} />
                             </button>
@@ -1776,7 +1774,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                         <button
                             onClick={onOpenManager}
                             className={`flex items-center gap-2 rounded-lg font-medium ${isMobile ? 'p-2 bg-gray-100 text-gray-700 hover:bg-gray-200' : 'p-2 text-gray-500 hover:bg-gray-100 text-sm'}`}
-                            title="My Plans"
+                            aria-label="My plans"
                         >
                             <Route size={18} />
                             <span className={isMobile ? 'sr-only' : 'hidden lg:inline'}>My Plans</span>
@@ -1880,11 +1878,11 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                     )}
                                     <div className="absolute top-3 right-3 z-40 flex gap-2">
                                         <div className="flex flex-row gap-1 bg-white/90 backdrop-blur border border-gray-200 rounded-lg shadow-sm p-1">
-                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z - 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600"><ZoomOut size={16} /></button>
-                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z + 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600"><ZoomIn size={16} /></button>
+                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z - 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600" aria-label="Zoom out timeline"><ZoomOut size={16} /></button>
+                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z + 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600" aria-label="Zoom in timeline"><ZoomIn size={16} /></button>
                                         </div>
                                         <div className="flex flex-row gap-1 bg-white/90 backdrop-blur border border-gray-200 rounded-lg shadow-sm p-1 h-fit my-auto">
-                                            <button onClick={() => setTimelineView(v => v === 'horizontal' ? 'vertical' : 'horizontal')} className="p-1.5 hover:bg-gray-100 rounded text-gray-600">
+                                            <button onClick={() => setTimelineView(v => v === 'horizontal' ? 'vertical' : 'horizontal')} className="p-1.5 hover:bg-gray-100 rounded text-gray-600" aria-label="Toggle timeline view">
                                                 {timelineView === 'horizontal' ? <List size={16} /> : <Calendar size={16} />}
                                             </button>
                                         </div>
@@ -1958,11 +1956,11 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                                     )}
                                                     <div className="absolute top-4 right-4 z-40 flex gap-2">
                                                         <div className="flex flex-row gap-1 bg-white/90 backdrop-blur border border-gray-200 rounded-lg shadow-sm p-1">
-                                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z - 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600"><ZoomOut size={16} /></button>
-                                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z + 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600"><ZoomIn size={16} /></button>
+                                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z - 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600" aria-label="Zoom out timeline"><ZoomOut size={16} /></button>
+                                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z + 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600" aria-label="Zoom in timeline"><ZoomIn size={16} /></button>
                                                         </div>
                                                         <div className="flex flex-row gap-1 bg-white/90 backdrop-blur border border-gray-200 rounded-lg shadow-sm p-1 h-fit my-auto">
-                                                            <button onClick={() => setTimelineView(v => v === 'horizontal' ? 'vertical' : 'horizontal')} className="p-1.5 hover:bg-gray-100 rounded text-gray-600">
+                                                            <button onClick={() => setTimelineView(v => v === 'horizontal' ? 'vertical' : 'horizontal')} className="p-1.5 hover:bg-gray-100 rounded text-gray-600" aria-label="Toggle timeline view">
                                                                 {timelineView === 'horizontal' ? <List size={16} /> : <Calendar size={16} />}
                                                             </button>
                                                         </div>
@@ -2091,11 +2089,11 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                                     )}
                                                     <div className="absolute top-4 right-4 z-40 flex gap-2">
                                                         <div className="flex flex-row gap-1 bg-white/90 backdrop-blur border border-gray-200 rounded-lg shadow-sm p-1">
-                                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z - 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600"><ZoomOut size={16} /></button>
-                                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z + 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600"><ZoomIn size={16} /></button>
+                                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z - 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600" aria-label="Zoom out timeline"><ZoomOut size={16} /></button>
+                                                            <button onClick={() => setZoomLevel(z => clampZoomLevel(z + 0.1))} className="p-1.5 hover:bg-gray-100 rounded text-gray-600" aria-label="Zoom in timeline"><ZoomIn size={16} /></button>
                                                         </div>
                                                         <div className="flex flex-row gap-1 bg-white/90 backdrop-blur border border-gray-200 rounded-lg shadow-sm p-1 h-fit my-auto">
-                                                            <button onClick={() => setTimelineView(v => v === 'horizontal' ? 'vertical' : 'horizontal')} className="p-1.5 hover:bg-gray-100 rounded text-gray-600">
+                                                            <button onClick={() => setTimelineView(v => v === 'horizontal' ? 'vertical' : 'horizontal')} className="p-1.5 hover:bg-gray-100 rounded text-gray-600" aria-label="Toggle timeline view">
                                                                 {timelineView === 'horizontal' ? <List size={16} /> : <Calendar size={16} />}
                                                             </button>
                                                         </div>
@@ -2201,9 +2199,7 @@ export const TripView: React.FC<TripViewProps> = ({ trip, onUpdateTrip, onCommit
                                                     <button
                                                         type="button"
                                                         onClick={handleStartTitleEdit}
-                                                        className="p-2 rounded-lg text-gray-500 hover:bg-gray-100"
-                                                        title="Edit title"
-                                                        aria-label="Edit title"
+                                                        className="p-2 rounded-lg text-gray-500 hover:bg-gray-100" aria-label="Edit title"
                                                     >
                                                         <Pencil size={16} />
                                                     </button>

--- a/components/VerticalTimeline.tsx
+++ b/components/VerticalTimeline.tsx
@@ -695,7 +695,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
                              onClick={(e) => { e.stopPropagation(); if (!canEdit) return; onAddActivity(visualStartOffset); }}
                              disabled={!canEdit}
                              className={`opacity-0 group-hover/activities:opacity-100 transition-opacity ml-1 bg-accent-50 text-accent-600 rounded-full p-0.5 ${canEdit ? 'hover:bg-accent-100' : 'opacity-50 cursor-not-allowed'}`}
-                             title="Add Activity"
+                             aria-label="Add activity"
                          >
                              <Plus size={12} />
                          </button>

--- a/content/updates/2026-02-08-my-plans-sort-modes.md
+++ b/content/updates/2026-02-08-my-plans-sort-modes.md
@@ -1,0 +1,19 @@
+---
+id: rel-2026-02-08-my-plans-sort-modes
+version: v0.16.0
+title: "My Plans: smarter sorting + clearer tooltips"
+date: 2026-02-08
+published_at: 2026-02-08T18:30:00Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "✨ My Plans now helps you find trips faster with smart sorting, better context, and cleaner tooltips so you can jump straight into anticipation mode."
+---
+
+## Changes
+- [x] [New feature] 🧭 Added a My Plans sort toggle so you can switch between **Last updated** and **Travel timeline** in one click.
+- [x] [Improved] 🚀 Trips are now easier to find: recent edits float to the top, upcoming trips are prioritized, and past trips are grouped separately.
+- [x] [Improved] ✈️ Added lightweight “when” context (like *tomorrow* / *in 5 weeks*) to keep planning clear and boost happy anticipation.
+- [x] [Improved] 💬 Icon-only controls now have consistent delayed hover tooltips, including the My Plans sort toggle and color picker.
+- [x] [Fixed] 🛠️ Tooltip behavior is now stable across refreshes, with smarter positioning and stronger layering to avoid clipping.
+- [ ] [Internal] Refined shared sorting + tooltip infrastructure for consistent behavior across planner surfaces.


### PR DESCRIPTION
## Summary
- add My Plans sort mode toggle for **Last updated** and **Travel timeline**
- prioritize upcoming trips with past trips separated in travel timeline mode
- add subtle relative timing labels for upcoming trips and low-emphasis updated info in trip tooltip
- add consistent icon-only button tooltips across planner surfaces
- replace fragile CSS-only tooltip approach with a global tooltip layer that supports delay, collision-aware placement, and strong stacking
- restore mobile navigation-related updates from main after merge conflict resolution
- add concise release notes entry for this release

## Validation
- npm run build
- npm run updates:validate
