### PR TITLE
fix: align release version and unblock umami events

### DIFF
--- a/content/updates/2026-02-08-umami-consent-gated-analytics.md
+++ b/content/updates/2026-02-08-umami-consent-gated-analytics.md
@@ -13,5 +13,6 @@ summary: "Added GDPR-aligned Umami tracking with consent mapping, marketing even
 ## Changes
 - [x] [New feature] 🚀 Added Umami analytics integration that only activates after optional consent and tracks SPA pageviews.
 - [x] [Improved] ✨ Added baseline marketing events for navigation, hero CTA clicks, consent acceptance, and trip creation.
+- [x] [Fixed] 🐛 Removed forced DNT tracking suppression in Umami script config so opted-in analytics events can be sent.
 - [x] [Improved] ✨ Added Umami + Supabase environment variable scaffolding and updated Netlify secret-scan config.
 - [x] [Improved] ✨ Updated the Cookie Policy page with explicit consent-banner mapping and implementation notes.

--- a/services/analyticsService.ts
+++ b/services/analyticsService.ts
@@ -73,7 +73,6 @@ const ensureUmamiScript = async (): Promise<boolean> => {
     script.dataset.loaded = 'false';
     script.setAttribute('data-website-id', UMAMI_WEBSITE_ID);
     script.setAttribute('data-auto-track', 'false');
-    script.setAttribute('data-do-not-track', 'true');
 
     scriptLoadPromise = createScriptLoadPromise(script);
     document.head.appendChild(script);


### PR DESCRIPTION
## Summary
- correct the Umami analytics release note version from `v0.25.0` to `v0.20.0`
- remove forced `data-do-not-track="true"` from Umami script injection so opted-in users can send analytics events
- update the same release note entry to include this tracking fix

## Validation
- npm run build
