### PR TITLE
Add dedicated OG image cards for non-trip pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This repo includes `netlify.toml` for build settings + SPA redirects.
 
 ## Dynamic Open Graph (Netlify Edge)
 
+- Non-trip pages (home, features, updates, blog, legal pages, etc.) use a dedicated `/api/og/site` image generator with page title + subline, TravelFlow branding, and an accent-gradient hero.
 - Shared links (`/s/:token`) use Netlify Edge Functions to inject route-specific Open Graph and Twitter meta tags into the HTML response.
 - OG images are generated at `/api/og/trip` with `og_edge` (Netlify-compatible `@vercel/og`), including:
   - trip title
@@ -123,6 +124,9 @@ This repo includes `netlify.toml` for build settings + SPA redirects.
 
 Example direct image URL:
 `http://localhost:8888/api/og/trip?s=demo-share&title=Japan%20Spring%20Loop&mapStyle=clean&routeMode=realistic&showStops=1&showCities=1`
+
+Example non-trip image URL:
+`http://localhost:8888/api/og/site?title=Features&description=See%20everything%20TravelFlow%20can%20do&path=/features`
 
 ## Create The GitHub Repo (CLI)
 

--- a/content/updates/2026-02-08-shared-trip-dynamic-og-previews.md
+++ b/content/updates/2026-02-08-shared-trip-dynamic-og-previews.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-08-shared-trip-dynamic-og-previews
-version: v0.25.0
+version: v0.19.0
 title: "Shared trip dynamic Open Graph previews"
 date: 2026-02-08
 published_at: 2026-02-08T23:59:00Z
@@ -12,7 +12,7 @@ summary: "Sharing is caring: shared trip links now open with a polished social p
 
 ## Changes
 - [x] [New feature] 🚀 Sharing is caring: shared trip links now generate a beautiful social preview with your trip title, timing, distance, and route map.
+- [x] [New feature] 🚀 Every non-trip page now gets a polished share card too, with a clean headline, TravelFlow branding, and a glowing flight-themed hero.
 - [x] [Improved] ✨ Shared preview maps now follow your saved trip view settings (map style, route style, and stop labels) so links match what people see in the trip.
-- [x] [Fixed] 🐛 Unsupported OG query parameters are now safely ignored so shared-trip pages keep loading instead of breaking.
 - [ ] [Internal] 🧰 Added edge metadata/image plumbing and caching hooks for OG rendering reliability.
 - [ ] [Internal] 🧰 Added the OG playground workflow for faster layout tuning during development.

--- a/index.html
+++ b/index.html
@@ -14,13 +14,13 @@
     <meta property="og:site_name" content="TravelFlow" />
     <meta property="og:title" content="TravelFlow" />
     <meta property="og:description" content="Plan and share travel routes with timeline and map previews in TravelFlow." />
-    <meta property="og:image" content="/api/og/trip" />
+    <meta property="og:image" content="/api/og/site" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="TravelFlow" />
     <meta name="twitter:description" content="Plan and share travel routes with timeline and map previews in TravelFlow." />
-    <meta name="twitter:image" content="/api/og/trip" />
+    <meta name="twitter:image" content="/api/og/site" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@700;800&display=swap" rel="stylesheet">

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,12 +21,60 @@
   function = "trip-og-playground"
 
 [[edge_functions]]
+  path = "/api/og/site"
+  function = "site-og-image"
+
+[[edge_functions]]
   path = "/s/*"
   function = "trip-og-meta"
 
 [[edge_functions]]
   path = "/trip/*"
   function = "trip-og-meta"
+
+[[edge_functions]]
+  path = "/"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/create-trip"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/updates"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/blog"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/admin/*"
+  function = "site-og-meta"
 
 [[redirects]]
   from = "/*"

--- a/netlify/edge-functions/site-og-image.tsx
+++ b/netlify/edge-functions/site-og-image.tsx
@@ -1,0 +1,291 @@
+import React from "https://esm.sh/react@18.3.1";
+import { ImageResponse } from "https://deno.land/x/og_edge/mod.ts";
+
+const IMAGE_WIDTH = 1200;
+const IMAGE_HEIGHT = 630;
+const SITE_NAME = "TravelFlow";
+const HEADLINE_FONT_FAMILY = "Space Grotesk";
+const HEADLINE_FONT_URL =
+  "https://unpkg.com/@fontsource/space-grotesk@5.0.18/files/space-grotesk-latin-700-normal.woff";
+
+const DEFAULT_TITLE = "TravelFlow";
+const DEFAULT_SUBLINE = "Plan and share travel routes with timeline and map previews.";
+
+// Keep OG visuals aligned with global app accent tokens.
+const ACCENT_200 = "#c7d2fe";
+const ACCENT_500 = "#6366f1";
+const ACCENT_600 = "#4f46e5";
+const ACCENT_700 = "#4338ca";
+
+let headingFontPromise: Promise<ArrayBuffer | null> | null = null;
+
+const loadHeadingFont = async (): Promise<ArrayBuffer | null> => {
+  if (!headingFontPromise) {
+    headingFontPromise = (async () => {
+      try {
+        const response = await fetch(HEADLINE_FONT_URL);
+        if (!response.ok) return null;
+        return await response.arrayBuffer();
+      } catch {
+        return null;
+      }
+    })();
+  }
+  return headingFontPromise;
+};
+
+const sanitizeText = (value: string | null, max: number): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}...` : trimmed;
+};
+
+const normalizePath = (value: string | null): string => {
+  if (!value) return "/";
+  const trimmed = value.trim();
+  if (!trimmed) return "/";
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    try {
+      const url = new URL(trimmed);
+      return url.pathname + (url.search || "");
+    } catch {
+      return "/";
+    }
+  }
+  if (trimmed.startsWith("/")) return trimmed;
+  return `/${trimmed}`;
+};
+
+const truncateText = (value: string, max: number): string =>
+  value.length > max ? `${value.slice(0, max - 1)}...` : value;
+
+const svgToDataUri = (svg: string): string => `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+
+const PLANE_GLYPH_PATH =
+  "M17.8 19.2 16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.3.6-.7.5-1.2z";
+
+const FOOTER_PLANE_ICON_URI = svgToDataUri(
+  `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='#ffffff' d='${PLANE_GLYPH_PATH}'/><path fill='none' stroke='rgba(255,255,255,0.42)' stroke-width='0.75' d='${PLANE_GLYPH_PATH}'/></svg>`,
+);
+
+const HERO_PLANE_ICON_URI = svgToDataUri(
+  `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 160 160'><defs><filter id='g' x='-50%' y='-50%' width='200%' height='200%'><feDropShadow dx='0' dy='8' stdDeviation='8' flood-color='rgba(255,255,255,0.32)'/></filter></defs><circle cx='80' cy='80' r='62' fill='rgba(255,255,255,0.16)'/><circle cx='80' cy='80' r='48' fill='rgba(255,255,255,0.1)'/><g filter='url(#g)' transform='translate(56 44) scale(2.35) rotate(-8 12 12)'><path fill='#ffffff' d='${PLANE_GLYPH_PATH}'/></g></svg>`,
+);
+
+export default async (request: Request): Promise<Response> => {
+  try {
+    const url = new URL(request.url);
+    const headingFontData = await loadHeadingFont();
+
+    const title = sanitizeText(url.searchParams.get("title"), 110) || DEFAULT_TITLE;
+    const subline = sanitizeText(url.searchParams.get("description"), 160) || DEFAULT_SUBLINE;
+    const pagePath = normalizePath(url.searchParams.get("path"));
+    const displayUrl = truncateText(`${url.host}${pagePath}`, 62);
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            padding: 28,
+            color: "#0f172a",
+            background:
+              "linear-gradient(165deg, #f8fafc 0%, #eef2ff 62%, #e0e7ff 100%)",
+          }}
+        >
+          <div
+            style={{
+              width: "61%",
+              height: "100%",
+              display: "flex",
+              flexDirection: "column",
+              borderRadius: 28,
+              padding: "38px 42px 34px",
+              background: "rgba(255, 255, 255, 0.88)",
+              border: "1px solid rgba(148, 163, 184, 0.28)",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                alignSelf: "flex-start",
+                padding: "10px 18px",
+                borderRadius: 9999,
+                background: ACCENT_600,
+                color: "#ffffff",
+                fontSize: 20,
+                fontWeight: 700,
+                fontFamily: `"${HEADLINE_FONT_FAMILY}", "Avenir Next", "Segoe UI", sans-serif`,
+              }}
+            >
+              <img src={FOOTER_PLANE_ICON_URI} alt="" style={{ width: 16, height: 16, display: "flex" }} />
+              TravelFlow
+            </div>
+
+            <div
+              style={{
+                display: "flex",
+                marginTop: 18,
+                fontSize: 70,
+                lineHeight: 1.02,
+                letterSpacing: -1.8,
+                fontWeight: 800,
+                textWrap: "pretty",
+                color: "#0f172a",
+                fontFamily: `"${HEADLINE_FONT_FAMILY}", "Avenir Next", "Segoe UI", sans-serif`,
+              }}
+            >
+              {title}
+            </div>
+
+            <div
+              style={{
+                display: "flex",
+                marginTop: 16,
+                fontSize: 30,
+                lineHeight: 1.25,
+                color: "#334155",
+                textWrap: "pretty",
+              }}
+            >
+              {subline}
+            </div>
+
+            <div
+              style={{
+                marginTop: "auto",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                borderTop: "1px solid rgba(148, 163, 184, 0.36)",
+                paddingTop: 20,
+                gap: 20,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                }}
+              >
+                <div
+                  style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: 10,
+                    background: ACCENT_600,
+                    color: "#ffffff",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <img src={FOOTER_PLANE_ICON_URI} alt="TravelFlow icon" style={{ width: 18, height: 18 }} />
+                </div>
+                <div
+                  style={{
+                    fontSize: 28,
+                    fontWeight: 700,
+                    color: "#111827",
+                    display: "flex",
+                    fontFamily: `"${HEADLINE_FONT_FAMILY}", "Avenir Next", "Segoe UI", sans-serif`,
+                  }}
+                >
+                  {SITE_NAME}
+                </div>
+              </div>
+
+              <div
+                style={{
+                  fontSize: 20,
+                  color: "#475569",
+                  display: "flex",
+                  minWidth: 0,
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {displayUrl}
+              </div>
+            </div>
+          </div>
+
+          <div
+            style={{
+              width: "39%",
+              height: "100%",
+              paddingLeft: 20,
+              display: "flex",
+            }}
+          >
+            <div
+              style={{
+                width: "100%",
+                height: "100%",
+                display: "flex",
+                borderRadius: 28,
+                overflow: "hidden",
+                border: "1px solid rgba(148, 163, 184, 0.35)",
+                background:
+                  `radial-gradient(circle at 36% 26%, ${ACCENT_200} 0%, rgba(199,210,254,0.2) 22%, transparent 54%), radial-gradient(circle at 72% 76%, rgba(99,102,241,0.36), transparent 56%), linear-gradient(145deg, ${ACCENT_500} 0%, ${ACCENT_600} 48%, ${ACCENT_700} 100%)`,
+                alignItems: "center",
+                justifyContent: "center",
+                boxShadow: "inset 0 0 120px rgba(15,23,42,0.18)",
+              }}
+            >
+              <img
+                src={HERO_PLANE_ICON_URI}
+                alt="Plane icon"
+                style={{
+                  width: 236,
+                  height: 236,
+                  opacity: 0.98,
+                  display: "flex",
+                  filter: "drop-shadow(0 16px 32px rgba(15,23,42,0.24))",
+                  transform: "translate(4px, -2px)",
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      ),
+      {
+        width: IMAGE_WIDTH,
+        height: IMAGE_HEIGHT,
+        headers: {
+          "Cache-Control": "public, max-age=0, s-maxage=43200, stale-while-revalidate=604800",
+        },
+        ...(headingFontData
+          ? {
+              fonts: [
+                {
+                  name: HEADLINE_FONT_FAMILY,
+                  data: headingFontData,
+                  style: "normal",
+                  weight: 700,
+                },
+              ],
+            }
+          : {}),
+      },
+    );
+  } catch (error) {
+    const message = error instanceof Error
+      ? `${error.name}: ${error.message}\n${error.stack || ""}`
+      : String(error);
+    return new Response(`Site OG render error\n${message}`, {
+      status: 500,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    });
+  }
+};

--- a/netlify/edge-functions/site-og-meta.ts
+++ b/netlify/edge-functions/site-og-meta.ts
@@ -1,0 +1,187 @@
+import { escapeHtml } from "../edge-lib/trip-og-data.ts";
+
+const SITE_NAME = "TravelFlow";
+const DEFAULT_DESCRIPTION = "Plan and share travel routes with timeline and map previews in TravelFlow.";
+const SITE_CACHE_CONTROL = "public, max-age=0, s-maxage=900, stale-while-revalidate=86400";
+
+interface Metadata {
+  pageTitle: string;
+  description: string;
+  canonicalUrl: string;
+  ogImageUrl: string;
+  robots: string;
+}
+
+interface PageDefinition {
+  title: string;
+  description: string;
+  robots?: string;
+}
+
+const PAGE_META: Record<string, PageDefinition> = {
+  "/": {
+    title: "TravelFlow",
+    description: "Plan smarter trips with timeline + map routing and share them beautifully.",
+  },
+  "/create-trip": {
+    title: "Create Trip",
+    description: "Build your itinerary with flexible stops, routes, and timeline planning.",
+  },
+  "/features": {
+    title: "Features",
+    description: "See everything TravelFlow offers for planning and sharing better adventures.",
+  },
+  "/updates": {
+    title: "Product Updates",
+    description: "Catch the latest TravelFlow improvements and recently shipped features.",
+  },
+  "/blog": {
+    title: "TravelFlow Blog",
+    description: "Guides, trip-planning ideas, and practical workflow tips from the TravelFlow team.",
+  },
+  "/login": {
+    title: "Login",
+    description: "Sign in and continue planning your next trip in TravelFlow.",
+  },
+  "/imprint": {
+    title: "Imprint",
+    description: "Legal and company information for TravelFlow.",
+  },
+  "/privacy": {
+    title: "Privacy Policy",
+    description: "Learn how TravelFlow handles personal data and privacy protection.",
+  },
+  "/terms": {
+    title: "Terms of Service",
+    description: "Read the terms that govern the use of TravelFlow.",
+  },
+  "/cookies": {
+    title: "Cookie Policy",
+    description: "Understand how TravelFlow uses cookies and similar technologies.",
+  },
+};
+
+const pathToTitle = (pathname: string): string => {
+  if (pathname === "/") return SITE_NAME;
+  const leaf = pathname.split("/").filter(Boolean).slice(-1)[0] || "Page";
+  const words = leaf
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+  return words.length > 0 ? words.join(" ") : "Page";
+};
+
+const getPageDefinition = (pathname: string): PageDefinition => {
+  if (PAGE_META[pathname]) return PAGE_META[pathname];
+  if (pathname.startsWith("/admin")) {
+    return {
+      title: "Admin Dashboard",
+      description: "Internal TravelFlow admin workspace.",
+      robots: "noindex,nofollow,max-image-preview:large",
+    };
+  }
+  return {
+    title: pathToTitle(pathname),
+    description: DEFAULT_DESCRIPTION,
+  };
+};
+
+const stripSeoTags = (html: string): string => {
+  const patterns = [
+    /<title>[\s\S]*?<\/title>/gi,
+    /<meta[^>]+name=["']description["'][^>]*>/gi,
+    /<meta[^>]+name=["']robots["'][^>]*>/gi,
+    /<meta[^>]+property=["']og:[^"']+["'][^>]*>/gi,
+    /<meta[^>]+name=["']twitter:[^"']+["'][^>]*>/gi,
+    /<link[^>]+rel=["']canonical["'][^>]*>/gi,
+  ];
+  return patterns.reduce((acc, regex) => acc.replace(regex, ""), html);
+};
+
+const buildMetaTags = (meta: Metadata): string => {
+  const title = escapeHtml(meta.pageTitle);
+  const description = escapeHtml(meta.description);
+  const canonicalUrl = escapeHtml(meta.canonicalUrl);
+  const ogImageUrl = escapeHtml(meta.ogImageUrl);
+  const robots = escapeHtml(meta.robots);
+
+  return [
+    `<title>${title}</title>`,
+    `<meta name="description" content="${description}" />`,
+    `<link rel="canonical" href="${canonicalUrl}" />`,
+    `<meta name="robots" content="${robots}" />`,
+    `<meta property="og:type" content="website" />`,
+    `<meta property="og:site_name" content="${SITE_NAME}" />`,
+    `<meta property="og:title" content="${title}" />`,
+    `<meta property="og:description" content="${description}" />`,
+    `<meta property="og:url" content="${canonicalUrl}" />`,
+    `<meta property="og:image" content="${ogImageUrl}" />`,
+    `<meta property="og:image:width" content="1200" />`,
+    `<meta property="og:image:height" content="630" />`,
+    `<meta property="og:image:alt" content="${title}" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${title}" />`,
+    `<meta name="twitter:description" content="${description}" />`,
+    `<meta name="twitter:image" content="${ogImageUrl}" />`,
+  ].join("\n");
+};
+
+const injectMetaTags = (html: string, meta: Metadata): string => {
+  if (!/<head[^>]*>/i.test(html) || !/<\/head>/i.test(html)) {
+    return html;
+  }
+  const cleaned = stripSeoTags(html);
+  return cleaned.replace(/<\/head>/i, `${buildMetaTags(meta)}\n</head>`);
+};
+
+const buildMetadata = (url: URL): Metadata => {
+  const page = getPageDefinition(url.pathname);
+  const title = page.title === SITE_NAME ? SITE_NAME : `${page.title} | ${SITE_NAME}`;
+  const canonicalUrl = new URL(url.pathname + url.search, url.origin).toString();
+  const ogImage = new URL("/api/og/site", url.origin);
+  ogImage.searchParams.set("title", page.title);
+  ogImage.searchParams.set("description", page.description);
+  ogImage.searchParams.set("path", url.pathname + url.search);
+
+  return {
+    pageTitle: title,
+    description: page.description,
+    canonicalUrl,
+    ogImageUrl: ogImage.toString(),
+    robots: page.robots || "index,follow,max-image-preview:large",
+  };
+};
+
+export default async (request: Request, context: { next: () => Promise<Response> }): Promise<Response> => {
+  const url = new URL(request.url);
+  const baseResponse = await context.next();
+  const fallbackResponse = baseResponse.clone();
+  const contentType = baseResponse.headers.get("content-type") || "";
+
+  if (url.pathname.startsWith("/api/og/") || url.pathname.startsWith("/s/") || url.pathname.startsWith("/trip/")) {
+    return baseResponse;
+  }
+
+  if (!contentType.includes("text/html")) {
+    return baseResponse;
+  }
+
+  try {
+    const metadata = buildMetadata(url);
+    const html = await baseResponse.text();
+    const rewrittenHtml = injectMetaTags(html, metadata);
+    const headers = new Headers(baseResponse.headers);
+    headers.set("content-type", "text/html; charset=utf-8");
+    headers.set("cache-control", SITE_CACHE_CONTROL);
+    headers.delete("content-length");
+    headers.delete("etag");
+
+    return new Response(rewrittenHtml, {
+      status: baseResponse.status,
+      statusText: baseResponse.statusText,
+      headers,
+    });
+  } catch {
+    return fallbackResponse;
+  }
+};


### PR DESCRIPTION
## Summary
- add a dedicated `/api/og/site` edge image endpoint for non-trip pages
- inject non-trip Open Graph metadata via a new edge function, while preserving trip OG behavior
- polish the non-trip OG visual with better plane icons and brand-consistent accent styling
- update the release note to `v0.19.0` and keep only the most relevant user-facing lines

## Validation
- npm run updates:validate
- npm run build
- npx netlify build --offline
