### PR TITLE
Homepage redesign, blog system, and inspirations overhaul

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,9 @@ When a user-facing feature, fix, or behavior change is completed, you must updat
 - Finalize that single release note shortly before PR creation so it reflects the final shipped scope.
 - Add user-facing items as `- [x] [Type] ...`.
 - Add internal/non-marketing items as `- [ ] [Internal] ...`.
-- Start every change line with the required emoji prefix described in `docs/UPDATE_FORMAT.md`.
+- Each change line must start with a **content-matching emoji** — pick an emoji that hints at what the specific change is about. Do NOT use a fixed emoji per type (no 🚀 for every feature, no ✨ for every improvement).
+- Only mark items `[x]` (visible) when they describe a **clear user benefit**. Hide technical details, dependency changes, refactors, and implementation specifics as `[ ]`.
+- Write visible items from the user's perspective — focus on what changed for them, not how it was built.
 - Keep the most important user-facing items first, and fixes after primary highlights.
 - Bump the release `version` whenever publishing a new release entry.
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -13,7 +13,9 @@ Rules:
 - Finalize the release note shortly before opening the PR, when the complete shipped scope is known.
 - Keep user-facing highlights visible with `[x]`.
 - Keep internal/infrastructure items hidden from marketing with `[ ]`.
-- Start every change line with the required emoji style from `docs/UPDATE_FORMAT.md`.
+- Each change line must start with a **content-matching emoji** — pick one that hints at the specific change. Do NOT use a fixed emoji per type (no 🚀 for every feature, no ✨ for every improvement).
+- Only mark items `[x]` when they describe a clear **user benefit**. Technical details, dependency swaps, refactors, and implementation specifics should be `[ ]`.
+- Write visible items from the user's perspective — what changed for them, not how it was built.
 - Put major highlights first; place fixes later.
 - Always bump to a new release `version` for every new published release.
 - Never reuse or downgrade a published release version.

--- a/components/CreateTripForm.tsx
+++ b/components/CreateTripForm.tsx
@@ -1,27 +1,27 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
-    AlertTriangle,
-    AlignLeft,
+    Warning as AlertTriangle,
+    TextAlignLeft as AlignLeft,
     Check,
-    ChevronDown,
-    ChevronLeft,
-    ChevronRight,
+    CaretDown as ChevronDown,
+    CaretLeft as ChevronLeft,
+    CaretRight as ChevronRight,
     Clock,
     Compass,
-    Dice6,
+    DiceSix as Dice6,
     FilePlus,
     Folder,
     Info,
-    Loader2,
+    SpinnerGap as Loader2,
     MapPin,
-    Plane,
+    AirplaneTilt as Plane,
     Plus,
-    Search,
-    Settings,
-    Sparkles,
-    Wand2,
+    MagnifyingGlass as Search,
+    GearSix as Settings,
+    Sparkle as Sparkles,
+    MagicWand as Wand2,
     X,
-} from 'lucide-react';
+} from '@phosphor-icons/react';
 import { Link, NavLink } from 'react-router-dom';
 import { createPortal } from 'react-dom';
 import { CountrySelect } from './CountrySelect';
@@ -90,21 +90,21 @@ const TAB_ITEMS: Array<{ id: FormMode; title: string; subtitle: string; beta?: b
         id: 'classic',
         title: 'Classic',
         subtitle: 'Stable and fully supported',
-        icon: <Sparkles size={16} />,
+        icon: <Sparkles size={16} weight="duotone" />,
     },
     {
         id: 'wizard',
         title: 'Wizard',
         subtitle: 'Guided multistep flow',
         beta: true,
-        icon: <Wand2 size={16} />,
+        icon: <Wand2 size={16} weight="duotone" />,
     },
     {
         id: 'surprise',
         title: 'Surprise Me',
         subtitle: 'Timeframe-first discovery',
         beta: true,
-        icon: <Dice6 size={16} />,
+        icon: <Dice6 size={16} weight="duotone" />,
     },
 ];
 
@@ -795,19 +795,20 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
     return (
         <div className="w-full min-h-screen flex flex-col relative isolate overflow-hidden bg-slate-50">
             <HeroWebGLBackground className="z-0" />
-            <div className="pointer-events-none absolute inset-0 z-[1] bg-white/35" />
-            <div className="pointer-events-none absolute -left-24 top-20 z-[1] h-72 w-72 rounded-full bg-accent-200/30 blur-3xl" />
-            <div className="pointer-events-none absolute -right-10 bottom-20 z-[1] h-80 w-80 rounded-full bg-accent-300/30 blur-3xl" />
+            <div className="pointer-events-none absolute inset-0 z-[1] bg-white/25" />
+            <div className="pointer-events-none absolute -left-24 top-20 z-[1] h-72 w-72 rounded-full bg-accent-200/30 blur-[80px]" />
+            <div className="pointer-events-none absolute -right-10 bottom-20 z-[1] h-80 w-80 rounded-full bg-accent-300/30 blur-[80px]" />
 
             <header className="absolute top-0 left-0 w-full p-4 sm:p-6 flex justify-between items-center z-20 gap-3">
                 <Link to="/" className="flex items-center gap-2">
                     <div className="w-8 h-8 bg-accent-600 rounded-lg flex items-center justify-center shadow-accent-200 shadow-lg transform rotate-3">
-                        <Plane className="text-white transform -rotate-3" size={18} fill="currentColor" />
+                        <Plane className="text-white transform -rotate-3" size={18} weight="duotone" />
                     </div>
                     <span className="font-bold text-xl tracking-tight text-gray-900 hidden sm:block">Travel<span className="text-accent-600">Flow</span></span>
                 </Link>
                 <nav className="hidden md:flex items-center gap-5 text-sm bg-white/75 backdrop-blur px-4 py-2 rounded-full border border-slate-200">
                     <NavLink to="/features" className={createNavLinkClass}>Features</NavLink>
+                    <NavLink to="/inspirations" className={createNavLinkClass}>Inspirations</NavLink>
                     <NavLink to="/updates" className={createNavLinkClass}>News & Updates</NavLink>
                     <NavLink to="/blog" className={createNavLinkClass}>Blog</NavLink>
                 </nav>
@@ -834,8 +835,8 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                     <p className="text-gray-500">Choose a flow and generate your itinerary in seconds.</p>
                 </div>
 
-                <div className={`bg-white p-5 sm:p-6 rounded-3xl shadow-xl border border-gray-100 w-full ${formWidthClass} relative overflow-visible transition-all`}>
-                    <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-accent-500 via-accent-600 to-accent-700" />
+                <div className={`bg-white p-5 sm:p-6 rounded-3xl shadow-2xl ring-1 ring-slate-900/5 border border-gray-100 w-full ${formWidthClass} relative overflow-visible transition-all`}>
+                    <div className="absolute top-0 left-0 w-full h-1.5 rounded-t-3xl bg-gradient-to-r from-accent-500 via-accent-600 to-accent-700 shadow-[0_1px_8px_rgb(var(--tf-accent-rgb)/0.3)]" />
 
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-2 mb-4">
                         {TAB_ITEMS.map((tab) => {
@@ -1022,9 +1023,9 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                     <button
                                         type="submit"
                                         disabled={isGenerating || selectedCountries.length === 0}
-                                        className="flex-1 py-3 bg-gradient-to-r from-accent-600 to-accent-700 hover:from-accent-700 hover:to-accent-800 text-white font-bold rounded-xl shadow-lg hover:shadow-xl transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                                        className="flex-1 py-3 bg-gradient-to-r from-accent-600 to-accent-700 hover:from-accent-700 hover:to-accent-800 text-white font-bold rounded-xl shadow-lg hover:shadow-xl hover:shadow-accent-glow-sm transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                                     >
-                                        {isGenerating ? <Loader2 className="animate-spin h-5 w-5" /> : <Sparkles className="fill-white/20 h-5 w-5" />}
+                                        {isGenerating ? <Loader2 className="animate-spin" size={20} weight="bold" /> : <Sparkles size={20} weight="duotone" />}
                                         <span>Auto-Generate</span>
                                     </button>
                                     <button
@@ -1354,7 +1355,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                         disabled={!wizardCanGenerate || isGenerating}
                                         className="px-4 py-2 rounded-xl bg-gradient-to-r from-accent-600 to-accent-700 text-white text-sm font-semibold hover:from-accent-700 hover:to-accent-800 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1"
                                     >
-                                        {isGenerating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+                                        {isGenerating ? <Loader2 size={14} className="animate-spin" weight="bold" /> : <Sparkles size={14} weight="duotone" />}
                                         Create Trip from Wizard
                                     </button>
                                 )}
@@ -1498,7 +1499,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                     disabled={!selectedSurpriseOption || isGenerating}
                                     className="px-4 py-2.5 rounded-xl bg-gradient-to-r from-accent-600 to-accent-700 text-white text-sm font-semibold hover:from-accent-700 hover:to-accent-800 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-2"
                                 >
-                                    {isGenerating ? <Loader2 size={15} className="animate-spin" /> : <Sparkles size={15} />}
+                                    {isGenerating ? <Loader2 size={15} className="animate-spin" weight="bold" /> : <Sparkles size={15} weight="duotone" />}
                                     Generate Surprise Trip
                                 </button>
                             </div>

--- a/components/marketing/CtaBanner.tsx
+++ b/components/marketing/CtaBanner.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { trackEvent } from '../../services/analyticsService';
+
+export const CtaBanner: React.FC = () => {
+    return (
+        <section className="pb-16 md:pb-24 animate-scroll-scale-in">
+            <div className="relative rounded-3xl bg-gradient-to-br from-accent-600 to-accent-800 px-8 py-14 text-center md:px-16 md:py-20 overflow-hidden">
+                {/* Decorative glow orbs */}
+                <div className="pointer-events-none absolute -top-20 -right-20 h-60 w-60 rounded-full bg-white/10 blur-[60px]" />
+                <div className="pointer-events-none absolute -bottom-16 -left-16 h-48 w-48 rounded-full bg-accent-400/20 blur-[50px]" />
+
+                <h2 className="relative text-3xl font-black tracking-tight text-white md:text-5xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>
+                    Ready to plan your next trip?
+                </h2>
+                <p className="relative mx-auto mt-4 max-w-xl text-base text-accent-100 md:text-lg">
+                    Join thousands of travelers who build smarter itineraries in minutes. No account needed to start.
+                </p>
+                <Link
+                    to="/create-trip"
+                    onClick={() =>
+                        trackEvent('marketing_hero_cta_clicked', {
+                            cta_name: 'cta_banner',
+                            page: 'home',
+                        })
+                    }
+                    className="relative mt-8 inline-block rounded-2xl bg-white px-8 py-3.5 text-base font-bold text-accent-700 shadow-lg transition-all hover:shadow-xl hover:bg-accent-50 hover:scale-[1.03] active:scale-[0.98]"
+                >
+                    Start Planning — It&apos;s Free
+                </Link>
+            </div>
+        </section>
+    );
+};

--- a/components/marketing/EarlyAccessBanner.tsx
+++ b/components/marketing/EarlyAccessBanner.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { X, Flask } from '@phosphor-icons/react';
+
+const STORAGE_KEY = 'tf_early_access_dismissed';
+
+export const EarlyAccessBanner: React.FC = () => {
+    const [dismissed, setDismissed] = useState(() => {
+        try {
+            return localStorage.getItem(STORAGE_KEY) === '1';
+        } catch {
+            return false;
+        }
+    });
+
+    if (dismissed) return null;
+
+    const handleDismiss = () => {
+        setDismissed(true);
+        try {
+            localStorage.setItem(STORAGE_KEY, '1');
+        } catch {
+            // ignore
+        }
+    };
+
+    return (
+        <div className="border-b border-amber-200/60 bg-gradient-to-r from-amber-50 via-amber-50/80 to-orange-50">
+            <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-5 py-2.5 md:px-8">
+                <Flask size={16} weight="duotone" className="shrink-0 text-amber-600" />
+                <p className="flex-1 text-xs leading-relaxed text-amber-900 sm:text-sm">
+                    <span className="font-bold">Early preview</span>
+                    <span className="mx-1.5 text-amber-400">—</span>
+                    TravelFlow is under active development. Features may change, and some things might not work perfectly yet.
+                </p>
+                <button
+                    type="button"
+                    onClick={handleDismiss}
+                    className="shrink-0 rounded-lg p-1.5 text-amber-500 transition-colors hover:bg-amber-100 hover:text-amber-700"
+                    aria-label="Dismiss banner"
+                >
+                    <X size={14} weight="bold" />
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/components/marketing/ExampleTripCard.tsx
+++ b/components/marketing/ExampleTripCard.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Clock, MapPin } from '@phosphor-icons/react';
+import type { ExampleTripCard as ExampleTripCardType } from '../../data/exampleTripCards';
+
+interface ExampleTripCardProps {
+    card: ExampleTripCardType;
+}
+
+export const ExampleTripCard: React.FC<ExampleTripCardProps> = ({ card }) => {
+    return (
+        <article className="rounded-2xl border border-slate-200 bg-white shadow-sm transition-all hover:shadow-lg cursor-pointer">
+            {/* Map placeholder */}
+            <div className={`relative h-36 rounded-t-2xl ${card.mapColor} overflow-hidden`}>
+                {/* Decorative route dots */}
+                <div className={`absolute left-[20%] top-[30%] h-2.5 w-2.5 rounded-full ${card.mapAccent}`} />
+                <div className={`absolute left-[40%] top-[55%] h-2 w-2 rounded-full ${card.mapAccent} opacity-70`} />
+                <div className={`absolute left-[60%] top-[35%] h-3 w-3 rounded-full ${card.mapAccent}`} />
+                <div className={`absolute left-[75%] top-[60%] h-2 w-2 rounded-full ${card.mapAccent} opacity-60`} />
+                {/* Decorative route line */}
+                <svg className="absolute inset-0 h-full w-full" viewBox="0 0 340 144" fill="none" preserveAspectRatio="none">
+                    <path
+                        d="M68 43 L136 79 L204 50 L255 86"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeDasharray="4 4"
+                        className="text-slate-400/40"
+                    />
+                </svg>
+            </div>
+
+            {/* Body */}
+            <div className="p-4">
+                <h3 className="text-base font-bold text-slate-900">{card.title}</h3>
+
+                {/* Country flags + names */}
+                <div className="mt-1.5 flex items-center gap-1.5 text-sm text-slate-600">
+                    {card.countries.map((c) => (
+                        <span key={c.name} className="inline-flex items-center gap-1">
+                            <span>{c.flag}</span>
+                            <span>{c.name}</span>
+                        </span>
+                    ))}
+                </div>
+
+                {/* Stats row */}
+                <div className="mt-3 flex items-center gap-4 text-xs text-slate-500">
+                    <span className="inline-flex items-center gap-1">
+                        <Clock size={14} weight="duotone" className="text-accent-500" />
+                        {card.durationDays} days
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                        <MapPin size={14} weight="duotone" className="text-accent-500" />
+                        {card.cityCount} cities
+                    </span>
+                </div>
+
+                {/* Tags */}
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                    {card.tags.map((tag) => (
+                        <span
+                            key={tag}
+                            className="rounded-full bg-slate-100 px-2.5 py-0.5 text-[11px] font-medium text-slate-600"
+                        >
+                            {tag}
+                        </span>
+                    ))}
+                </div>
+            </div>
+
+            {/* Footer */}
+            <div className="border-t border-slate-100 px-4 py-3 flex items-center gap-2">
+                <div className={`h-6 w-6 rounded-full ${card.avatarColor} flex items-center justify-center text-white text-[10px] font-bold`}>
+                    {card.username[0].toUpperCase()}
+                </div>
+                <span className="text-xs text-slate-500">{card.username}</span>
+            </div>
+        </article>
+    );
+};

--- a/components/marketing/ExampleTripsCarousel.tsx
+++ b/components/marketing/ExampleTripsCarousel.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { exampleTripCards } from '../../data/exampleTripCards';
+import { ExampleTripCard } from './ExampleTripCard';
+
+// Deterministic rotation per card index — alternating slight tilts
+const ROTATIONS = [-2, 1.5, -1, 2, -1.5, 1, -2.5, 1.8];
+
+export const ExampleTripsCarousel: React.FC = () => {
+    // Duplicate the cards array so the marquee loops seamlessly
+    const doubledCards = [...exampleTripCards, ...exampleTripCards];
+
+    return (
+        <section id="examples" className="py-16 md:py-24">
+            {/* Heading stays within parent max-w via normal flow */}
+            <div className="animate-scroll-blur-in">
+                <h2 className="text-3xl font-black tracking-tight text-slate-900 md:text-4xl">
+                    Trips built with TravelFlow
+                </h2>
+                <p className="mt-3 max-w-xl text-base text-slate-600">
+                    Browse real itineraries created by our community — from week-long island getaways to cross-country road trips.
+                </p>
+            </div>
+
+            {/* Full-width breakout container */}
+            <div className="relative mt-12 -mx-5 md:-mx-8 lg:mx-[calc(-50vw+50%)] overflow-hidden">
+                {/* Fade edges */}
+                <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-16 bg-gradient-to-r from-slate-50 to-transparent md:w-24" />
+                <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-16 bg-gradient-to-l from-slate-50 to-transparent md:w-24" />
+
+                {/* Marquee track — pauses on hover */}
+                <div className="group py-6">
+                    <div
+                        className="flex w-max gap-6 animate-marquee group-hover:[animation-play-state:paused]"
+                        style={{ '--marquee-duration': '60s' } as React.CSSProperties}
+                    >
+                        {doubledCards.map((card, index) => {
+                            const rotation = ROTATIONS[index % ROTATIONS.length];
+                            return (
+                                <a
+                                    key={`${card.id}-${index}`}
+                                    href="#"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="block w-[300px] md:w-[340px] flex-shrink-0 transition-transform duration-300 hover:!rotate-0 hover:scale-105"
+                                    style={{ transform: `rotate(${rotation}deg)` }}
+                                >
+                                    <ExampleTripCard card={card} />
+                                </a>
+                            );
+                        })}
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+};

--- a/components/marketing/FeatureShowcase.tsx
+++ b/components/marketing/FeatureShowcase.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+    Sparkle,
+    MapTrifold,
+    SlidersHorizontal,
+    UsersThree,
+    ShareNetwork,
+    LinkSimple,
+} from '@phosphor-icons/react';
+import type { Icon } from '@phosphor-icons/react';
+
+interface Feature {
+    icon: Icon;
+    title: string;
+    description: string;
+}
+
+const features: Feature[] = [
+    {
+        icon: Sparkle,
+        title: 'AI Trip Creation',
+        description:
+            'Describe your dream trip in plain language. Our AI builds a complete, day-by-day itinerary with smart city sequencing, activity suggestions, and estimated travel times — all in under 30 seconds.',
+    },
+    {
+        icon: MapTrifold,
+        title: 'Interactive Map Styles',
+        description:
+            'Switch between satellite, terrain, and minimalist map layers. See your route come alive with animated path lines, city markers, and dynamic zoom that follows your scroll position.',
+    },
+    {
+        icon: SlidersHorizontal,
+        title: 'Easy Itinerary Adjustments',
+        description:
+            'Drag cities to reorder, stretch durations, or add spontaneous stops — all on a visual timeline. Changes cascade automatically so dates and connections always stay in sync.',
+    },
+    {
+        icon: UsersThree,
+        title: 'Community Examples',
+        description:
+            'Browse itineraries from fellow travelers to discover hidden gems and proven routes. Fork any community trip as a starting point for your own adventure.',
+    },
+    {
+        icon: ShareNetwork,
+        title: 'Share & Collaborate',
+        description:
+            'Generate a shareable link in one click. Co-travelers see the full map, timeline, and activity list — no account required. Updates sync instantly for everyone viewing the trip.',
+    },
+    {
+        icon: LinkSimple,
+        title: 'Activity Booking Links',
+        description:
+            'Each AI-suggested activity links directly to booking platforms. Reserve tours, restaurants, and transport without leaving your itinerary — keeping everything in one place.',
+    },
+];
+
+export const FeatureShowcase: React.FC = () => {
+    return (
+        <section className="py-16 md:py-24">
+            <div className="animate-scroll-blur-in">
+                <h2 className="text-3xl font-black tracking-tight text-slate-900 md:text-4xl">
+                    Everything you need to plan, share, and go
+                </h2>
+                <p className="mt-3 max-w-xl text-base text-slate-600">
+                    From first spark of inspiration to boarding pass — TravelFlow handles the entire journey.
+                </p>
+            </div>
+
+            <div className="mt-14 space-y-16 md:space-y-20">
+                {features.map((feature, index) => {
+                    const IconComponent = feature.icon;
+                    const isEven = index % 2 === 0;
+                    // Alternate slide direction to match the visual side
+                    const slideClass = isEven
+                        ? 'animate-scroll-slide-left'
+                        : 'animate-scroll-slide-right';
+
+                    return (
+                        <div
+                            key={feature.title}
+                            className={`${slideClass} flex flex-col gap-6 md:flex-row md:items-center md:gap-12 ${
+                                !isEven ? 'md:flex-row-reverse' : ''
+                            }`}
+                        >
+                            {/* Icon container */}
+                            <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl bg-accent-50 text-accent-600 shadow-sm ring-1 ring-accent-100 transition-transform duration-300 hover:scale-110 hover:shadow-md md:h-24 md:w-24">
+                                <IconComponent size={40} weight="duotone" />
+                            </div>
+
+                            {/* Text */}
+                            <div className="max-w-lg">
+                                <h3 className="text-xl font-bold text-slate-900">
+                                    {feature.title}
+                                </h3>
+                                <p className="mt-2 text-base leading-relaxed text-slate-600">
+                                    {feature.description}
+                                </p>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </section>
+    );
+};

--- a/components/marketing/HeroSection.tsx
+++ b/components/marketing/HeroSection.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Sparkle, ShareNetwork, LinkSimple, RocketLaunch } from '@phosphor-icons/react';
+import { trackEvent } from '../../services/analyticsService';
+
+/** Animated hand-drawn zigzag underline SVG */
+const ZigzagUnderline: React.FC = () => (
+    <svg
+        className="pointer-events-none absolute -bottom-[10%] left-0 w-full"
+        viewBox="0 0 200 14"
+        fill="none"
+        preserveAspectRatio="none"
+        style={{ height: '0.18em' }}
+    >
+        <path
+            d="M 2 8 L 18 3 L 36 10 L 54 2 L 71 9 L 88 3 L 106 10 L 123 2 L 140 9 L 157 3 L 174 10 L 191 4 L 198 7"
+            stroke="var(--tf-accent-400)"
+            strokeWidth="3.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="hand-drawn-zigzag"
+            style={{ filter: 'url(#zigzag-roughen)' }}
+        />
+        <defs>
+            <filter id="zigzag-roughen" x="-5%" y="-20%" width="110%" height="140%">
+                <feTurbulence type="turbulence" baseFrequency="0.035" numOctaves="3" seed="7" result="noise" />
+                <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.8" xChannelSelector="R" yChannelSelector="G" />
+            </filter>
+        </defs>
+    </svg>
+);
+
+export const HeroSection: React.FC = () => {
+    const handleCtaClick = (ctaName: string) => {
+        trackEvent('marketing_hero_cta_clicked', {
+            cta_name: ctaName,
+            page: 'home',
+        });
+    };
+
+    return (
+        <section className="relative pt-8 pb-16 md:pt-16 md:pb-24">
+            {/* Decorative gradient blobs */}
+            <div className="pointer-events-none absolute -right-32 -top-20 h-[420px] w-[420px] rounded-full bg-accent-300/40 blur-[100px]" />
+            <div className="pointer-events-none absolute -bottom-32 -left-20 h-[380px] w-[380px] rounded-full bg-accent-200/50 blur-[100px]" />
+
+            <div className="relative max-w-3xl">
+                {/* Badge pill — stagger 0 */}
+                <div className="animate-hero-stagger" style={{ '--stagger': '0ms' } as React.CSSProperties}>
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700">
+                        <Sparkle size={14} weight="duotone" />
+                        AI-Powered Trip Planning
+                    </span>
+                </div>
+
+                {/* Heading — stagger 80ms */}
+                <div className="animate-hero-stagger" style={{ '--stagger': '80ms' } as React.CSSProperties}>
+                    <h1 className="mt-6 text-5xl font-black tracking-tight text-slate-900 md:text-7xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>
+                        Your next adventure, planned{' '}
+                        <span className="relative inline-block">
+                            in seconds
+                            <ZigzagUnderline />
+                        </span>
+                    </h1>
+                </div>
+
+                {/* Subheading — stagger 160ms */}
+                <div className="animate-hero-stagger" style={{ '--stagger': '160ms' } as React.CSSProperties}>
+                    <p className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-600 md:text-xl">
+                        Tell us where you want to go and when — our AI builds a complete, day-by-day itinerary with optimized routes, curated activities, and real booking links. Adjust everything on a visual timeline and map, then share with your travel crew in one click.
+                    </p>
+                </div>
+
+                {/* CTAs — stagger 240ms */}
+                <div className="mt-10 flex flex-wrap items-center gap-4 animate-hero-stagger" style={{ '--stagger': '240ms' } as React.CSSProperties}>
+                    <Link
+                        to="/create-trip"
+                        onClick={() => handleCtaClick('start_planning')}
+                        className="group relative rounded-2xl bg-accent-600 px-7 py-3.5 text-base font-bold text-white shadow-lg shadow-accent-200 transition-all hover:bg-accent-700 hover:shadow-xl hover:shadow-accent-300 hover:scale-[1.02] active:scale-[0.98]"
+                    >
+                        Start Planning
+                    </Link>
+                    <a
+                        href="#examples"
+                        onClick={() => handleCtaClick('see_examples')}
+                        className="rounded-2xl border border-slate-300 bg-white px-7 py-3.5 text-base font-bold text-slate-700 transition-all hover:border-slate-400 hover:text-slate-900 hover:shadow-sm hover:scale-[1.02] active:scale-[0.98]"
+                    >
+                        See Example Trips
+                    </a>
+                </div>
+
+                {/* Floating feature pills — stagger 360ms, with gentle float */}
+                <div className="mt-8 flex flex-wrap gap-2.5 animate-hero-stagger" style={{ '--stagger': '360ms' } as React.CSSProperties}>
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 shadow-sm animate-float" style={{ '--float-delay': '0ms' } as React.CSSProperties}>
+                        <RocketLaunch size={14} weight="duotone" className="text-accent-500" />
+                        AI-generated itineraries
+                    </span>
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 shadow-sm animate-float" style={{ '--float-delay': '600ms' } as React.CSSProperties}>
+                        <ShareNetwork size={14} weight="duotone" className="text-accent-500" />
+                        Share & collaborate
+                    </span>
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 shadow-sm animate-float" style={{ '--float-delay': '1200ms' } as React.CSSProperties}>
+                        <LinkSimple size={14} weight="duotone" className="text-accent-500" />
+                        Booking links
+                    </span>
+                </div>
+            </div>
+        </section>
+    );
+};

--- a/components/marketing/MarketingLayout.tsx
+++ b/components/marketing/MarketingLayout.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { Plane } from 'lucide-react';
+import { AirplaneTilt } from '@phosphor-icons/react';
 import { SiteFooter } from './SiteFooter';
+import { EarlyAccessBanner } from './EarlyAccessBanner';
 import { trackEvent } from '../../services/analyticsService';
 
 interface MarketingLayoutProps {
@@ -22,19 +23,20 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
     };
 
     return (
-        <div className="min-h-screen bg-slate-50 text-slate-900 flex flex-col">
+        <div className="min-h-screen scroll-smooth bg-slate-50 text-slate-900 flex flex-col">
             <div className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(14,165,233,0.18),_transparent_48%),radial-gradient(circle_at_80%_30%,_rgba(15,23,42,0.10),_transparent_35%)]" />
-            <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur">
-                <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-5 py-4 md:px-8">
+            <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur" style={{ viewTransitionName: 'site-header' }}>
+                <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-5 py-4 md:px-8">
                     <NavLink to="/" onClick={() => handleNavClick('brand')} className="flex items-center gap-2">
                         <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent-600 text-white shadow-lg shadow-accent-200">
-                            <Plane size={16} fill="currentColor" />
+                            <AirplaneTilt size={16} weight="duotone" />
                         </span>
                         <span className="text-lg font-extrabold tracking-tight">TravelFlow</span>
                     </NavLink>
 
                     <nav className="hidden items-center gap-6 text-sm md:flex">
                         <NavLink to="/features" onClick={() => handleNavClick('features')} className={navLinkClass}>Features</NavLink>
+                        <NavLink to="/inspirations" onClick={() => handleNavClick('inspirations')} className={navLinkClass}>Inspirations</NavLink>
                         <NavLink to="/updates" onClick={() => handleNavClick('updates')} className={navLinkClass}>News & Updates</NavLink>
                         <NavLink to="/blog" onClick={() => handleNavClick('blog')} className={navLinkClass}>Blog</NavLink>
                     </nav>
@@ -57,8 +59,9 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
                     </div>
                 </div>
             </header>
+            <EarlyAccessBanner />
 
-            <main className="mx-auto w-full max-w-6xl flex-1 px-5 pb-16 pt-10 md:px-8 md:pt-14">
+            <main className="mx-auto w-full max-w-7xl flex-1 px-5 pb-16 pt-10 md:px-8 md:pt-14">
                 {children}
             </main>
             <SiteFooter />

--- a/content/blog/best-time-visit-japan.md
+++ b/content/blog/best-time-visit-japan.md
@@ -1,0 +1,115 @@
+---
+slug: best-time-visit-japan
+title: "The Best Time to Visit Japan — A Month-by-Month Guide"
+date: 2026-02-03
+published_at: 2026-02-03T10:00:00Z
+author: TravelFlow Team
+tags: ["japan", "seasonal", "asia"]
+summary: "Japan transforms with every season. From cherry blossoms to powder snow, here's when to go depending on what you want to experience."
+cover_color: bg-rose-100
+reading_time_min: 7
+status: published
+---
+
+## Japan Is a Four-Season Destination
+
+Unlike tropical destinations where weather is broadly "hot" or "rainy," Japan offers dramatically different experiences depending on when you visit. Each season brings distinct landscapes, festivals, food, and energy. There's no single "best" time — only the best time for what you want to do.
+
+## Spring (March – May)
+
+### Cherry Blossom Season: Late March to Mid-April
+
+This is Japan's most iconic season. The sakura front moves north from Kyushu to Hokkaido over several weeks:
+
+- **Tokyo**: Late March to early April
+- **Kyoto**: Early to mid-April
+- **Osaka**: Late March to early April
+- **Hokkaido**: Early to mid-May
+
+Peak bloom lasts about one week per location. Parks fill with hanami (flower viewing) picnics, temples glow pink, and the entire country celebrates.
+
+### Practical Notes for Spring
+
+- Book 3-6 months ahead — accommodation sells out fast during cherry blossom season
+- Temperatures are mild (10-20°C) but bring layers for cool evenings
+- Golden Week (late April to early May) is a major holiday — domestic travel spikes, prices jump, and trains are packed. Avoid if possible.
+
+## Summer (June – August)
+
+### The Rainy Season: June to Mid-July
+
+Tsuyu (rainy season) brings humidity and regular rainfall across most of Japan. It's not constant rain — more like afternoon showers and overcast skies. Hydrangeas bloom beautifully during this period.
+
+### Festival Season: July and August
+
+Summer is matsuri (festival) season. Highlights include:
+
+- **Gion Matsuri** in Kyoto (July) — one of Japan's most famous festivals
+- **Tenjin Matsuri** in Osaka (July) — river processions and fireworks
+- **Nebuta Matsuri** in Aomori (August) — giant illuminated floats
+- **Awa Odori** in Tokushima (August) — mesmerizing street dancing
+
+Summer temperatures hit 30-35°C with high humidity. Pack light, breathable clothing and stay hydrated.
+
+### Escape the Heat
+
+Head to the Japanese Alps, Hokkaido, or the northern Tohoku region for cooler temperatures. Hokkaido's summer (20-25°C) is genuinely pleasant — lavender fields in Furano, seafood in Hakodate, and hiking in Daisetsuzan National Park.
+
+## Autumn (September – November)
+
+### Koyo: Autumn Foliage
+
+Japan's autumn colors rival New England's — and the cultural backdrop makes them even more spectacular. The koyo front moves south from Hokkaido:
+
+- **Hokkaido**: Late September to mid-October
+- **Tohoku**: Mid-October to early November
+- **Tokyo & Kyoto**: Mid-November to early December
+
+### Why Autumn Might Be the Best Season
+
+- Comfortable temperatures (15-25°C in October)
+- Lower crowds than cherry blossom season
+- Incredible food — matsutake mushrooms, sanma (Pacific saury), persimmons, and new rice
+- Stunning photography opportunities at temples surrounded by red and gold maples
+
+Nikko, Kyoto's Arashiyama, and the Koyasan temple stay are particularly spectacular in autumn.
+
+## Winter (December – February)
+
+### Powder Snow and Hot Springs
+
+Japan receives some of the deepest, lightest powder snow in the world. Hokkaido and the Japanese Alps are world-class ski destinations:
+
+- **Niseko** (Hokkaido) — international resort town with consistent powder
+- **Hakuba** (Nagano) — Olympic-quality slopes, closer to Tokyo
+- **Nozawa Onsen** — traditional village with skiing and hot springs
+
+### Winter Culture
+
+- **Illuminations**: Tokyo, Osaka, and Kobe light up with spectacular displays from November through February
+- **Onsen season**: Nothing beats a rotenburo (outdoor hot spring) with snow falling around you
+- **Sapporo Snow Festival** (early February) — massive ice sculptures and snow art
+
+### Winter Travel Tips
+
+- Temperatures: 0-10°C in Tokyo, well below zero in mountain regions
+- Trains run reliably even in heavy snow
+- Fewer tourists than spring and autumn — better prices and shorter queues
+
+## Quick Decision Guide
+
+| What you want | When to go |
+|---|---|
+| Cherry blossoms | Late March – mid-April |
+| Autumn foliage | Mid-November – early December |
+| Skiing / powder snow | January – February |
+| Festivals | July – August |
+| Fewest crowds | January, June, November |
+| Best weather | October – November |
+| Cheapest flights | January (after New Year), June |
+
+## Planning Your Japan Trip
+
+Whatever season you choose, two weeks is the sweet spot for a first visit. Tokyo, Kyoto, Osaka, and one wildcard destination (Hiroshima, Hakone, or Kanazawa) give you the greatest contrast.
+
+Use TravelFlow to map out your route with the right timing — the tool accounts for travel days between cities and helps you avoid wasting precious hours on logistics.

--- a/content/blog/budget-travel-europe.md
+++ b/content/blog/budget-travel-europe.md
@@ -1,0 +1,143 @@
+---
+slug: budget-travel-europe
+title: "Budget Travel Hacks for Europe"
+date: 2026-01-25
+published_at: 2026-01-25T10:00:00Z
+author: TravelFlow Team
+tags: ["europe", "budget", "tips"]
+summary: "Europe doesn't have to break the bank. Smart timing, local habits, and a few practical tricks can cut your costs in half."
+cover_color: bg-emerald-100
+reading_time_min: 7
+status: published
+---
+
+## Europe on a Budget Is Not What It Used to Be
+
+The old backpacker playbook — hostels, overnight buses, supermarket sandwiches — still works. But modern budget travel in Europe is more nuanced. You can travel affordably without sacrificing comfort if you know where to look.
+
+The biggest savings come from three areas: when you go, how you move, and where you eat.
+
+## Timing Is Everything
+
+### Shoulder Season (April–May, September–October)
+
+This is the sweet spot. Weather is good, prices are 30-40% lower than peak summer, and major attractions aren't rammed. Southern Europe (Spain, Italy, Greece, Portugal) is particularly pleasant in these months.
+
+### Off-Season Gems
+
+Some destinations are better off-season:
+
+- **Prague in November** — atmospheric, uncrowded, and Christmas markets start late month
+- **Lisbon in February** — mild winters (12-15°C), empty viewpoints, and local prices
+- **Scotland in September** — autumn colors, whisky festival season, and Highlands without midges
+
+### Avoid These Expensive Windows
+
+- Easter week in Southern Europe
+- Summer school holidays (mid-June to August)
+- Christmas and New Year everywhere
+- Any city during a major conference or event
+
+## Getting Around Cheaply
+
+### Trains
+
+- **Interrail/Eurail passes** save money on 4+ long journeys. Book early for seat reservations on popular routes
+- **Regional trains** are often unreserved and cheaper — combine them for medium distances
+- **Night trains** are making a comeback — you save a night's accommodation while traveling (Vienna → Rome, Zurich → Barcelona)
+
+### Budget Airlines
+
+- **Ryanair, easyJet, Wizz Air** — cheap if you follow their rules (carry-on only, online check-in, no extras)
+- Book directly on the airline website (aggregators sometimes have different baggage rules)
+- Tuesday and Wednesday flights are typically cheapest
+- Secondary airports are sometimes far from the city — factor in transfer costs
+
+### Buses
+
+- **FlixBus** covers most of Europe. Not glamorous, but cheap and reliable
+- Book 2-4 weeks ahead for the best prices
+- Overnight buses save accommodation costs on longer routes
+
+## Accommodation Strategies
+
+### Beyond Hostels
+
+Hostels are still great for solo travelers, but alternatives can be cheaper:
+
+- **Apartments** — split between 2-3 people, often cheaper per person than hostels with better facilities
+- **University accommodation** — available in summer months in many European cities
+- **House-sitting** — free accommodation in exchange for looking after pets or plants
+
+### Hostel Tips
+
+- Private rooms in hostels are often cheaper than budget hotels
+- Kitchens save you restaurant money — cook one meal per day
+- Book directly with the hostel (avoid booking platform fees)
+- Stay slightly outside the center — prices drop dramatically one metro stop away
+
+## Eating Well for Less
+
+### The Local Lunch Strategy
+
+In Southern Europe (Italy, Spain, France, Portugal), lunch menus are the secret weapon:
+
+- **Menu del día** (Spain) — a 3-course lunch with drink for €10-15
+- **Pranzo** (Italy) — lunch specials at trattorias, half the dinner price
+- **Formule midi** (France) — set lunch menus at restaurants that charge double at dinner
+
+Eat your big meal at lunch. Have a light dinner from a bakery, market, or supermarket.
+
+### Market Meals
+
+Every European city has a food market. Some favorites:
+
+- **Mercado da Ribeira** (Lisbon) — seafood, pastéis de nata, wine
+- **Mercato Centrale** (Florence) — lampredotto, focaccia, gelato
+- **Markthal** (Rotterdam) — international food under a stunning ceiling
+- **Naschmarkt** (Vienna) — Middle Eastern food at reasonable prices
+
+### Supermarket Is Not Shameful
+
+European supermarkets stock excellent bread, cheese, cured meats, and wine. A supermarket picnic in a park costs €5-8 per person and can be the highlight of your day.
+
+## Free and Cheap Activities
+
+### Always Free
+
+- Walking tours (tip-based) — available in every major European city
+- Parks and gardens — Europe's urban green spaces are world-class
+- Churches and cathedrals — most are free to enter
+- Street markets and window shopping
+- Sunset viewpoints
+
+### Cheap Days
+
+- Many museums have free entry one day per month (first Sunday in Paris, for example)
+- City passes (Roma Pass, Amsterdam City Card) bundle transport and museums at a discount
+- Student/youth discounts are widely available — bring an ISIC card
+
+### The Free Walking Strategy
+
+Budget one paid attraction per day. Fill the rest with walking, parks, markets, neighborhoods, and people-watching. The best European cities reveal themselves on foot.
+
+## Country-by-Country Budget Guide
+
+| Country | Daily Budget (mid-range) | Cheapest Month |
+|---|---|---|
+| Portugal | €50-70 | January–February |
+| Spain | €55-75 | November–February |
+| Italy | €60-80 | November, February |
+| Greece | €45-65 | April–May, October |
+| Czech Republic | €40-55 | November–March |
+| Poland | €35-50 | November–March |
+| Croatia | €50-70 | May, September–October |
+| Hungary | €35-50 | November–March |
+
+Eastern Europe (Poland, Hungary, Czech Republic, Romania) is significantly cheaper than Western Europe for the same quality of experience.
+
+## Planning Your Budget Europe Trip
+
+Use TravelFlow to map multi-city routes across Europe. The tool shows you travel connections and timing, so you can optimize your route to minimize expensive backtracking. Add your cities, set dates in shoulder season, and let the AI suggest an efficient itinerary.
+
+The best budget trips don't feel budget. They feel smart.

--- a/content/blog/festival-travel-guide.md
+++ b/content/blog/festival-travel-guide.md
@@ -1,0 +1,118 @@
+---
+slug: festival-travel-guide
+title: "How to Plan a Trip Around a Festival"
+date: 2026-01-28
+published_at: 2026-01-28T10:00:00Z
+author: TravelFlow Team
+tags: ["festivals", "tips", "planning"]
+summary: "Festival-centered trips are some of the most memorable journeys you can take. Here's how to plan one without the chaos."
+cover_color: bg-fuchsia-100
+reading_time_min: 7
+status: published
+---
+
+## Why Festival Trips Are Different
+
+A regular trip revolves around a place. A festival trip revolves around an event. This changes everything: your dates are fixed, accommodation is scarce, and the city transforms into something you won't experience at any other time of year.
+
+That's what makes festival trips electric — and what makes them harder to plan.
+
+## Choosing Your Festival
+
+The world has thousands of festivals. To pick the right one, consider:
+
+- **What moves you?** Music, food, culture, religion, nature, art?
+- **How much chaos do you enjoy?** Carnival in Rio is sensory overload. A Kyoto cherry blossom viewing is serene contemplation. Both are festivals.
+- **Solo or group?** Some festivals are better with friends (Oktoberfest, music festivals). Others are incredible solo (Holi, lantern festivals).
+
+Start with one festival per trip. Trying to hit two festivals in one journey usually means you enjoy neither properly.
+
+## Book Early — Really Early
+
+Festival accommodation follows a brutal supply-and-demand curve. For major events:
+
+- **6-12 months ahead**: Book accommodation. This is not optional.
+- **3-6 months ahead**: Book flights. Prices spike as the festival approaches.
+- **1-3 months ahead**: Book any tickets, passes, or reserved experiences.
+
+For events like Oktoberfest, hotel rooms within walking distance sell out a year in advance. Consider staying slightly outside the city center and using public transit — it's cheaper and availability is much better.
+
+## Build the Trip Around the Festival, Not Vice Versa
+
+The festival is your anchor. Build your trip outward from it:
+
+1. **Arrive 1-2 days before** — settle in, explore the city, recover from travel
+2. **Festival days** — dedicate yourself fully
+3. **1-2 days after** — decompress, see what you missed, visit nearby towns
+
+This gives you a 5-7 day trip with the festival at its heart. The pre- and post-festival days let you see the destination in its normal state too.
+
+## Navigating Festival Logistics
+
+### Crowds
+
+Accept them. You chose this. Some strategies:
+
+- Arrive early to popular events and stages
+- Have a meeting point arranged with your group (phones die, signal drops)
+- Carry a small daypack with water, snacks, sunscreen, and a portable charger
+- Know the exits and less-crowded areas
+
+### Money
+
+- Carry some cash — card machines fail at peak times
+- Some festivals use tokens or wristband payment systems
+- Street food and local vendors are usually cash-only
+- Budget 30-50% more than a normal trip day
+
+### Safety
+
+- Keep valuables minimal — phone, some cash, ID
+- Use a money belt or front pocket in dense crowds
+- Stay hydrated, especially at outdoor summer festivals
+- Know the location of first aid stations
+
+## Festival Types and What to Expect
+
+### Cultural / Religious Festivals
+
+Examples: Holi (India), Día de los Muertos (Mexico), Songkran (Thailand)
+
+These are often the most immersive. You're participating in something with deep meaning to the local community. Be respectful, ask before photographing people, and follow local customs. The experience is usually free or very cheap.
+
+### Music Festivals
+
+Examples: Glastonbury (UK), Coachella (USA), Fuji Rock (Japan)
+
+Ticketed, often multi-day, and usually in dedicated venues or fields. Camping is common. Pack for weather extremes — you'll be outside for long hours.
+
+### Food & Drink Festivals
+
+Examples: Oktoberfest (Germany), La Tomatina (Spain), Salon du Chocolat (France)
+
+Come hungry, pace yourself, and try things you wouldn't normally order. These festivals are best when you let curiosity guide your choices.
+
+### Light & Lantern Festivals
+
+Examples: Loy Krathong (Thailand), Vivid Sydney (Australia), Lantern Festival (Taiwan)
+
+Usually evening events. Bring a camera, arrive before sunset for the best positions, and stay for the full display. These are often the most photogenic festival experiences.
+
+## Combining Festivals with Deeper Travel
+
+The best festival trips extend beyond the event itself. If you're flying to the other side of the world for a 3-day festival, spend at least a week exploring the region.
+
+Use TravelFlow to plan the surrounding itinerary — add cities before and after the festival dates, and the AI will suggest day trips, transport connections, and activities that complement your festival experience.
+
+## Your Festival Trip Checklist
+
+- [ ] Festival dates confirmed (some vary year to year)
+- [ ] Accommodation booked (as early as possible)
+- [ ] Flights booked (watch for price spikes near the event)
+- [ ] Festival tickets or passes purchased
+- [ ] Packing list adjusted for outdoor/weather conditions
+- [ ] Local customs and dress codes researched
+- [ ] Emergency contacts and insurance sorted
+- [ ] Pre- and post-festival itinerary roughed out
+
+The magic of a festival trip is that it gives you a reason to be somewhere at exactly the right moment. Everything else — the food, the people, the streets decorated for the occasion — is a bonus you can't plan for.

--- a/content/blog/how-to-plan-multi-city-trip.md
+++ b/content/blog/how-to-plan-multi-city-trip.md
@@ -1,0 +1,101 @@
+---
+slug: how-to-plan-multi-city-trip
+title: "How to Plan the Perfect Multi-City Trip"
+date: 2026-02-05
+published_at: 2026-02-05T10:00:00Z
+author: TravelFlow Team
+tags: ["planning", "tips", "multi-city"]
+summary: "Master the art of multi-destination travel with practical advice on route planning, timing, and logistics that actually works."
+cover_color: bg-sky-100
+reading_time_min: 8
+status: published
+---
+
+## Why Multi-City Trips Are Worth the Extra Planning
+
+Single-destination trips are simple. You book a flight, find a hotel, and figure out the rest when you get there. Multi-city trips require more thought upfront — but the payoff is enormous. You see more, experience more contrast, and come home with stories that span cultures.
+
+The trick isn't to plan every minute. It's to get the structure right so the spontaneous moments have room to happen.
+
+## Start With the Map, Not the Bucket List
+
+Most people begin with a list of cities they want to visit and then try to connect them. This leads to backtracking, exhausting travel days, and wasted time. Instead, start with a map.
+
+Plot your potential cities and look for natural routes:
+
+- **Linear routes** work best for first-timers — start at one end and work your way to the other
+- **Loop routes** are great when you want to fly into and out of the same airport
+- **Hub-and-spoke** works when one city is central and you want day trips radiating outward
+
+A good rule: never backtrack more than an hour just to tick off a city. If it doesn't fit the route, save it for another trip.
+
+## The 3-2-1 Rule for Timing
+
+For each city on your route, think in terms of the 3-2-1 rule:
+
+- **3 nights minimum** for major cities (Tokyo, Rome, Istanbul) — enough to get oriented, hit the highlights, and stumble into something unexpected
+- **2 nights** for smaller cities or towns (Kyoto side trip, Cinque Terre, Bruges) — arrive, explore, move on
+- **1 night** only for transit stops or places you're passing through
+
+Anything less than two nights usually isn't worth the packing and unpacking. You'll spend more time in transit than actually experiencing the place.
+
+## Build in Buffer Days
+
+The number one mistake in multi-city planning is cramming too many cities into too few days. Your itinerary on paper looks efficient. In practice, you're exhausted by day four.
+
+Add buffer days:
+
+- One buffer day for every 4-5 travel days
+- Place buffers in the most interesting cities — you'll want the extra time there anyway
+- Use them for recovery, serendipity, or extending something you loved
+
+## Transportation Between Cities
+
+The connection between cities matters as much as the cities themselves. Consider:
+
+- **Trains** — often more scenic and city-center to city-center (Japan, Europe, parts of Southeast Asia)
+- **Budget airlines** — fast but factor in airport transit time, baggage fees, and early check-in
+- **Buses** — cheapest option, often surprisingly comfortable (Southeast Asia, South America)
+- **Rental cars** — maximum flexibility, best for countryside routes and places with poor public transit
+
+For trips crossing multiple countries, look into rail passes. The Eurail pass, Japan Rail Pass, and similar options can save money if you're taking 3+ long-distance trains.
+
+## Accommodation Strategy
+
+Don't book everything upfront. Here's a balanced approach:
+
+1. **Book the first and last night** — you want certainty at arrival and departure
+2. **Book key cities** where availability is limited (festivals, peak season)
+3. **Leave 2-3 stops flexible** — you might want to extend a stay or skip a city
+
+Mix accommodation types. A hostel for a solo night, a boutique hotel for a special city, an apartment when you need to do laundry and cook a meal.
+
+## Packing for Multiple Climates
+
+Multi-city trips often cross climate zones. Pack in layers and follow the one-bag philosophy:
+
+- Merino wool base layers work in heat and cold
+- One pair of versatile shoes that work for walking and casual dining
+- A packable rain jacket that doubles as a wind layer
+- Compression cubes to keep things organized across multiple unpacking sessions
+
+Do laundry every 4-5 days instead of packing for the entire trip. Most cities have laundromats or hotel laundry services.
+
+## Using TravelFlow for Multi-City Planning
+
+This is exactly what TravelFlow was built for. Add your cities, set your dates, and the AI generates a day-by-day plan with transport connections, timing, and activity suggestions. You can drag cities to reorder your route, adjust durations, and see the whole trip on a map.
+
+The visual timeline makes it easy to spot problems — like a 12-hour travel day sandwiched between two packed sightseeing days — before you've booked anything.
+
+## Final Checklist
+
+Before you book anything, verify:
+
+- [ ] Your route makes geographic sense (no unnecessary backtracking)
+- [ ] You have at least 2 nights per city
+- [ ] Buffer days are placed in interesting cities
+- [ ] You've checked visa requirements for every country on the route
+- [ ] Travel insurance covers multi-country trips
+- [ ] You have backup plans for missed connections
+
+The best multi-city trips feel effortless. That effortlessness comes from getting the structure right, then letting go of the details. Plan the skeleton. Let the trip fill in the rest.

--- a/content/blog/weekend-getaway-tips.md
+++ b/content/blog/weekend-getaway-tips.md
@@ -1,0 +1,99 @@
+---
+slug: weekend-getaway-tips
+title: "Weekend Getaway Planning: From Idea to Boarding Pass"
+date: 2026-02-01
+published_at: 2026-02-01T10:00:00Z
+author: TravelFlow Team
+tags: ["weekend", "tips", "planning"]
+summary: "You don't need two weeks off to travel well. Here's how to squeeze the most out of a 2-3 day trip without the stress."
+cover_color: bg-amber-100
+reading_time_min: 6
+status: published
+---
+
+## The Case for Short Trips
+
+Long vacations are wonderful but rare. Most people get a handful of extended holidays per year. Weekend getaways, on the other hand, can happen monthly — and they add up to more travel days than you'd think.
+
+A well-planned 3-day trip can feel more refreshing than a poorly planned 10-day one. The secret is reducing friction and maximizing time at the destination.
+
+## The Friday Night Rule
+
+If you can leave Thursday evening or early Friday morning, your trip gains an entire day. That's the difference between a rushed 2-day trip and a relaxed 3-day one.
+
+For European city breaks, Thursday evening flights are often cheaper than Friday ones. Book them. The extra night of accommodation costs less than the stress of cramming everything into two days.
+
+## Pick the Right Distance
+
+The golden zone for weekend trips is **1-3 hours of travel time** from your front door to the hotel. Beyond that, you're spending too much of your weekend in transit.
+
+This means:
+
+- **1-hour flights** — perfect for European city hops (London → Amsterdam, Berlin → Prague)
+- **2-3 hour trains** — often door-to-door faster than flying (Paris → Brussels, Tokyo → Kyoto)
+- **Driving 2-3 hours** — ideal for countryside escapes, coastal towns, and mountain retreats
+
+Avoid connections. A 90-minute direct flight beats a 4-hour journey with a layover every time.
+
+## The One-Bag Weekend
+
+Pack a single carry-on or backpack. No checked luggage. This alone saves you 45-60 minutes per direction (check-in queues, baggage carousel, potential lost bag stress).
+
+Weekend packing list:
+
+- 2 outfits that mix and match
+- One pair of comfortable walking shoes
+- A light jacket
+- Toiletries in a small pouch
+- Phone charger and one adapter if needed
+- That's it
+
+You're going for 2-3 days, not emigrating. If you forget something, buy it there.
+
+## Research Just Enough
+
+Over-researching kills spontaneity. For a weekend trip, you need:
+
+1. **One must-do activity** — the reason you're going (a museum, a hike, a food market)
+2. **Two restaurant reservations** — one for each evening, ideally booked a week ahead
+3. **A rough neighborhood map** — know where the interesting areas are so you can wander with purpose
+
+Everything else? Figure it out when you get there. Ask your hotel, follow your nose, and embrace getting slightly lost.
+
+## Accommodation Sweet Spot
+
+For weekend trips, location beats everything else. Pay a bit more to stay central. Walking distance to the main sights means:
+
+- No wasted time on transit
+- You can pop back to the hotel for a break
+- Late nights out don't require expensive taxi rides
+
+Boutique hotels and well-reviewed apartments in the city center are usually worth the premium. You're only paying for 2-3 nights.
+
+## The Saturday Deep Dive
+
+Use Saturday — your one full day — for the main event. This is when you:
+
+- Visit the headline attraction first thing (before crowds build)
+- Explore the most interesting neighborhood on foot
+- Have a proper lunch at a place you've researched
+- Leave the afternoon open for whatever catches your eye
+
+Don't schedule Saturday to the minute. The best weekend trips have one solid anchor and lots of space around it.
+
+## Sunday Morning Magic
+
+Sunday mornings in most cities are quieter. Use this time for:
+
+- Markets (most European cities have Sunday morning markets)
+- A leisurely breakfast at a local cafe
+- A walk through a park or along a waterfront
+- One final museum or viewpoint before heading to the airport
+
+Aim to leave by mid-afternoon. Late Sunday flights mean you arrive home exhausted with a Monday morning alarm looming.
+
+## Weekend Trip Ideas Generator
+
+Not sure where to go? Use TravelFlow's Inspirations page to browse weekend getaway ideas. Filter by your home base and see curated 2-3 day trips you can book this week.
+
+The best weekend getaway is the one you actually take. Stop planning the perfect trip and just book the next available one.

--- a/content/updates/2026-02-08-umami-consent-gated-analytics.md
+++ b/content/updates/2026-02-08-umami-consent-gated-analytics.md
@@ -3,7 +3,7 @@ id: rel-2026-02-08-umami-consent-gated-analytics
 version: v0.20.0
 title: "Consent-gated Umami analytics"
 date: 2026-02-08
-published_at: 2026-02-08T23:59:00Z
+published_at: 2026-02-08T23:59:30Z
 status: published
 notify_in_app: true
 in_app_hours: 24

--- a/content/updates/2026-02-09-homepage-redesign.md
+++ b/content/updates/2026-02-09-homepage-redesign.md
@@ -1,0 +1,41 @@
+---
+id: rel-2026-02-09-homepage-redesign
+version: v0.23.0
+title: "View transitions, country pages, and blog & homepage redesign"
+date: 2026-02-09
+published_at: 2026-02-09T12:00:00Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "Smooth page transitions, country-specific inspiration pages, interactive month calendar, smarter festivals, a markdown-powered blog, and a redesigned homepage."
+---
+
+## Changes
+- [x] [New feature] 📅 Interactive month calendar — pick any month to discover the best destinations and seasonal travel tips.
+- [x] [New feature] 🎉 Upcoming festivals — events now show in chronological order with their next date, so you never miss one.
+- [x] [New feature] 📝 Blog — travel planning guides, destination deep-dives, and tips, powered by markdown.
+- [x] [New feature] 🔗 Related articles appear throughout inspirations for deeper reading.
+- [x] [Improved] 🗓️ 20+ festivals with real dates for accurate upcoming-event sorting.
+- [x] [New feature] 🏠 Completely redesigned homepage with a bold hero, feature showcase, and bottom call-to-action.
+- [x] [New feature] 🧭 New Features page with three hero capabilities, "How it works" steps, a 9-feature grid, and a comparison table against other planning tools.
+- [x] [New feature] 🌍 New Inspirations page with 18+ curated destinations across 6 travel themes — adventure, food & culture, beaches, cities, slow travel, and photography trips.
+- [x] [New feature] 🔍 Search across all destinations, festivals, and weekend getaways from the Inspirations page.
+- [x] [New feature] 🗺️ Browse by country with best-month recommendations and tags for 12 popular destinations.
+- [x] [New feature] ⚡ Spontaneous weekend getaway picks — 6 short-trip ideas you can book on a whim.
+- [x] [New feature] 🎠 Browse a scrolling gallery of example trips on the homepage — hover to pause, click to explore.
+- [x] [Improved] 🎞️ Sections animate smoothly into view as you scroll — blur reveals, directional slides, and staggered entrances.
+- [x] [Improved] 🎨 Trip creation form feels more premium with refined card shadows, a glowing accent bar, and softer background effects.
+- [x] [Improved] 🚀 Pages transition smoothly with the View Transition API — a fast, subtle slide animation between routes.
+- [x] [Fixed] 📍 Navigating between pages now always starts at the top of the page.
+- [x] [New feature] 🇯🇵 Country detail pages — click any country card to see travel info, best months, and tags at a glance.
+- [x] [Fixed] 📑 Release notes now always display in the correct chronological order.
+- [ ] [Internal] Added blog service layer, validation script, and 5 example blog posts.
+- [ ] [Internal] Added /blog/:slug route and blog post detail page with ReactMarkdown rendering.
+- [ ] [Internal] Enhanced FestivalEvent interface with startMonth, startDay for date-aware sorting.
+- [ ] [Internal] Added blogSlugs references across inspiration data types.
+- [ ] [Internal] Added content-fade-in CSS animation for month tab transitions.
+- [ ] [Internal] Adopted Phosphor Icons (duotone) on marketing pages and create-trip form.
+- [ ] [Internal] Added CSS scroll-driven animation utilities and @phosphor-icons/react dependency.
+- [ ] [Internal] Added ScrollToTop and ViewTransitionHandler components in App.tsx.
+- [ ] [Internal] Added view transition CSS keyframes (vt-slide-out/vt-slide-in) for ::view-transition pseudo-elements.
+- [ ] [Internal] Added /inspirations/country/:countryName route and CountryDetailPage.

--- a/data/exampleTripCards.ts
+++ b/data/exampleTripCards.ts
@@ -1,0 +1,111 @@
+export interface ExampleTripCard {
+  id: string;
+  title: string;
+  countries: { name: string; flag: string }[];
+  durationDays: number;
+  cityCount: number;
+  mapColor: string;
+  mapAccent: string;
+  username: string;
+  avatarColor: string;
+  tags: string[];
+}
+
+export const exampleTripCards: ExampleTripCard[] = [
+  {
+    id: 'japan-spring',
+    title: 'Cherry Blossom Trail',
+    countries: [{ name: 'Japan', flag: '🇯🇵' }],
+    durationDays: 14,
+    cityCount: 5,
+    mapColor: 'bg-rose-100',
+    mapAccent: 'bg-rose-400',
+    username: 'sakura_wanderer',
+    avatarColor: 'bg-rose-500',
+    tags: ['Culture', 'Food', 'Nature'],
+  },
+  {
+    id: 'italy-classic',
+    title: 'Italian Grand Tour',
+    countries: [{ name: 'Italy', flag: '🇮🇹' }],
+    durationDays: 18,
+    cityCount: 6,
+    mapColor: 'bg-amber-100',
+    mapAccent: 'bg-amber-500',
+    username: 'dolce_vita',
+    avatarColor: 'bg-amber-600',
+    tags: ['Food', 'Art', 'History'],
+  },
+  {
+    id: 'thailand-islands',
+    title: 'Temples & Beaches',
+    countries: [{ name: 'Thailand', flag: '🇹🇭' }],
+    durationDays: 12,
+    cityCount: 4,
+    mapColor: 'bg-emerald-100',
+    mapAccent: 'bg-emerald-400',
+    username: 'island_hopper',
+    avatarColor: 'bg-emerald-500',
+    tags: ['Beach', 'Adventure', 'Food'],
+  },
+  {
+    id: 'portugal-coast',
+    title: 'Atlantic Coast Road Trip',
+    countries: [{ name: 'Portugal', flag: '🇵🇹' }],
+    durationDays: 10,
+    cityCount: 4,
+    mapColor: 'bg-sky-100',
+    mapAccent: 'bg-sky-400',
+    username: 'surf_nomad',
+    avatarColor: 'bg-sky-600',
+    tags: ['Surf', 'Culture', 'Wine'],
+  },
+  {
+    id: 'peru-adventure',
+    title: 'Andes & Amazon Explorer',
+    countries: [{ name: 'Peru', flag: '🇵🇪' }],
+    durationDays: 16,
+    cityCount: 5,
+    mapColor: 'bg-orange-100',
+    mapAccent: 'bg-orange-400',
+    username: 'altitude_addict',
+    avatarColor: 'bg-orange-600',
+    tags: ['Adventure', 'Nature', 'History'],
+  },
+  {
+    id: 'new-zealand-wild',
+    title: 'South Island Wilderness',
+    countries: [{ name: 'New Zealand', flag: '🇳🇿' }],
+    durationDays: 21,
+    cityCount: 7,
+    mapColor: 'bg-teal-100',
+    mapAccent: 'bg-teal-400',
+    username: 'kiwi_trails',
+    avatarColor: 'bg-teal-600',
+    tags: ['Nature', 'Hiking', 'Road Trip'],
+  },
+  {
+    id: 'morocco-medina',
+    title: 'Medinas & Sahara Nights',
+    countries: [{ name: 'Morocco', flag: '🇲🇦' }],
+    durationDays: 9,
+    cityCount: 4,
+    mapColor: 'bg-yellow-100',
+    mapAccent: 'bg-yellow-500',
+    username: 'desert_dreamer',
+    avatarColor: 'bg-yellow-700',
+    tags: ['Culture', 'Food', 'Desert'],
+  },
+  {
+    id: 'iceland-ring',
+    title: 'Ring Road Circuit',
+    countries: [{ name: 'Iceland', flag: '🇮🇸' }],
+    durationDays: 7,
+    cityCount: 3,
+    mapColor: 'bg-indigo-100',
+    mapAccent: 'bg-indigo-400',
+    username: 'arctic_rover',
+    avatarColor: 'bg-indigo-600',
+    tags: ['Nature', 'Road Trip', 'Photography'],
+  },
+];

--- a/data/inspirationsData.ts
+++ b/data/inspirationsData.ts
@@ -1,0 +1,244 @@
+import type { Icon } from '@phosphor-icons/react';
+import {
+    Mountains,
+    ForkKnife,
+    Buildings,
+    Boat,
+    TreePalm,
+    Camera,
+} from '@phosphor-icons/react';
+
+/* ── Shared types ── */
+
+export interface Destination {
+    title: string;
+    country: string;
+    flag: string;
+    durationDays: number;
+    cityCount: number;
+    description: string;
+    mapColor: string;
+    mapAccent: string;
+    tags: string[];
+}
+
+export interface InspirationCategory {
+    id: string;
+    icon: Icon;
+    title: string;
+    subtitle: string;
+    color: string;
+    destinations: Destination[];
+    blogSlugs?: string[];
+}
+
+export interface MonthEntry {
+    month: string;
+    monthIndex: number; // 0-based
+    emoji: string;
+    destinations: string[];
+    description: string;
+    blogSlugs?: string[];
+}
+
+export interface FestivalEvent {
+    name: string;
+    country: string;
+    flag: string;
+    months: string;
+    startMonth: number;    // 0-based (Jan=0)
+    startDay: number;      // 1-31
+    durationDays: number;
+    description: string;
+    mapColor: string;
+    blogSlugs?: string[];
+}
+
+export interface WeekendGetaway {
+    title: string;
+    from: string;
+    to: string;
+    flag: string;
+    durationDays: number;
+    description: string;
+    mapColor: string;
+    mapAccent: string;
+    blogSlugs?: string[];
+}
+
+export interface CountryGroup {
+    country: string;
+    flag: string;
+    tripCount: number;
+    bestMonths: string;
+    tags: string[];
+    blogSlugs?: string[];
+}
+
+/* ── Categories (by theme) ── */
+
+export const categories: InspirationCategory[] = [
+    {
+        id: 'adventure',
+        icon: Mountains,
+        title: 'Adventure & Outdoors',
+        subtitle: 'Hikes, summits, and wild landscapes',
+        color: 'bg-emerald-50 text-emerald-600 ring-emerald-100',
+        destinations: [
+            { title: 'South Island Wilderness', country: 'New Zealand', flag: '🇳🇿', durationDays: 21, cityCount: 7, description: 'Milford Sound, glaciers, and the Routeburn Track — three weeks of jaw-dropping scenery.', mapColor: 'bg-emerald-100', mapAccent: 'bg-emerald-400', tags: ['nature', 'hiking', 'new zealand'] },
+            { title: 'Andes & Amazon Explorer', country: 'Peru', flag: '🇵🇪', durationDays: 16, cityCount: 5, description: 'From Machu Picchu at altitude to the Amazon basin — a route that covers every elevation.', mapColor: 'bg-orange-100', mapAccent: 'bg-orange-400', tags: ['adventure', 'nature', 'peru'] },
+            { title: 'Patagonia Circuit', country: 'Chile & Argentina', flag: '🇨🇱', durationDays: 14, cityCount: 4, description: 'Torres del Paine, Perito Moreno, and El Chaltén — the ultimate southern trek.', mapColor: 'bg-sky-100', mapAccent: 'bg-sky-400', tags: ['hiking', 'nature', 'chile', 'argentina'] },
+        ],
+    },
+    {
+        id: 'food-culture',
+        icon: ForkKnife,
+        title: 'Food & Culture',
+        subtitle: 'Eat your way through history',
+        color: 'bg-amber-50 text-amber-600 ring-amber-100',
+        destinations: [
+            { title: 'Italian Grand Tour', country: 'Italy', flag: '🇮🇹', durationDays: 18, cityCount: 6, description: 'Rome, Florence, Bologna, and the Amalfi Coast — pasta, art, and espresso in every city.', mapColor: 'bg-amber-100', mapAccent: 'bg-amber-500', tags: ['food', 'art', 'italy'] },
+            { title: 'Cherry Blossom Trail', country: 'Japan', flag: '🇯🇵', durationDays: 14, cityCount: 5, description: 'Tokyo, Kyoto, Osaka, Hiroshima — ramen counters, temple gardens, and spring blossoms.', mapColor: 'bg-rose-100', mapAccent: 'bg-rose-400', tags: ['culture', 'food', 'japan'] },
+            { title: 'Medinas & Sahara Nights', country: 'Morocco', flag: '🇲🇦', durationDays: 9, cityCount: 4, description: 'Marrakech souks, Fez tanneries, and a night under the Saharan stars.', mapColor: 'bg-yellow-100', mapAccent: 'bg-yellow-500', tags: ['culture', 'food', 'morocco'] },
+        ],
+        blogSlugs: ['budget-travel-europe'],
+    },
+    {
+        id: 'beach-islands',
+        icon: TreePalm,
+        title: 'Beach & Islands',
+        subtitle: 'Turquoise water, white sand, zero stress',
+        color: 'bg-cyan-50 text-cyan-600 ring-cyan-100',
+        destinations: [
+            { title: 'Temples & Beaches', country: 'Thailand', flag: '🇹🇭', durationDays: 12, cityCount: 4, description: 'Bangkok temples, Chiang Mai markets, then island-hop through Koh Samui and Krabi.', mapColor: 'bg-emerald-100', mapAccent: 'bg-emerald-400', tags: ['beach', 'food', 'thailand'] },
+            { title: 'Greek Island Hop', country: 'Greece', flag: '🇬🇷', durationDays: 10, cityCount: 4, description: 'Athens, Santorini, Naxos, and Crete — whitewashed villages above the Aegean.', mapColor: 'bg-blue-100', mapAccent: 'bg-blue-400', tags: ['beach', 'culture', 'greece'] },
+            { title: 'Bali & Lombok', country: 'Indonesia', flag: '🇮🇩', durationDays: 14, cityCount: 5, description: 'Rice terraces, surf breaks, and volcano sunrises — two islands, endless vibes.', mapColor: 'bg-lime-100', mapAccent: 'bg-lime-500', tags: ['beach', 'adventure', 'indonesia'] },
+        ],
+    },
+    {
+        id: 'city-breaks',
+        icon: Buildings,
+        title: 'City Breaks',
+        subtitle: 'Weekend escapes and urban deep-dives',
+        color: 'bg-violet-50 text-violet-600 ring-violet-100',
+        destinations: [
+            { title: 'Atlantic Coast Road Trip', country: 'Portugal', flag: '🇵🇹', durationDays: 10, cityCount: 4, description: "Lisbon's tiles, Porto's port cellars, and the wild surf beaches of the Algarve.", mapColor: 'bg-sky-100', mapAccent: 'bg-sky-400', tags: ['city', 'surf', 'portugal'] },
+            { title: 'Nordic Design Circuit', country: 'Denmark & Sweden', flag: '🇩🇰', durationDays: 7, cityCount: 3, description: "Copenhagen canals, Malmö bridges, and Stockholm's old town — Scandinavian cool in one week.", mapColor: 'bg-slate-100', mapAccent: 'bg-slate-400', tags: ['city', 'design', 'denmark', 'sweden'] },
+            { title: 'Ring Road Circuit', country: 'Iceland', flag: '🇮🇸', durationDays: 7, cityCount: 3, description: 'Waterfalls, geysers, and black-sand beaches — the full island loop in a week.', mapColor: 'bg-indigo-100', mapAccent: 'bg-indigo-400', tags: ['nature', 'road trip', 'iceland'] },
+        ],
+        blogSlugs: ['how-to-plan-multi-city-trip'],
+    },
+    {
+        id: 'slow-travel',
+        icon: Boat,
+        title: 'Slow Travel',
+        subtitle: 'Fewer moves, deeper immersion',
+        color: 'bg-rose-50 text-rose-600 ring-rose-100',
+        destinations: [
+            { title: 'Tuscan Countryside', country: 'Italy', flag: '🇮🇹', durationDays: 10, cityCount: 3, description: 'A farmhouse base near Siena with day trips to hilltop villages, vineyards, and Florence.', mapColor: 'bg-amber-100', mapAccent: 'bg-amber-400', tags: ['slow travel', 'food', 'italy'] },
+            { title: 'Sri Lanka Coast to Hills', country: 'Sri Lanka', flag: '🇱🇰', durationDays: 14, cityCount: 4, description: 'Beach mornings in Mirissa, tea plantations in Ella, and train rides through the highlands.', mapColor: 'bg-teal-100', mapAccent: 'bg-teal-400', tags: ['slow travel', 'nature', 'sri lanka'] },
+            { title: 'Oaxaca & Pacific Coast', country: 'Mexico', flag: '🇲🇽', durationDays: 12, cityCount: 3, description: 'Mezcal, mole, and markets in Oaxaca city, then surf and sea turtles in Puerto Escondido.', mapColor: 'bg-red-100', mapAccent: 'bg-red-400', tags: ['food', 'beach', 'mexico'] },
+        ],
+    },
+    {
+        id: 'photography',
+        icon: Camera,
+        title: 'Photography Trips',
+        subtitle: 'Golden hours and epic backdrops',
+        color: 'bg-fuchsia-50 text-fuchsia-600 ring-fuchsia-100',
+        destinations: [
+            { title: 'Northern Lights Chase', country: 'Norway', flag: '🇳🇴', durationDays: 7, cityCount: 3, description: 'Tromsø fjords, Lofoten fishing villages, and aurora borealis on winter nights.', mapColor: 'bg-indigo-100', mapAccent: 'bg-indigo-500', tags: ['photography', 'nature', 'norway'] },
+            { title: 'Cappadocia & Istanbul', country: 'Turkey', flag: '🇹🇷', durationDays: 8, cityCount: 3, description: 'Hot-air balloons at sunrise, fairy chimneys, and the Bosphorus at golden hour.', mapColor: 'bg-orange-100', mapAccent: 'bg-orange-500', tags: ['photography', 'culture', 'turkey'] },
+            { title: 'Rajasthan Heritage Trail', country: 'India', flag: '🇮🇳', durationDays: 12, cityCount: 5, description: "Jaipur's pink city, Jodhpur's blue lanes, and the Thar Desert under the stars.", mapColor: 'bg-yellow-100', mapAccent: 'bg-yellow-600', tags: ['photography', 'culture', 'india'] },
+        ],
+    },
+];
+
+/* ── By month ── */
+
+export const monthEntries: MonthEntry[] = [
+    { month: 'January', monthIndex: 0, emoji: '❄️', destinations: ['Thailand', 'Sri Lanka', 'Mexico'], description: 'Escape winter — tropical heat, dry season beaches, and far-flung new year vibes.' },
+    { month: 'February', monthIndex: 1, emoji: '🎭', destinations: ['Brazil', 'Italy', 'Japan'], description: 'Carnival in Rio, Venice masquerade, and early plum blossom season in Kyoto.' },
+    { month: 'March', monthIndex: 2, emoji: '🌸', destinations: ['Japan', 'Morocco', 'Portugal'], description: 'Cherry blossoms peak, Sahara is still comfortable, and Lisbon starts warming up.', blogSlugs: ['best-time-visit-japan'] },
+    { month: 'April', monthIndex: 3, emoji: '🌷', destinations: ['Netherlands', 'Greece', 'Peru'], description: 'Tulip fields, Greek islands before the crowds, and dry-season Inca Trail.' },
+    { month: 'May', monthIndex: 4, emoji: '☀️', destinations: ['Italy', 'Croatia', 'Iceland'], description: 'Mediterranean shoulder season — perfect temps, smaller crowds, longer days.', blogSlugs: ['budget-travel-europe'] },
+    { month: 'June', monthIndex: 5, emoji: '🌅', destinations: ['Norway', 'Turkey', 'Indonesia'], description: 'Midnight sun in the Nordics, Cappadocia hot-air balloons, and Bali dry season.' },
+    { month: 'July', monthIndex: 6, emoji: '🏖️', destinations: ['Greece', 'France', 'Canada'], description: 'Peak summer in the Med, lavender fields in Provence, and Canadian Rockies.' },
+    { month: 'August', monthIndex: 7, emoji: '🌊', destinations: ['Iceland', 'Tanzania', 'Sweden'], description: 'Ring Road weather window, Great Migration, and Swedish archipelago sailing.' },
+    { month: 'September', monthIndex: 8, emoji: '🍂', destinations: ['Italy', 'Japan', 'New Zealand'], description: 'Wine harvest in Tuscany, autumn leaves in Kyoto, and NZ spring wildflowers.', blogSlugs: ['best-time-visit-japan'] },
+    { month: 'October', monthIndex: 9, emoji: '🎃', destinations: ['Mexico', 'Morocco', 'Portugal'], description: 'Día de los Muertos, comfortable desert temps, and Algarve autumn sun.', blogSlugs: ['festival-travel-guide'] },
+    { month: 'November', monthIndex: 10, emoji: '🍁', destinations: ['India', 'Thailand', 'Chile'], description: 'Rajasthan festival season, Thai loy krathong lanterns, and Patagonia spring.' },
+    { month: 'December', monthIndex: 11, emoji: '🎄', destinations: ['Austria', 'Thailand', 'New Zealand'], description: 'Christmas markets in Vienna, tropical island escapes, and NZ summer hiking.' },
+];
+
+/* ── Festivals & events ── */
+
+export const festivalEvents: FestivalEvent[] = [
+    { name: 'Cherry Blossom Festival', country: 'Japan', flag: '🇯🇵', months: 'Mar–Apr', startMonth: 2, startDay: 20, description: 'Sakura season transforms parks and temples into clouds of pink — picnic under the blossoms in Kyoto and Tokyo.', mapColor: 'bg-rose-100', durationDays: 10, blogSlugs: ['best-time-visit-japan'] },
+    { name: 'Carnival', country: 'Brazil', flag: '🇧🇷', months: 'Feb', startMonth: 1, startDay: 25, description: 'The world\'s biggest party — samba parades, street blocos, and non-stop energy across Rio and Salvador.', mapColor: 'bg-yellow-100', durationDays: 5, blogSlugs: ['festival-travel-guide'] },
+    { name: 'Holi', country: 'India', flag: '🇮🇳', months: 'Mar', startMonth: 2, startDay: 14, description: 'The festival of colors — join locals throwing vibrant powders in Jaipur, Varanasi, and Mathura.', mapColor: 'bg-fuchsia-100', durationDays: 3, blogSlugs: ['festival-travel-guide'] },
+    { name: 'Día de los Muertos', country: 'Mexico', flag: '🇲🇽', months: 'Oct–Nov', startMonth: 9, startDay: 31, description: 'Marigold-decked altars, painted skulls, and candlelit cemetery vigils honoring the departed in Oaxaca.', mapColor: 'bg-orange-100', durationDays: 4, blogSlugs: ['festival-travel-guide'] },
+    { name: 'Oktoberfest', country: 'Germany', flag: '🇩🇪', months: 'Sep–Oct', startMonth: 8, startDay: 20, description: 'Munich\'s legendary beer festival — lederhosen, brass bands, pretzels, and 6 million visitors.', mapColor: 'bg-amber-100', durationDays: 4, blogSlugs: ['festival-travel-guide', 'budget-travel-europe'] },
+    { name: 'Loy Krathong', country: 'Thailand', flag: '🇹🇭', months: 'Nov', startMonth: 10, startDay: 5, description: 'Thousands of floating lanterns and candle-lit lotus boats released on rivers and lakes across Thailand.', mapColor: 'bg-emerald-100', durationDays: 3 },
+    { name: 'Northern Lights Season', country: 'Norway / Iceland', flag: '🇳🇴', months: 'Sep–Mar', startMonth: 8, startDay: 15, description: 'Chase the aurora borealis from Tromsø fjords or Icelandic lava fields — best viewed on clear winter nights.', mapColor: 'bg-indigo-100', durationDays: 7 },
+    { name: 'La Tomatina', country: 'Spain', flag: '🇪🇸', months: 'Aug', startMonth: 7, startDay: 27, description: 'The world\'s largest tomato fight in Buñol — an hour of pure, pulpy chaos followed by paella.', mapColor: 'bg-red-100', durationDays: 2, blogSlugs: ['festival-travel-guide'] },
+    { name: 'Songkran Water Festival', country: 'Thailand', flag: '🇹🇭', months: 'Apr', startMonth: 3, startDay: 13, description: 'Thai New Year celebrated with city-wide water fights, temple visits, and street food marathons.', mapColor: 'bg-cyan-100', durationDays: 4 },
+    { name: 'Venice Carnival', country: 'Italy', flag: '🇮🇹', months: 'Feb', startMonth: 1, startDay: 8, description: 'Ornate masks, gondola parades, and grand masquerade balls in the floating city.', mapColor: 'bg-violet-100', durationDays: 5, blogSlugs: ['festival-travel-guide', 'budget-travel-europe'] },
+    { name: 'Running of the Bulls', country: 'Spain', flag: '🇪🇸', months: 'Jul', startMonth: 6, startDay: 6, description: 'San Fermín festival in Pamplona — encierro runs, parades, fireworks, and non-stop Basque celebrations.', mapColor: 'bg-red-100', durationDays: 9, blogSlugs: ['festival-travel-guide'] },
+    { name: 'Chinese New Year', country: 'China', flag: '🇨🇳', months: 'Jan–Feb', startMonth: 0, startDay: 29, description: 'Dragon dances, lantern displays, and spectacular fireworks across Beijing, Shanghai, and Hong Kong.', mapColor: 'bg-red-100', durationDays: 7 },
+    { name: 'Glastonbury Festival', country: 'United Kingdom', flag: '🇬🇧', months: 'Jun', startMonth: 5, startDay: 25, description: 'The world\'s most iconic music festival — five days of legendary performances on a Somerset farm.', mapColor: 'bg-lime-100', durationDays: 5 },
+    { name: 'Burning Man', country: 'USA', flag: '🇺🇸', months: 'Aug–Sep', startMonth: 7, startDay: 24, description: 'A temporary city in the Nevada desert — radical self-expression, art installations, and the burning of the Man.', mapColor: 'bg-orange-100', durationDays: 9 },
+    { name: 'Diwali', country: 'India', flag: '🇮🇳', months: 'Oct–Nov', startMonth: 9, startDay: 20, description: 'The festival of lights — fireworks, oil lamps, rangoli art, and sweet feasts illuminate India for five days.', mapColor: 'bg-amber-100', durationDays: 5, blogSlugs: ['festival-travel-guide'] },
+    { name: "St. Patrick's Day", country: 'Ireland', flag: '🇮🇪', months: 'Mar', startMonth: 2, startDay: 17, description: 'Dublin turns green — parades, live music, and the best pints of Guinness you\'ll ever have.', mapColor: 'bg-emerald-100', durationDays: 3 },
+    { name: 'Mardi Gras', country: 'USA', flag: '🇺🇸', months: 'Feb', startMonth: 1, startDay: 17, description: 'New Orleans erupts with jazz, floats, beads, and king cake — weeks of parades building to Fat Tuesday.', mapColor: 'bg-purple-100', durationDays: 14 },
+    { name: 'Lantern Festival', country: 'Taiwan', flag: '🇹🇼', months: 'Feb', startMonth: 1, startDay: 12, description: 'Thousands of sky lanterns released over Pingxi — a mesmerizing sea of light drifting into the night sky.', mapColor: 'bg-amber-100', durationDays: 3 },
+    { name: 'Inti Raymi', country: 'Peru', flag: '🇵🇪', months: 'Jun', startMonth: 5, startDay: 24, description: 'The Inca festival of the sun — a grand ceremony at Sacsayhuamán fortress above Cusco with music and dance.', mapColor: 'bg-yellow-100', durationDays: 3 },
+    { name: 'Edinburgh Fringe', country: 'United Kingdom', flag: '🏴󠁧󠁢󠁳󠁣󠁴󠁿', months: 'Aug', startMonth: 7, startDay: 1, description: 'The world\'s largest arts festival — thousands of shows from comedy to theatre across Edinburgh\'s venues.', mapColor: 'bg-violet-100', durationDays: 25 },
+];
+
+/* ── Weekend getaways ── */
+
+export const weekendGetaways: WeekendGetaway[] = [
+    { title: 'Barcelona Express', from: 'Anywhere in Europe', to: 'Barcelona, Spain', flag: '🇪🇸', durationDays: 3, description: 'Gaudí, tapas crawl through El Born, and sunset from Bunkers del Carmel.', mapColor: 'bg-orange-100', mapAccent: 'bg-orange-400', blogSlugs: ['weekend-getaway-tips'] },
+    { title: 'Prague Old Town', from: 'Central Europe', to: 'Prague, Czech Republic', flag: '🇨🇿', durationDays: 3, description: 'Charles Bridge at dawn, beer halls, and the astronomical clock — Europe\'s most photogenic city break.', mapColor: 'bg-amber-100', mapAccent: 'bg-amber-500', blogSlugs: ['weekend-getaway-tips', 'budget-travel-europe'] },
+    { title: 'Marrakech Medina', from: 'Europe / North Africa', to: 'Marrakech, Morocco', flag: '🇲🇦', durationDays: 3, description: 'Get lost in the souks, sip mint tea on a riad rooftop, and visit the Jardin Majorelle.', mapColor: 'bg-yellow-100', mapAccent: 'bg-yellow-500', blogSlugs: ['weekend-getaway-tips'] },
+    { title: 'Amsterdam Canals', from: 'Northern Europe', to: 'Amsterdam, Netherlands', flag: '🇳🇱', durationDays: 2, description: 'Bike the canal ring, Rijksmuseum, and Jordaan neighbourhood brunch spots.', mapColor: 'bg-sky-100', mapAccent: 'bg-sky-400', blogSlugs: ['weekend-getaway-tips'] },
+    { title: 'Edinburgh Highlands', from: 'UK / Ireland', to: 'Edinburgh, Scotland', flag: '🏴\u200d☠️', durationDays: 3, description: 'Arthur\'s Seat hike, whisky tasting on the Royal Mile, and a day trip into the Highlands.', mapColor: 'bg-emerald-100', mapAccent: 'bg-emerald-500', blogSlugs: ['weekend-getaway-tips'] },
+    { title: 'Istanbul Bosphorus', from: 'Europe / Middle East', to: 'Istanbul, Turkey', flag: '🇹🇷', durationDays: 3, description: 'Hagia Sophia, Grand Bazaar haggling, and ferry rides between two continents.', mapColor: 'bg-rose-100', mapAccent: 'bg-rose-400', blogSlugs: ['weekend-getaway-tips'] },
+];
+
+/* ── By country ── */
+
+export const countryGroups: CountryGroup[] = [
+    { country: 'Japan', flag: '🇯🇵', tripCount: 3, bestMonths: 'Mar–May, Oct–Nov', tags: ['Culture', 'Food', 'Nature'], blogSlugs: ['best-time-visit-japan'] },
+    { country: 'Italy', flag: '🇮🇹', tripCount: 3, bestMonths: 'Apr–Jun, Sep–Oct', tags: ['Food', 'Art', 'History'], blogSlugs: ['budget-travel-europe'] },
+    { country: 'Thailand', flag: '🇹🇭', tripCount: 2, bestMonths: 'Nov–Feb', tags: ['Beach', 'Food', 'Adventure'] },
+    { country: 'Portugal', flag: '🇵🇹', tripCount: 2, bestMonths: 'Mar–Jun, Sep–Oct', tags: ['Surf', 'Wine', 'City'], blogSlugs: ['budget-travel-europe'] },
+    { country: 'Peru', flag: '🇵🇪', tripCount: 1, bestMonths: 'May–Sep', tags: ['Adventure', 'History', 'Nature'] },
+    { country: 'Iceland', flag: '🇮🇸', tripCount: 2, bestMonths: 'Jun–Aug', tags: ['Nature', 'Road Trip', 'Photography'] },
+    { country: 'Morocco', flag: '🇲🇦', tripCount: 2, bestMonths: 'Mar–May, Sep–Nov', tags: ['Culture', 'Food', 'Desert'] },
+    { country: 'India', flag: '🇮🇳', tripCount: 2, bestMonths: 'Oct–Mar', tags: ['Culture', 'Photography', 'Food'] },
+    { country: 'Greece', flag: '🇬🇷', tripCount: 1, bestMonths: 'May–Jun, Sep–Oct', tags: ['Beach', 'Culture', 'Islands'], blogSlugs: ['budget-travel-europe'] },
+    { country: 'New Zealand', flag: '🇳🇿', tripCount: 1, bestMonths: 'Nov–Mar', tags: ['Nature', 'Hiking', 'Road Trip'] },
+    { country: 'Norway', flag: '🇳🇴', tripCount: 1, bestMonths: 'Jun–Aug, Sep–Mar (aurora)', tags: ['Nature', 'Photography', 'Fjords'] },
+    { country: 'Mexico', flag: '🇲🇽', tripCount: 2, bestMonths: 'Oct–Apr', tags: ['Food', 'Beach', 'Culture'] },
+];
+
+/* ── Quick starts ── */
+
+export const quickIdeas = [
+    { label: '🇯🇵 7 Days in Japan', dest: 'Japan', days: 7 },
+    { label: '🇮🇹 2 Weeks in Italy', dest: 'Italy', days: 14 },
+    { label: '🇹🇭 10 Days in Thailand', dest: 'Thailand', days: 10 },
+    { label: '🇮🇸 Iceland Ring Road', dest: 'Iceland', days: 7 },
+    { label: '🇵🇹 Portugal Road Trip', dest: 'Portugal', days: 10 },
+    { label: '🇬🇷 Greek Islands', dest: 'Greece', days: 10 },
+    { label: '🇲🇦 Morocco Discovery', dest: 'Morocco', days: 9 },
+    { label: '🇳🇿 NZ Adventure', dest: 'New Zealand', days: 21 },
+];
+
+/* ── Helpers ── */
+
+/** Returns all destinations across all categories. */
+export const getAllDestinations = (): (Destination & { categoryId: string })[] =>
+    categories.flatMap((cat) => cat.destinations.map((d) => ({ ...d, categoryId: cat.id })));

--- a/docs/UPDATE_FORMAT.md
+++ b/docs/UPDATE_FORMAT.md
@@ -23,10 +23,10 @@ summary: "One concise summary sentence."
 ---
 
 ## Changes
-- [x] [New feature] 🚀 User-facing highlight shown on the website updates page.
-- [x] [Improved] ✨ User-facing improvement shown on the website updates page.
-- [x] [Fixed] 🐛 User-facing fix shown on the website updates page.
-- [ ] [Internal] 🧰 Kept in markdown history, hidden from marketing website output.
+- [x] [New feature] 🗺️ Plan trips collaboratively with real-time shared cursors.
+- [x] [Improved] ⚡ Itinerary generation now completes 3x faster.
+- [x] [Fixed] 📍 Map markers no longer disappear after editing a city name.
+- [ ] [Internal] Migrated state management to Zustand.
 ```
 
 ## Field rules
@@ -44,12 +44,29 @@ summary: "One concise summary sentence."
 - `[x]`: visible on marketing website (`/updates`).
 - `[ ]`: hidden from marketing website but preserved in markdown history.
 - `Type` is used for visual pills (`New feature`, `Improved`, `Fixed`, `Internal`, etc.).
-- Message must start with an emoji:
-  - `New feature` → `🚀`
-  - `Improved` → `✨`
-  - `Fixed` → `🐛`
-  - `Internal` → `🧰`
-  - Other types → `📌`
+
+### Emoji guideline
+Each change line **must** start with a single emoji. Pick an emoji that **matches the specific content** of that line — do NOT use a fixed emoji per type. The emoji should visually hint at what the change is about.
+
+Good examples:
+- `- [x] [New feature] 🗺️ Interactive map now supports terrain and satellite layers.`
+- `- [x] [Improved] ⚡ Trip generation is 3x faster with streaming responses.`
+- `- [x] [Fixed] 📍 Fixed map markers disappearing after city rename.`
+- `- [x] [New feature] 🤝 Share trips with co-travelers via a single link.`
+
+Bad examples (do NOT do this):
+- `- [x] [New feature] 🚀 Added map layers.` (🚀 for everything — generic, says nothing)
+- `- [x] [Improved] ✨ Faster generation.` (✨ for every improvement — lazy)
+
+### Visibility guideline
+Only mark items as `[x]` (visible) when they communicate a **clear user benefit**. Ask: "Would a user care about this on a product changelog?"
+
+Mark as `[ ]` (hidden) when the item:
+- Is a technical implementation detail (e.g. dependency swaps, refactors, internal tooling).
+- Describes *how* something was built rather than *what changed* for the user.
+- Would require developer context to understand.
+
+Write visible items from the user's perspective — focus on the benefit, not the implementation.
 
 ## Recommended workflow (auto-deploy friendly)
 1. Use exactly one release note file per worktree/feature.

--- a/index.css
+++ b/index.css
@@ -72,3 +72,264 @@ h6,
   font-family: var(--tf-font-heading);
   letter-spacing: -0.015em;
 }
+
+/* ── Scroll-driven animations ── */
+
+@keyframes scroll-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(32px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes scroll-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes scroll-scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes scroll-blur-in {
+  from {
+    opacity: 0;
+    filter: blur(8px);
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+}
+
+@keyframes scroll-slide-left {
+  from {
+    opacity: 0;
+    transform: translateX(-48px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes scroll-slide-right {
+  from {
+    opacity: 0;
+    transform: translateX(48px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes hero-entrance {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes hand-drawn-zigzag {
+  from {
+    stroke-dashoffset: 360;
+    opacity: 0;
+  }
+  5% {
+    opacity: 1;
+  }
+  to {
+    stroke-dashoffset: 0;
+    opacity: 1;
+  }
+}
+
+.hand-drawn-zigzag {
+  stroke-dasharray: 360;
+  stroke-dashoffset: 360;
+  opacity: 0;
+  animation: hand-drawn-zigzag 1s cubic-bezier(0.25, 1, 0.5, 1) 0.9s forwards;
+}
+
+@keyframes marquee-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes float-gentle {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+@utility animate-scroll-fade-up {
+  animation: scroll-fade-up ease-out both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 35%;
+}
+
+@utility animate-scroll-fade-in {
+  animation: scroll-fade-in ease-out both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 35%;
+}
+
+@utility animate-scroll-scale-in {
+  animation: scroll-scale-in ease-out both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 35%;
+}
+
+@utility animate-scroll-blur-in {
+  animation: scroll-blur-in ease-out both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 40%;
+}
+
+@utility animate-scroll-slide-left {
+  animation: scroll-slide-left ease-out both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 35%;
+}
+
+@utility animate-scroll-slide-right {
+  animation: scroll-slide-right ease-out both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 35%;
+}
+
+@utility animate-hero-entrance {
+  animation: hero-entrance 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@utility animate-hero-stagger {
+  animation: hero-entrance 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: var(--stagger, 0ms);
+}
+
+@utility animate-marquee {
+  animation: marquee-scroll var(--marquee-duration, 40s) linear infinite;
+}
+
+@utility animate-float {
+  animation: float-gentle 3s ease-in-out infinite;
+  animation-delay: var(--float-delay, 0ms);
+}
+
+@keyframes content-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@utility animate-content-fade-in {
+  animation: content-fade-in 0.25s ease-out both;
+}
+
+@utility scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+/* ── Reading progress indicator (scroll-driven) ── */
+
+@keyframes reading-progress {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+.reading-progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--tf-accent-500);
+  transform-origin: 0 50%;
+  transform: scaleX(0);
+  animation: reading-progress linear both;
+  animation-timeline: scroll(root);
+  z-index: 9999;
+}
+
+@utility glass-card {
+  background: rgb(255 255 255 / 0.7);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgb(255 255 255 / 0.5);
+}
+
+/* ── View Transitions ── */
+
+@keyframes vt-slide-out {
+  to {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+}
+
+@keyframes vt-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.99);
+  }
+}
+
+::view-transition-old(root) {
+  animation: vt-slide-out 0.15s cubic-bezier(0.4, 0, 1, 1) both;
+}
+
+::view-transition-new(root) {
+  animation: vt-slide-in 0.2s cubic-bezier(0, 0, 0.2, 1) 0.08s both;
+}
+
+/* Keep the header static during transitions */
+::view-transition-group(site-header) {
+  animation: none;
+}
+
+::view-transition-old(site-header),
+::view-transition-new(site-header) {
+  animation: none;
+  mix-blend-mode: normal;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "latest",
+        "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-checkbox": "^1.2.3",
         "@supabase/supabase-js": "^2.49.1",
         "@types/google.maps": "^3.58.1",
@@ -842,6 +843,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
+      "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "dev": "vite",
     "updates:validate": "node scripts/validate-updates.mjs",
-    "build": "npm run updates:validate && vite build",
+    "blog:validate": "node scripts/validate-blog.mjs",
+    "build": "npm run updates:validate && npm run blog:validate && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
     "@google/genai": "latest",
+    "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-checkbox": "^1.2.3",
     "@supabase/supabase-js": "^2.49.1",
     "@types/google.maps": "^3.58.1",

--- a/pages/BlogPage.tsx
+++ b/pages/BlogPage.tsx
@@ -1,14 +1,197 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { Article, Clock, Tag, ArrowRight, MagnifyingGlass } from '@phosphor-icons/react';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
-import { WipPlaceholder } from '../components/marketing/WipPlaceholder';
+import { getPublishedBlogPosts } from '../services/blogService';
+import type { BlogPost } from '../services/blogService';
+
+const BlogCard: React.FC<{ post: BlogPost }> = ({ post }) => {
+    const formattedDate = new Date(post.publishedAt).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    });
+
+    return (
+        <Link
+            to={`/blog/${post.slug}`}
+            className="group flex flex-col rounded-2xl border border-slate-200 bg-white shadow-sm transition-all hover:shadow-lg hover:-translate-y-1"
+        >
+            <div className={`relative h-32 rounded-t-2xl ${post.coverColor} overflow-hidden flex items-center justify-center`}>
+                <Article size={36} weight="duotone" className="text-slate-400/40" />
+            </div>
+            <div className="flex flex-1 flex-col p-5">
+                <h3 className="text-base font-bold text-slate-900 group-hover:text-accent-700 transition-colors line-clamp-2">
+                    {post.title}
+                </h3>
+                <p className="mt-2 flex-1 text-sm leading-relaxed text-slate-500 line-clamp-3">
+                    {post.summary}
+                </p>
+                <div className="mt-3 flex items-center gap-3 text-xs text-slate-400">
+                    <span className="inline-flex items-center gap-1">
+                        <Clock size={13} weight="duotone" className="text-accent-400" />
+                        {post.readingTimeMin} min read
+                    </span>
+                    <span>{formattedDate}</span>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                    {post.tags.map((tag) => (
+                        <span
+                            key={tag}
+                            className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-500"
+                        >
+                            {tag}
+                        </span>
+                    ))}
+                </div>
+            </div>
+        </Link>
+    );
+};
 
 export const BlogPage: React.FC = () => {
+    const posts = useMemo(() => getPublishedBlogPosts(), []);
+    const [selectedTag, setSelectedTag] = useState<string | null>(null);
+    const [search, setSearch] = useState('');
+
+    const allTags = useMemo(() => {
+        const tagSet = new Set<string>();
+        for (const post of posts) {
+            for (const tag of post.tags) {
+                tagSet.add(tag);
+            }
+        }
+        return Array.from(tagSet).sort();
+    }, [posts]);
+
+    const filteredPosts = useMemo(() => {
+        let result = posts;
+        if (selectedTag) {
+            result = result.filter((post) => post.tags.includes(selectedTag));
+        }
+        if (search.trim()) {
+            const q = search.toLowerCase();
+            result = result.filter(
+                (post) =>
+                    post.title.toLowerCase().includes(q) ||
+                    post.summary.toLowerCase().includes(q) ||
+                    post.tags.some((t) => t.toLowerCase().includes(q))
+            );
+        }
+        return result;
+    }, [posts, selectedTag, search]);
+
+    const isSearching = search.trim().length > 0;
+
     return (
         <MarketingLayout>
-            <WipPlaceholder
-                title="Blog"
-                description="The blog section is scaffolded and will host long-form travel planning content, product deep dives, and launch stories."
-            />
+            {/* Hero */}
+            <section className="pt-8 pb-8 md:pt-14 md:pb-12 animate-hero-entrance">
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700">
+                    <Article size={14} weight="duotone" />
+                    Blog
+                </span>
+                <h1
+                    className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl"
+                    style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                >
+                    Travel Planning Insights
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
+                    Guides, tips, and deep-dives to help you plan smarter trips — from weekend getaways to multi-city adventures.
+                </p>
+            </section>
+
+            {/* Search */}
+            <section className="pb-4 animate-hero-stagger" style={{ '--stagger': '100ms' } as React.CSSProperties}>
+                <div className="relative max-w-xl">
+                    <MagnifyingGlass size={18} weight="duotone" className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+                    <input
+                        type="text"
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        placeholder="Search articles…"
+                        className="w-full rounded-xl border border-slate-200 bg-white py-3 pl-10 pr-4 text-sm text-slate-800 shadow-sm placeholder:text-slate-400 focus:border-accent-400 focus:outline-none focus:ring-2 focus:ring-accent-200 transition-shadow"
+                    />
+                    {isSearching && (
+                        <span className="absolute right-3.5 top-1/2 -translate-y-1/2 rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-500">
+                            {filteredPosts.length} result{filteredPosts.length !== 1 ? 's' : ''}
+                        </span>
+                    )}
+                </div>
+            </section>
+
+            {/* Tag filter */}
+            <section className="pb-8 animate-hero-stagger" style={{ '--stagger': '160ms' } as React.CSSProperties}>
+                <div className="flex flex-wrap gap-2">
+                    <button
+                        onClick={() => setSelectedTag(null)}
+                        className={`rounded-full px-3.5 py-1.5 text-sm font-medium shadow-sm transition-all ${
+                            selectedTag === null
+                                ? 'bg-accent-100 text-accent-800 ring-2 ring-accent-300'
+                                : 'bg-white border border-slate-200 text-slate-600 hover:border-accent-300 hover:text-accent-700'
+                        }`}
+                    >
+                        All
+                    </button>
+                    {allTags.map((tag) => (
+                        <button
+                            key={tag}
+                            onClick={() => setSelectedTag(tag === selectedTag ? null : tag)}
+                            className={`inline-flex items-center gap-1 rounded-full px-3.5 py-1.5 text-sm font-medium shadow-sm transition-all ${
+                                selectedTag === tag
+                                    ? 'bg-accent-100 text-accent-800 ring-2 ring-accent-300'
+                                    : 'bg-white border border-slate-200 text-slate-600 hover:border-accent-300 hover:text-accent-700'
+                            }`}
+                        >
+                            <Tag size={12} weight="duotone" />
+                            {tag}
+                        </button>
+                    ))}
+                </div>
+            </section>
+
+            {/* Cards grid */}
+            <section className="pb-16 md:pb-24">
+                {filteredPosts.length === 0 ? (
+                    <p className="text-sm text-slate-400">
+                        {isSearching
+                            ? <>No articles found for &ldquo;{search}&rdquo;. Try a different keyword.</>
+                            : 'No posts found for this tag.'}
+                    </p>
+                ) : (
+                    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                        {filteredPosts.map((post) => (
+                            <div key={post.slug} className="animate-scroll-fade-up">
+                                <BlogCard post={post} />
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </section>
+
+            {/* Bottom CTA */}
+            <section className="pb-16 md:pb-24 animate-scroll-scale-in">
+                <div className="relative rounded-3xl bg-gradient-to-br from-accent-600 to-accent-800 px-8 py-14 text-center md:px-16 md:py-20 overflow-hidden">
+                    <div className="pointer-events-none absolute -top-20 -right-20 h-60 w-60 rounded-full bg-white/10 blur-[60px]" />
+                    <h2
+                        className="relative text-3xl font-black tracking-tight text-white md:text-5xl"
+                        style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                    >
+                        Ready to plan your trip?
+                    </h2>
+                    <p className="relative mx-auto mt-4 max-w-xl text-base text-accent-100 md:text-lg">
+                        Turn these ideas into a real itinerary. Our AI builds your day-by-day plan in seconds.
+                    </p>
+                    <Link
+                        to="/create-trip"
+                        className="relative mt-8 inline-flex items-center gap-2 rounded-2xl bg-white px-8 py-3.5 text-base font-bold text-accent-700 shadow-lg transition-all hover:shadow-xl hover:bg-accent-50 hover:scale-[1.03] active:scale-[0.98]"
+                    >
+                        Start Planning
+                        <ArrowRight size={18} weight="bold" />
+                    </Link>
+                </div>
+            </section>
         </MarketingLayout>
     );
 };

--- a/pages/BlogPostPage.tsx
+++ b/pages/BlogPostPage.tsx
@@ -1,0 +1,390 @@
+import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { ArrowLeft, Clock, User, Tag, ArrowRight, Compass, Article } from '@phosphor-icons/react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { MarketingLayout } from '../components/marketing/MarketingLayout';
+import { getBlogPostBySlug, getPublishedBlogPosts } from '../services/blogService';
+import type { Components } from 'react-markdown';
+
+/** Convert heading text to a URL-safe slug */
+const toSlug = (text: string): string =>
+    text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '');
+
+const markdownComponents: Components = {
+    h2: ({ children }) => {
+        const text = typeof children === 'string' ? children : String(children);
+        const id = toSlug(text);
+        return (
+            <h2
+                id={id}
+                className="mt-10 mb-4 text-2xl font-black tracking-tight text-slate-900 scroll-mt-24"
+                style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+            >
+                {children}
+            </h2>
+        );
+    },
+    h3: ({ children }) => (
+        <h3 className="mt-8 mb-3 text-xl font-bold text-slate-800" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>
+            {children}
+        </h3>
+    ),
+    p: ({ children }) => (
+        <p className="mb-4 text-base leading-relaxed text-slate-600">{children}</p>
+    ),
+    a: ({ href, children }) => (
+        <a href={href} className="text-accent-600 underline decoration-accent-300 hover:text-accent-800 transition-colors" target="_blank" rel="noopener noreferrer">
+            {children}
+        </a>
+    ),
+    ul: ({ children }) => (
+        <ul className="mb-4 ml-6 list-disc space-y-1.5 text-base leading-relaxed text-slate-600">{children}</ul>
+    ),
+    ol: ({ children }) => (
+        <ol className="mb-4 ml-6 list-decimal space-y-1.5 text-base leading-relaxed text-slate-600">{children}</ol>
+    ),
+    li: ({ children }) => <li>{children}</li>,
+    code: ({ children, className }) => {
+        const isInline = !className;
+        if (isInline) {
+            return <code className="rounded bg-slate-100 px-1.5 py-0.5 text-sm font-mono text-slate-700">{children}</code>;
+        }
+        return (
+            <code className={`block overflow-x-auto rounded-xl bg-slate-900 p-4 text-sm font-mono text-slate-200 ${className}`}>
+                {children}
+            </code>
+        );
+    },
+    blockquote: ({ children }) => (
+        <blockquote className="mb-4 border-l-4 border-accent-300 pl-4 italic text-slate-500">{children}</blockquote>
+    ),
+    table: ({ children }) => (
+        <div className="mb-4 overflow-x-auto">
+            <table className="w-full text-sm text-left border-collapse">
+                {children}
+            </table>
+        </div>
+    ),
+    thead: ({ children }) => (
+        <thead className="bg-slate-50 text-xs font-bold uppercase tracking-wider text-slate-500">
+            {children}
+        </thead>
+    ),
+    th: ({ children }) => (
+        <th className="px-4 py-2.5 border-b border-slate-200">{children}</th>
+    ),
+    td: ({ children }) => (
+        <td className="px-4 py-2.5 border-b border-slate-100 text-slate-600">{children}</td>
+    ),
+    hr: () => <hr className="my-8 border-slate-200" />,
+};
+
+interface HeadingInfo {
+    text: string;
+    slug: string;
+}
+
+/** Extract h2 headings from markdown for TOC */
+const extractHeadings = (content: string): HeadingInfo[] => {
+    const lines = content.split('\n');
+    const headings: HeadingInfo[] = [];
+    for (const line of lines) {
+        const match = line.match(/^##\s+(.+)$/);
+        if (match) {
+            const text = match[1].trim();
+            headings.push({ text, slug: toSlug(text) });
+        }
+    }
+    return headings;
+};
+
+/** Hook: track which heading is currently visible */
+const useActiveHeading = (headingSlugs: string[]): string | null => {
+    const [activeId, setActiveId] = useState<string | null>(null);
+    const observerRef = useRef<IntersectionObserver | null>(null);
+
+    const handleIntersect = useCallback((entries: IntersectionObserverEntry[]) => {
+        // Find the topmost visible heading
+        const visible = entries
+            .filter((e) => e.isIntersecting)
+            .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+
+        if (visible.length > 0) {
+            setActiveId(visible[0].target.id);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (headingSlugs.length === 0) return;
+
+        observerRef.current = new IntersectionObserver(handleIntersect, {
+            rootMargin: '-80px 0px -60% 0px',
+            threshold: 0,
+        });
+
+        for (const slug of headingSlugs) {
+            const el = document.getElementById(slug);
+            if (el) observerRef.current.observe(el);
+        }
+
+        return () => {
+            observerRef.current?.disconnect();
+        };
+    }, [headingSlugs, handleIntersect]);
+
+    return activeId;
+};
+
+export const BlogPostPage: React.FC = () => {
+    const { slug } = useParams<{ slug: string }>();
+    const post = useMemo(() => (slug ? getBlogPostBySlug(slug) : undefined), [slug]);
+
+    const relatedPosts = useMemo(() => {
+        if (!post) return [];
+        const allPosts = getPublishedBlogPosts();
+        const postTags = new Set(post.tags);
+        return allPosts
+            .filter((p) => p.slug !== post.slug && p.tags.some((t) => postTags.has(t)))
+            .slice(0, 3);
+    }, [post]);
+
+    const headings = useMemo(() => (post ? extractHeadings(post.content) : []), [post]);
+    const headingSlugs = useMemo(() => headings.map((h) => h.slug), [headings]);
+    const activeHeadingId = useActiveHeading(headingSlugs);
+
+    if (!post) {
+        return (
+            <MarketingLayout>
+                <section className="py-20 text-center">
+                    <h1 className="text-3xl font-black text-slate-900" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>
+                        Post not found
+                    </h1>
+                    <p className="mt-4 text-slate-500">The blog post you're looking for doesn't exist.</p>
+                    <Link
+                        to="/blog"
+                        className="mt-6 inline-flex items-center gap-2 rounded-xl bg-accent-600 px-6 py-3 text-sm font-bold text-white shadow-lg transition-all hover:bg-accent-700"
+                    >
+                        <ArrowLeft size={16} weight="bold" />
+                        Back to Blog
+                    </Link>
+                </section>
+            </MarketingLayout>
+        );
+    }
+
+    const formattedDate = new Date(post.publishedAt).toLocaleDateString('en-US', {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+    });
+
+    return (
+        <MarketingLayout>
+            {/* Reading progress bar — pure CSS scroll-driven */}
+            <div className="reading-progress-bar" />
+
+            <article className="pb-16 md:pb-24">
+                {/* Back link */}
+                <div className="pt-6 pb-4">
+                    <Link
+                        to="/blog"
+                        className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-accent-700 transition-colors"
+                    >
+                        <ArrowLeft size={14} weight="bold" />
+                        Back to Blog
+                    </Link>
+                </div>
+
+                {/* Cover banner */}
+                <div className={`rounded-2xl ${post.coverColor} h-32 md:h-40 mb-8`} />
+
+                {/* Two-column layout: content + sidebar */}
+                <div className="flex gap-10 lg:gap-14">
+                    {/* Main content */}
+                    <div className="min-w-0 flex-1 max-w-3xl">
+                        {/* Title */}
+                        <h1
+                            className="text-3xl font-black tracking-tight text-slate-900 md:text-5xl"
+                            style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                        >
+                            {post.title}
+                        </h1>
+
+                        {/* Meta row */}
+                        <div className="mt-5 flex flex-wrap items-center gap-4 text-sm text-slate-500">
+                            <span className="inline-flex items-center gap-1.5">
+                                <User size={14} weight="duotone" className="text-accent-400" />
+                                {post.author}
+                            </span>
+                            <span>{formattedDate}</span>
+                            <span className="inline-flex items-center gap-1.5">
+                                <Clock size={14} weight="duotone" className="text-accent-400" />
+                                {post.readingTimeMin} min read
+                            </span>
+                        </div>
+
+                        {/* Tags */}
+                        <div className="mt-4 flex flex-wrap gap-1.5">
+                            {post.tags.map((tag) => (
+                                <Link
+                                    key={tag}
+                                    to="/blog"
+                                    className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-500 hover:bg-slate-200 transition-colors"
+                                >
+                                    <Tag size={10} weight="duotone" />
+                                    {tag}
+                                </Link>
+                            ))}
+                        </div>
+
+                        {/* Summary */}
+                        <p className="mt-6 text-lg leading-relaxed text-slate-600 border-l-4 border-accent-200 pl-4">
+                            {post.summary}
+                        </p>
+
+                        {/* Body */}
+                        <div className="mt-10">
+                            <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                                {post.content}
+                            </ReactMarkdown>
+                        </div>
+                    </div>
+
+                    {/* Sidebar (hidden on mobile) */}
+                    <aside className="hidden lg:block w-64 shrink-0">
+                        <div className="sticky top-24 space-y-8">
+                            {/* In this article — styled TOC */}
+                            {headings.length > 0 && (
+                                <nav>
+                                    <h4 className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-3">In this article</h4>
+                                    <ul className="relative border-l border-slate-200">
+                                        {headings.map((heading) => {
+                                            const isActive = activeHeadingId === heading.slug;
+                                            return (
+                                                <li key={heading.slug} className="relative">
+                                                    {/* Active indicator bar */}
+                                                    <div
+                                                        className={`absolute -left-px top-0 h-full w-0.5 rounded-full transition-colors duration-200 ${
+                                                            isActive ? 'bg-accent-500' : 'bg-transparent'
+                                                        }`}
+                                                    />
+                                                    <a
+                                                        href={`#${heading.slug}`}
+                                                        className={`block py-1.5 pl-4 text-[13px] leading-snug transition-colors duration-200 ${
+                                                            isActive
+                                                                ? 'font-semibold text-accent-700'
+                                                                : 'text-slate-500 hover:text-slate-800'
+                                                        }`}
+                                                    >
+                                                        {heading.text}
+                                                    </a>
+                                                </li>
+                                            );
+                                        })}
+                                    </ul>
+                                </nav>
+                            )}
+
+                            {/* Related articles */}
+                            {relatedPosts.length > 0 && (
+                                <div>
+                                    <h4 className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-3">Related</h4>
+                                    <ul className="space-y-3">
+                                        {relatedPosts.map((related) => (
+                                            <li key={related.slug}>
+                                                <Link
+                                                    to={`/blog/${related.slug}`}
+                                                    className="group flex items-start gap-2"
+                                                >
+                                                    <div className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md ${related.coverColor}`}>
+                                                        <Article size={12} weight="duotone" className="text-slate-400" />
+                                                    </div>
+                                                    <div className="min-w-0">
+                                                        <p className="text-sm font-medium text-slate-700 group-hover:text-accent-700 transition-colors line-clamp-2 leading-snug">
+                                                            {related.title}
+                                                        </p>
+                                                        <p className="mt-0.5 text-xs text-slate-400">{related.readingTimeMin} min</p>
+                                                    </div>
+                                                </Link>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
+
+                            {/* CTA */}
+                            <div className="rounded-2xl border border-slate-200 bg-gradient-to-br from-accent-50 to-white p-5">
+                                <div className="flex items-center gap-2 mb-2">
+                                    <Compass size={18} weight="duotone" className="text-accent-500" />
+                                    <h4 className="text-sm font-bold text-slate-900">Plan your trip</h4>
+                                </div>
+                                <p className="text-xs leading-relaxed text-slate-500 mb-3">
+                                    Turn what you've read into a real itinerary — AI-powered, day by day.
+                                </p>
+                                <Link
+                                    to="/create-trip"
+                                    className="inline-flex items-center gap-1.5 rounded-xl bg-accent-600 px-4 py-2 text-xs font-bold text-white shadow-sm transition-all hover:bg-accent-700 hover:shadow-md"
+                                >
+                                    Start Planning
+                                    <ArrowRight size={12} weight="bold" />
+                                </Link>
+                            </div>
+
+                            {/* Browse more */}
+                            <div>
+                                <h4 className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-3">Explore</h4>
+                                <div className="space-y-2">
+                                    <Link to="/blog" className="flex items-center gap-2 text-sm text-slate-600 hover:text-accent-700 transition-colors">
+                                        <Article size={14} weight="duotone" className="text-slate-400" />
+                                        All articles
+                                    </Link>
+                                    <Link to="/inspirations" className="flex items-center gap-2 text-sm text-slate-600 hover:text-accent-700 transition-colors">
+                                        <Compass size={14} weight="duotone" className="text-slate-400" />
+                                        Trip inspirations
+                                    </Link>
+                                </div>
+                            </div>
+                        </div>
+                    </aside>
+                </div>
+
+                {/* Related posts — mobile (below content, visible on small screens) */}
+                {relatedPosts.length > 0 && (
+                    <div className="mt-16 border-t border-slate-200 pt-10 lg:hidden">
+                        <h2
+                            className="text-xl font-black tracking-tight text-slate-900"
+                            style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                        >
+                            Related Articles
+                        </h2>
+                        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                            {relatedPosts.map((related) => (
+                                <Link
+                                    key={related.slug}
+                                    to={`/blog/${related.slug}`}
+                                    className="group flex items-start gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5"
+                                >
+                                    <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${related.coverColor}`}>
+                                        <ArrowRight size={16} weight="bold" className="text-slate-400 group-hover:text-accent-600 transition-colors" />
+                                    </div>
+                                    <div className="min-w-0 flex-1">
+                                        <h3 className="text-sm font-bold text-slate-900 group-hover:text-accent-700 transition-colors line-clamp-2">
+                                            {related.title}
+                                        </h3>
+                                        <p className="mt-1 text-xs text-slate-400">
+                                            {related.readingTimeMin} min read
+                                        </p>
+                                    </div>
+                                </Link>
+                            ))}
+                        </div>
+                    </div>
+                )}
+            </article>
+        </MarketingLayout>
+    );
+};

--- a/pages/FeaturesPage.tsx
+++ b/pages/FeaturesPage.tsx
@@ -1,14 +1,254 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+    Sparkle,
+    MapTrifold,
+    SlidersHorizontal,
+    UsersThree,
+    ShareNetwork,
+    LinkSimple,
+    Timer,
+    DeviceMobile,
+    Printer,
+    Globe,
+    ArrowsClockwise,
+    ShieldCheck,
+} from '@phosphor-icons/react';
+import type { Icon } from '@phosphor-icons/react';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
-import { WipPlaceholder } from '../components/marketing/WipPlaceholder';
+
+interface Feature {
+    icon: Icon;
+    title: string;
+    description: string;
+    color: string;
+}
+
+const heroFeatures: Feature[] = [
+    {
+        icon: Sparkle,
+        title: 'AI Trip Generation',
+        description:
+            'Describe where you want to go and TravelFlow creates a full itinerary — optimized routes, curated activities, realistic timing — in under 30 seconds. Classic, Wizard, or Surprise Me modes adapt to how you like to plan.',
+        color: 'bg-violet-50 text-violet-600 ring-violet-100',
+    },
+    {
+        icon: MapTrifold,
+        title: 'Interactive Map & Timeline',
+        description:
+            'Your trip lives on a real map with animated route lines, city markers, and dynamic zoom. Below the map, a visual timeline shows every day at a glance. Switch between satellite, terrain, and minimalist styles.',
+        color: 'bg-sky-50 text-sky-600 ring-sky-100',
+    },
+    {
+        icon: SlidersHorizontal,
+        title: 'Drag-and-Drop Editing',
+        description:
+            'Reorder cities, stretch stay durations, and insert spontaneous stops — all by dragging on the timeline. Dates, connections, and the map update automatically so everything stays in sync.',
+        color: 'bg-amber-50 text-amber-600 ring-amber-100',
+    },
+];
+
+const secondaryFeatures: { icon: Icon; title: string; description: string }[] = [
+    {
+        icon: ShareNetwork,
+        title: 'One-Click Sharing',
+        description: 'Generate a link and send it to your travel crew. They see the full map, timeline, and activities — no account needed.',
+    },
+    {
+        icon: UsersThree,
+        title: 'Community Inspirations',
+        description: 'Browse curated trips from travelers worldwide. Fork any itinerary as a starting point and make it your own.',
+    },
+    {
+        icon: LinkSimple,
+        title: 'Booking Links',
+        description: 'Every AI-suggested activity links to booking platforms — tours, restaurants, transport — so you can reserve without leaving TravelFlow.',
+    },
+    {
+        icon: Timer,
+        title: 'Smart Duration Hints',
+        description: 'TravelFlow analyzes seasonal data and travel distances to suggest how long to spend in each city so you never feel rushed.',
+    },
+    {
+        icon: DeviceMobile,
+        title: 'Mobile-Optimized',
+        description: 'Plan on the go with a responsive layout tuned for phones and tablets. The map, timeline, and editing all adapt to smaller screens.',
+    },
+    {
+        icon: Printer,
+        title: 'Print-Ready Itineraries',
+        description: 'Switch to print view for a clean, paper-friendly itinerary with day headers, activity lists, and essential logistics.',
+    },
+    {
+        icon: Globe,
+        title: 'Multi-Country Routing',
+        description: 'Select multiple countries or islands and TravelFlow builds a cross-border route with realistic transit between regions.',
+    },
+    {
+        icon: ArrowsClockwise,
+        title: 'Version History',
+        description: 'Every meaningful change creates a snapshot. Jump back to any previous version of your trip with a single click.',
+    },
+    {
+        icon: ShieldCheck,
+        title: 'Privacy-First',
+        description: 'Your trips stay local by default. Optional cloud sync is consent-gated, and analytics only run after explicit opt-in.',
+    },
+];
+
+const comparisonRows = [
+    { feature: 'AI-generated itinerary', travelflow: true, spreadsheet: false, other: 'Partial' },
+    { feature: 'Interactive map', travelflow: true, spreadsheet: false, other: true },
+    { feature: 'Drag-and-drop timeline', travelflow: true, spreadsheet: false, other: false },
+    { feature: 'One-click sharing', travelflow: true, spreadsheet: 'Manual', other: true },
+    { feature: 'Booking links', travelflow: true, spreadsheet: false, other: 'Partial' },
+    { feature: 'Offline-first / local data', travelflow: true, spreadsheet: false, other: false },
+    { feature: 'Free to use', travelflow: true, spreadsheet: true, other: 'Freemium' },
+];
+
+const ComparisonCell: React.FC<{ value: boolean | string }> = ({ value }) => {
+    if (value === true) return <span className="text-emerald-600 font-bold">Yes</span>;
+    if (value === false) return <span className="text-slate-300">—</span>;
+    return <span className="text-amber-600 text-xs font-medium">{value}</span>;
+};
 
 export const FeaturesPage: React.FC = () => {
     return (
         <MarketingLayout>
-            <WipPlaceholder
-                title="Features"
-                description="This will become the detailed product capability page. For now, use the home page and updates page for the latest feature highlights."
-            />
+            {/* ── Hero ── */}
+            <section className="pt-8 pb-16 md:pt-14 md:pb-24 animate-hero-entrance">
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700">
+                    Product Capabilities
+                </span>
+                <h1 className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>
+                    Plan smarter, travel better
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
+                    TravelFlow combines AI generation, visual editing, and collaboration into one workspace. Here is everything the platform can do for your next trip.
+                </p>
+            </section>
+
+            {/* ── Three hero feature cards ── */}
+            <section className="grid gap-6 md:grid-cols-3 pb-20">
+                {heroFeatures.map((feature, index) => {
+                    const IconComponent = feature.icon;
+                    return (
+                        <article
+                            key={feature.title}
+                            className="animate-scroll-blur-in rounded-3xl border border-slate-200 bg-white p-7 shadow-sm transition-all hover:shadow-lg hover:-translate-y-1"
+                            style={{ animationDelay: `${index * 80}ms` }}
+                        >
+                            <div className={`inline-flex h-12 w-12 items-center justify-center rounded-2xl ring-1 ${feature.color}`}>
+                                <IconComponent size={24} weight="duotone" />
+                            </div>
+                            <h2 className="mt-5 text-lg font-bold text-slate-900">{feature.title}</h2>
+                            <p className="mt-2 text-sm leading-relaxed text-slate-600">{feature.description}</p>
+                        </article>
+                    );
+                })}
+            </section>
+
+            {/* ── Visual break: workflow steps ── */}
+            <section className="py-16 md:py-24 border-t border-slate-200">
+                <div className="animate-scroll-blur-in text-center">
+                    <h2 className="text-3xl font-black tracking-tight text-slate-900 md:text-4xl">How it works</h2>
+                    <p className="mx-auto mt-3 max-w-lg text-base text-slate-600">From idea to itinerary in three steps.</p>
+                </div>
+
+                <div className="mt-14 grid gap-8 md:grid-cols-3">
+                    {[
+                        { step: '01', title: 'Choose your destination', description: 'Pick countries, islands, or let Surprise Me suggest the perfect match for your travel window.' },
+                        { step: '02', title: 'Generate with AI', description: 'Our model drafts a full route with city timing, activities, and logistics. Tweak the result in seconds.' },
+                        { step: '03', title: 'Refine & share', description: 'Drag cities, adjust durations, add notes. Then share a link — your crew sees the live map and timeline.' },
+                    ].map((item, index) => (
+                        <div key={item.step} className="animate-scroll-fade-up text-center" style={{ animationDelay: `${index * 100}ms` }}>
+                            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-accent-600 text-white text-lg font-black">
+                                {item.step}
+                            </div>
+                            <h3 className="mt-4 text-base font-bold text-slate-900">{item.title}</h3>
+                            <p className="mt-2 text-sm leading-relaxed text-slate-500">{item.description}</p>
+                        </div>
+                    ))}
+                </div>
+            </section>
+
+            {/* ── Secondary feature grid ── */}
+            <section className="py-16 md:py-24 border-t border-slate-200">
+                <div className="animate-scroll-blur-in">
+                    <h2 className="text-3xl font-black tracking-tight text-slate-900 md:text-4xl">And so much more</h2>
+                    <p className="mt-3 max-w-xl text-base text-slate-600">Every detail is designed to remove friction from trip planning.</p>
+                </div>
+
+                <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                    {secondaryFeatures.map((feature) => {
+                        const IconComponent = feature.icon;
+                        return (
+                            <div
+                                key={feature.title}
+                                className="animate-scroll-fade-up rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition-all hover:shadow-md"
+                            >
+                                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent-50 text-accent-600">
+                                    <IconComponent size={22} weight="duotone" />
+                                </div>
+                                <h3 className="mt-4 text-sm font-bold text-slate-900">{feature.title}</h3>
+                                <p className="mt-1.5 text-sm leading-relaxed text-slate-500">{feature.description}</p>
+                            </div>
+                        );
+                    })}
+                </div>
+            </section>
+
+            {/* ── Comparison table ── */}
+            <section className="py-16 md:py-24 border-t border-slate-200">
+                <div className="animate-scroll-blur-in">
+                    <h2 className="text-3xl font-black tracking-tight text-slate-900 md:text-4xl">How TravelFlow compares</h2>
+                    <p className="mt-3 max-w-xl text-base text-slate-600">Side-by-side against spreadsheet planning and other trip tools.</p>
+                </div>
+
+                <div className="mt-10 overflow-x-auto animate-scroll-fade-up">
+                    <table className="w-full min-w-[540px] text-sm">
+                        <thead>
+                            <tr className="border-b border-slate-200 text-left">
+                                <th className="py-3 pr-4 font-semibold text-slate-500">Feature</th>
+                                <th className="py-3 px-4 font-bold text-accent-700">TravelFlow</th>
+                                <th className="py-3 px-4 font-semibold text-slate-500">Spreadsheet</th>
+                                <th className="py-3 px-4 font-semibold text-slate-500">Other Tools</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {comparisonRows.map((row) => (
+                                <tr key={row.feature} className="border-b border-slate-100">
+                                    <td className="py-3 pr-4 text-slate-700">{row.feature}</td>
+                                    <td className="py-3 px-4"><ComparisonCell value={row.travelflow} /></td>
+                                    <td className="py-3 px-4"><ComparisonCell value={row.spreadsheet} /></td>
+                                    <td className="py-3 px-4"><ComparisonCell value={row.other} /></td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            {/* ── Bottom CTA ── */}
+            <section className="pb-16 md:pb-24 animate-scroll-scale-in">
+                <div className="relative rounded-3xl bg-gradient-to-br from-accent-600 to-accent-800 px-8 py-14 text-center md:px-16 md:py-20 overflow-hidden">
+                    <div className="pointer-events-none absolute -top-20 -right-20 h-60 w-60 rounded-full bg-white/10 blur-[60px]" />
+                    <div className="pointer-events-none absolute -bottom-16 -left-16 h-48 w-48 rounded-full bg-accent-400/20 blur-[50px]" />
+
+                    <h2 className="relative text-3xl font-black tracking-tight text-white md:text-5xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>
+                        See it in action
+                    </h2>
+                    <p className="relative mx-auto mt-4 max-w-xl text-base text-accent-100 md:text-lg">
+                        Create your first AI-powered itinerary in under a minute.
+                    </p>
+                    <Link
+                        to="/create-trip"
+                        className="relative mt-8 inline-block rounded-2xl bg-white px-8 py-3.5 text-base font-bold text-accent-700 shadow-lg transition-all hover:shadow-xl hover:bg-accent-50 hover:scale-[1.03] active:scale-[0.98]"
+                    >
+                        Start Planning — Free
+                    </Link>
+                </div>
+            </section>
         </MarketingLayout>
     );
 };

--- a/pages/InspirationsPage.tsx
+++ b/pages/InspirationsPage.tsx
@@ -1,0 +1,605 @@
+import React, { useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import {
+    Backpack,
+    Clock,
+    MapPin,
+    MagnifyingGlass,
+    CalendarDots,
+    Globe,
+    Confetti,
+    Lightning,
+    Compass,
+    AirplaneTakeoff,
+    ArrowRight,
+    Article,
+} from '@phosphor-icons/react';
+import { MarketingLayout } from '../components/marketing/MarketingLayout';
+import {
+    categories,
+    monthEntries,
+    festivalEvents,
+    weekendGetaways,
+    countryGroups,
+    quickIdeas,
+    getAllDestinations,
+} from '../data/inspirationsData';
+import type { Destination, FestivalEvent as FestivalEventType, WeekendGetaway as WeekendGetawayType, CountryGroup } from '../data/inspirationsData';
+import { getBlogPostsBySlugs } from '../services/blogService';
+
+/* ── Festival date helpers ── */
+
+const getNextOccurrence = (festival: FestivalEventType, now: Date): Date => {
+    const currentYear = now.getFullYear();
+    const thisYear = new Date(currentYear, festival.startMonth, festival.startDay);
+    // If the festival end date (start + duration) is still in the future, use this year
+    const endThisYear = new Date(thisYear.getTime() + festival.durationDays * 86400000);
+    if (endThisYear >= now) {
+        return thisYear;
+    }
+    return new Date(currentYear + 1, festival.startMonth, festival.startDay);
+};
+
+const formatFestivalDate = (date: Date): string => {
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+};
+
+/* ── Blog link helper ── */
+
+const BlogLinks: React.FC<{ slugs?: string[] }> = ({ slugs }) => {
+    const posts = useMemo(() => getBlogPostsBySlugs(slugs || []), [slugs]);
+    if (posts.length === 0) return null;
+    return (
+        <div className="flex flex-wrap gap-x-3 gap-y-1">
+            {posts.map((post) => (
+                <Link
+                    key={post.slug}
+                    to={`/blog/${post.slug}`}
+                    className="inline-flex items-center gap-1 text-xs text-accent-700 hover:underline"
+                >
+                    <Article size={11} weight="duotone" />
+                    {post.title}
+                </Link>
+            ))}
+        </div>
+    );
+};
+
+/* ── Section anchors ── */
+
+const sections = [
+    { id: 'themes', label: 'By Theme', icon: Compass },
+    { id: 'months', label: 'By Month', icon: CalendarDots },
+    { id: 'countries', label: 'By Country', icon: Globe },
+    { id: 'festivals', label: 'Events & Festivals', icon: Confetti },
+    { id: 'weekends', label: 'Weekend Getaways', icon: Lightning },
+];
+
+/* ── Destination card ── */
+
+const DestinationCard: React.FC<{ destination: Destination }> = ({ destination }) => (
+    <Link
+        to="/create-trip"
+        className="group block rounded-2xl border border-slate-200 bg-white shadow-sm transition-all hover:shadow-lg hover:-translate-y-1"
+    >
+        <div className={`relative h-32 rounded-t-2xl ${destination.mapColor} overflow-hidden`}>
+            <div className={`absolute left-[22%] top-[28%] h-2.5 w-2.5 rounded-full ${destination.mapAccent}`} />
+            <div className={`absolute left-[48%] top-[55%] h-2 w-2 rounded-full ${destination.mapAccent} opacity-70`} />
+            <div className={`absolute left-[72%] top-[38%] h-3 w-3 rounded-full ${destination.mapAccent}`} />
+            <svg className="absolute inset-0 h-full w-full" viewBox="0 0 340 128" fill="none" preserveAspectRatio="none">
+                <path d="M75 36 L163 70 L245 49" stroke="currentColor" strokeWidth="1.5" strokeDasharray="4 4" className="text-slate-400/40" />
+            </svg>
+            <div className="absolute bottom-2 right-2 rounded-full bg-white/80 backdrop-blur px-2 py-0.5 text-[11px] font-bold text-slate-700">
+                {destination.flag} {destination.country}
+            </div>
+        </div>
+
+        <div className="p-4">
+            <h3 className="text-base font-bold text-slate-900 group-hover:text-accent-700 transition-colors">{destination.title}</h3>
+            <p className="mt-1.5 text-sm leading-relaxed text-slate-500 line-clamp-2">{destination.description}</p>
+            <div className="mt-3 flex items-center gap-4 text-xs text-slate-400">
+                <span className="inline-flex items-center gap-1"><Clock size={13} weight="duotone" className="text-accent-400" />{destination.durationDays} days</span>
+                <span className="inline-flex items-center gap-1"><MapPin size={13} weight="duotone" className="text-accent-400" />{destination.cityCount} cities</span>
+            </div>
+        </div>
+    </Link>
+);
+
+/* ── Festival card ── */
+
+const FestivalCard: React.FC<{ event: FestivalEventType; nextDate: Date }> = ({ event, nextDate }) => (
+    <Link
+        to="/create-trip"
+        className="group flex flex-col rounded-2xl border border-slate-200 bg-white shadow-sm transition-all hover:shadow-lg hover:-translate-y-1"
+    >
+        <div className={`relative h-24 rounded-t-2xl ${event.mapColor} overflow-hidden flex items-center justify-center`}>
+            <Confetti size={36} weight="duotone" className="text-slate-400/40" />
+            <div className="absolute bottom-2 right-2 rounded-full bg-white/80 backdrop-blur px-2 py-0.5 text-[11px] font-bold text-slate-700">
+                {event.flag} {event.months}
+            </div>
+        </div>
+        <div className="flex flex-1 flex-col p-4">
+            <h3 className="text-base font-bold text-slate-900 group-hover:text-accent-700 transition-colors">{event.name}</h3>
+            <p className="mt-1 text-xs font-medium text-slate-400">{event.country}</p>
+            <p className="mt-0.5 text-xs font-semibold text-fuchsia-600">Next: {formatFestivalDate(nextDate)}</p>
+            <p className="mt-1.5 flex-1 text-sm leading-relaxed text-slate-500 line-clamp-2">{event.description}</p>
+            <div className="mt-3 flex items-center gap-1 text-xs text-slate-400">
+                <Clock size={13} weight="duotone" className="text-accent-400" />
+                {event.durationDays} days recommended
+            </div>
+            {event.blogSlugs && event.blogSlugs.length > 0 && (
+                <div className="mt-2">
+                    <BlogLinks slugs={event.blogSlugs} />
+                </div>
+            )}
+        </div>
+    </Link>
+);
+
+/* ── Weekend getaway card ── */
+
+const GetawayCard: React.FC<{ getaway: WeekendGetawayType }> = ({ getaway }) => (
+    <Link
+        to="/create-trip"
+        className="group flex items-start gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition-all hover:shadow-lg hover:-translate-y-0.5"
+    >
+        <div className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-xl ${getaway.mapColor}`}>
+            <AirplaneTakeoff size={24} weight="duotone" className={getaway.mapAccent.replace('bg-', 'text-')} />
+        </div>
+        <div className="min-w-0 flex-1">
+            <h3 className="text-base font-bold text-slate-900 group-hover:text-accent-700 transition-colors">{getaway.title}</h3>
+            <p className="mt-0.5 text-xs font-medium text-slate-400">{getaway.flag} {getaway.to} · {getaway.durationDays} days</p>
+            <p className="mt-1.5 text-sm leading-relaxed text-slate-500 line-clamp-2">{getaway.description}</p>
+            {getaway.blogSlugs && getaway.blogSlugs.length > 0 && (
+                <div className="mt-2">
+                    <BlogLinks slugs={getaway.blogSlugs} />
+                </div>
+            )}
+        </div>
+        <ArrowRight size={18} weight="bold" className="mt-1 shrink-0 text-slate-300 transition-colors group-hover:text-accent-500" />
+    </Link>
+);
+
+/* ── Country pill ── */
+
+const CountryPill: React.FC<{ group: CountryGroup }> = ({ group }) => (
+    <Link
+        to={`/inspirations/country/${encodeURIComponent(group.country)}`}
+        className="group flex items-center gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition-all hover:shadow-lg hover:-translate-y-0.5"
+    >
+        <span className="text-3xl">{group.flag}</span>
+        <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-bold text-slate-900 group-hover:text-accent-700 transition-colors">{group.country}</h3>
+            <p className="text-xs text-slate-400">{group.bestMonths}</p>
+            <div className="mt-1.5 flex flex-wrap gap-1">
+                {group.tags.map((tag) => (
+                    <span key={tag} className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-500">{tag}</span>
+                ))}
+            </div>
+            {group.blogSlugs && group.blogSlugs.length > 0 && (
+                <div className="mt-2">
+                    <BlogLinks slugs={group.blogSlugs} />
+                </div>
+            )}
+        </div>
+        <span className="shrink-0 rounded-full bg-accent-50 px-2 py-0.5 text-xs font-bold text-accent-600">{group.tripCount}</span>
+    </Link>
+);
+
+/* ── Page ── */
+
+export const InspirationsPage: React.FC = () => {
+    const [search, setSearch] = useState('');
+    const [selectedMonthIndex, setSelectedMonthIndex] = useState(() => new Date().getMonth());
+
+    const allDestinations = useMemo(() => getAllDestinations(), []);
+
+    const filteredDestinations = useMemo(() => {
+        if (!search.trim()) return null;
+        const q = search.toLowerCase();
+        return allDestinations.filter(
+            (d) =>
+                d.title.toLowerCase().includes(q) ||
+                d.country.toLowerCase().includes(q) ||
+                d.description.toLowerCase().includes(q) ||
+                d.tags.some((t) => t.includes(q))
+        );
+    }, [search, allDestinations]);
+
+    const filteredFestivals = useMemo(() => {
+        if (!search.trim()) return null;
+        const q = search.toLowerCase();
+        return festivalEvents.filter(
+            (e) =>
+                e.name.toLowerCase().includes(q) ||
+                e.country.toLowerCase().includes(q) ||
+                e.description.toLowerCase().includes(q)
+        );
+    }, [search]);
+
+    const filteredGetaways = useMemo(() => {
+        if (!search.trim()) return null;
+        const q = search.toLowerCase();
+        return weekendGetaways.filter(
+            (g) =>
+                g.title.toLowerCase().includes(q) ||
+                g.to.toLowerCase().includes(q) ||
+                g.description.toLowerCase().includes(q)
+        );
+    }, [search]);
+
+    const isSearching = search.trim().length > 0;
+    const totalSearchResults = isSearching
+        ? (filteredDestinations?.length ?? 0) + (filteredFestivals?.length ?? 0) + (filteredGetaways?.length ?? 0)
+        : 0;
+
+    // Selected month data
+    const selectedMonth = monthEntries[selectedMonthIndex];
+
+    // Upcoming festivals sorted by next occurrence
+    const upcomingFestivals = useMemo(() => {
+        const now = new Date();
+        return festivalEvents
+            .map((event) => ({ ...event, nextDate: getNextOccurrence(event, now) }))
+            .sort((a, b) => a.nextDate.getTime() - b.nextDate.getTime());
+    }, []);
+
+    return (
+        <MarketingLayout>
+            {/* ── Hero ── */}
+            <section className="pt-8 pb-8 md:pt-14 md:pb-12 animate-hero-entrance">
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700">
+                    <Backpack size={14} weight="duotone" />
+                    Trip Inspirations
+                </span>
+                <h1 className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>
+                    Where will you go next?
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
+                    Not sure where to start? Browse curated trip ideas by theme, month, country, or upcoming festivals. Click any itinerary to use it as a starting point.
+                </p>
+            </section>
+
+            {/* ── Search ── */}
+            <section className="pb-6 animate-hero-stagger" style={{ '--stagger': '120ms' } as React.CSSProperties}>
+                <div className="relative max-w-xl">
+                    <MagnifyingGlass size={18} weight="duotone" className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+                    <input
+                        type="text"
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        placeholder="Search destinations, festivals, countries…"
+                        className="w-full rounded-xl border border-slate-200 bg-white py-3 pl-10 pr-4 text-sm text-slate-800 shadow-sm placeholder:text-slate-400 focus:border-accent-400 focus:outline-none focus:ring-2 focus:ring-accent-200 transition-shadow"
+                    />
+                    {isSearching && (
+                        <span className="absolute right-3.5 top-1/2 -translate-y-1/2 rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-500">
+                            {totalSearchResults} result{totalSearchResults !== 1 ? 's' : ''}
+                        </span>
+                    )}
+                </div>
+            </section>
+
+            {/* ── Search results ── */}
+            {isSearching && (
+                <section className="pb-12">
+                    {totalSearchResults === 0 && (
+                        <p className="text-sm text-slate-400">No results found for &ldquo;{search}&rdquo;. Try a different keyword.</p>
+                    )}
+                    {filteredDestinations && filteredDestinations.length > 0 && (
+                        <div className="mb-8">
+                            <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">Destinations</h3>
+                            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                                {filteredDestinations.map((d) => <DestinationCard key={d.title} destination={d} />)}
+                            </div>
+                        </div>
+                    )}
+                    {filteredFestivals && filteredFestivals.length > 0 && (
+                        <div className="mb-8">
+                            <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">Events & Festivals</h3>
+                            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                                {filteredFestivals.map((e) => <FestivalCard key={e.name} event={e} nextDate={getNextOccurrence(e, new Date())} />)}
+                            </div>
+                        </div>
+                    )}
+                    {filteredGetaways && filteredGetaways.length > 0 && (
+                        <div className="mb-8">
+                            <h3 className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">Weekend Getaways</h3>
+                            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                                {filteredGetaways.map((g) => <GetawayCard key={g.title} getaway={g} />)}
+                            </div>
+                        </div>
+                    )}
+                </section>
+            )}
+
+            {/* ── Quick navigation + Quick start (hidden while searching) ── */}
+            {!isSearching && (
+                <>
+                    {/* Anchor nav */}
+                    <nav className="pb-8 animate-hero-stagger" style={{ '--stagger': '200ms' } as React.CSSProperties}>
+                        <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">Jump to</h2>
+                        <div className="flex flex-wrap gap-2">
+                            {sections.map((s) => {
+                                const SIcon = s.icon;
+                                return (
+                                    <a
+                                        key={s.id}
+                                        href={`#${s.id}`}
+                                        className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3.5 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition-all hover:border-accent-300 hover:text-accent-700 hover:shadow-md"
+                                    >
+                                        <SIcon size={14} weight="duotone" />
+                                        {s.label}
+                                    </a>
+                                );
+                            })}
+                        </div>
+                    </nav>
+
+                    {/* Quick start pills */}
+                    <section className="pb-12 animate-hero-stagger" style={{ '--stagger': '280ms' } as React.CSSProperties}>
+                        <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">Quick start</h2>
+                        <div className="flex flex-wrap gap-2">
+                            {quickIdeas.map((idea) => (
+                                <Link
+                                    key={idea.label}
+                                    to="/create-trip"
+                                    className="rounded-full border border-slate-200 bg-white px-3.5 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition-all hover:border-accent-300 hover:text-accent-700 hover:shadow-md hover:scale-[1.03] active:scale-[0.98]"
+                                >
+                                    {idea.label}
+                                </Link>
+                            ))}
+                        </div>
+                    </section>
+
+                    {/* ── By Theme ── */}
+                    <div id="themes">
+                        {categories.map((category, idx) => {
+                            const CategoryIcon = category.icon;
+                            return (
+                                <section key={category.id} className="py-12 md:py-16 border-t border-slate-200">
+                                    <div className="animate-scroll-blur-in flex items-start gap-4">
+                                        <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl ring-1 ${category.color}`}>
+                                            <CategoryIcon size={24} weight="duotone" />
+                                        </div>
+                                        <div className="min-w-0 flex-1">
+                                            <div className="flex items-start justify-between gap-4">
+                                                <h2 className="text-2xl font-black tracking-tight text-slate-900 md:text-3xl">{category.title}</h2>
+                                                {idx === 0 && (
+                                                    <Link to="/inspirations/themes" className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
+                                                        All themes
+                                                        <ArrowRight size={14} weight="bold" />
+                                                    </Link>
+                                                )}
+                                            </div>
+                                            <p className="mt-1 text-base text-slate-500">{category.subtitle}</p>
+                                            {category.blogSlugs && category.blogSlugs.length > 0 && (
+                                                <div className="mt-2">
+                                                    <BlogLinks slugs={category.blogSlugs} />
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                                        {category.destinations.map((dest) => (
+                                            <div key={dest.title} className="animate-scroll-fade-up">
+                                                <DestinationCard destination={dest} />
+                                            </div>
+                                        ))}
+                                    </div>
+                                </section>
+                            );
+                        })}
+                    </div>
+
+                    {/* ── By Month (Tab Bar) ── */}
+                    <section id="months" className="py-12 md:py-16 border-t border-slate-200">
+                        <div className="animate-scroll-blur-in">
+                            <div className="flex items-start gap-4">
+                                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-sky-50 text-sky-600 ring-1 ring-sky-100">
+                                    <CalendarDots size={24} weight="duotone" />
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-start justify-between gap-4">
+                                        <h2 className="text-2xl font-black tracking-tight text-slate-900 md:text-3xl">Best Time to Travel</h2>
+                                        <Link to="/inspirations/best-time-to-travel" className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
+                                            Month guide
+                                            <ArrowRight size={14} weight="bold" />
+                                        </Link>
+                                    </div>
+                                    <p className="mt-1 text-base text-slate-500">When to go where — pick a month</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Month calendar strip */}
+                        <div className="mt-6 -mx-4 px-4 overflow-x-auto scrollbar-hide md:mx-0 md:px-0">
+                            <div className="inline-flex rounded-xl border border-slate-200 bg-slate-50 p-1">
+                                {monthEntries.map((entry) => (
+                                    <button
+                                        key={entry.monthIndex}
+                                        onClick={() => setSelectedMonthIndex(entry.monthIndex)}
+                                        className={`relative px-3.5 py-2 text-sm font-semibold transition-all rounded-lg whitespace-nowrap ${
+                                            selectedMonthIndex === entry.monthIndex
+                                                ? 'bg-white text-sky-700 shadow-sm'
+                                                : 'text-slate-500 hover:text-slate-800'
+                                        }`}
+                                    >
+                                        {entry.month.slice(0, 3)}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+
+                        {/* Month content panel */}
+                        <div
+                            key={selectedMonthIndex}
+                            className="mt-6 max-w-2xl animate-content-fade-in rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+                        >
+                            <h3 className="text-xl font-black text-slate-900" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>
+                                {selectedMonth.month}
+                            </h3>
+                            <p className="mt-3 text-base leading-relaxed text-slate-600">{selectedMonth.description}</p>
+                            <div className="mt-4 flex flex-wrap gap-2">
+                                {selectedMonth.destinations.map((dest) => (
+                                    <Link
+                                        key={dest}
+                                        to="/create-trip"
+                                        className="rounded-full bg-sky-50 px-3 py-1 text-sm font-semibold text-sky-700 transition-colors hover:bg-sky-100"
+                                    >
+                                        {dest}
+                                    </Link>
+                                ))}
+                            </div>
+                            {selectedMonth.blogSlugs && selectedMonth.blogSlugs.length > 0 && (
+                                <div className="mt-4 pt-3 border-t border-slate-100">
+                                    <p className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-2">Related Articles</p>
+                                    <BlogLinks slugs={selectedMonth.blogSlugs} />
+                                </div>
+                            )}
+                        </div>
+                    </section>
+
+                    {/* ── By Country ── */}
+                    <section id="countries" className="py-12 md:py-16 border-t border-slate-200">
+                        <div className="animate-scroll-blur-in">
+                            <div className="flex items-start gap-4">
+                                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-teal-50 text-teal-600 ring-1 ring-teal-100">
+                                    <Globe size={24} weight="duotone" />
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-start justify-between gap-4">
+                                        <h2 className="text-2xl font-black tracking-tight text-slate-900 md:text-3xl">Browse by Country</h2>
+                                        <Link to="/inspirations/countries" className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
+                                            All countries
+                                            <ArrowRight size={14} weight="bold" />
+                                        </Link>
+                                    </div>
+                                    <p className="mt-1 text-base text-slate-500">Find trips by destination — {countryGroups.length} countries and counting</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                            {countryGroups.map((group) => (
+                                <div key={group.country} className="animate-scroll-fade-up">
+                                    <CountryPill group={group} />
+                                </div>
+                            ))}
+                        </div>
+                    </section>
+
+                    {/* ── Upcoming Events & Festivals ── */}
+                    <section id="festivals" className="py-12 md:py-16 border-t border-slate-200">
+                        <div className="animate-scroll-blur-in">
+                            <div className="flex items-start gap-4">
+                                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-fuchsia-50 text-fuchsia-600 ring-1 ring-fuchsia-100">
+                                    <Confetti size={24} weight="duotone" />
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-start justify-between gap-4">
+                                        <h2 className="text-2xl font-black tracking-tight text-slate-900 md:text-3xl">Upcoming Events & Festivals</h2>
+                                        <Link to="/inspirations/events-and-festivals" className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
+                                            All events
+                                            <ArrowRight size={14} weight="bold" />
+                                        </Link>
+                                    </div>
+                                    <p className="mt-1 text-base text-slate-500">
+                                        {upcomingFestivals.length} celebrations sorted by next date — plan around the world's most unforgettable moments
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                            {upcomingFestivals.slice(0, 6).map((event) => (
+                                <div key={event.name} className="animate-scroll-fade-up">
+                                    <FestivalCard event={event} nextDate={event.nextDate} />
+                                </div>
+                            ))}
+                        </div>
+                        {upcomingFestivals.length > 6 && (
+                            <div className="mt-8 text-center">
+                                <Link
+                                    to="/inspirations/events-and-festivals"
+                                    className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-6 py-3 text-sm font-bold text-slate-700 shadow-sm transition-all hover:border-accent-300 hover:text-accent-700 hover:shadow-md"
+                                >
+                                    View all {upcomingFestivals.length} events
+                                    <ArrowRight size={14} weight="bold" />
+                                </Link>
+                            </div>
+                        )}
+                    </section>
+
+                    {/* ── Weekend Getaways ── */}
+                    <section id="weekends" className="py-12 md:py-16 border-t border-slate-200">
+                        <div className="animate-scroll-blur-in">
+                            <div className="flex items-start gap-4">
+                                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-amber-50 text-amber-600 ring-1 ring-amber-100">
+                                    <Lightning size={24} weight="duotone" />
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-start justify-between gap-4">
+                                        <h2 className="text-2xl font-black tracking-tight text-slate-900 md:text-3xl">Spontaneous Weekend Getaways</h2>
+                                        <Link to="/inspirations/weekend-getaways" className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
+                                            All getaways
+                                            <ArrowRight size={14} weight="bold" />
+                                        </Link>
+                                    </div>
+                                    <p className="mt-1 text-base text-slate-500">Short trips you can book on a whim — 2–3 days, zero overthinking</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                            {weekendGetaways.map((getaway) => (
+                                <div key={getaway.title} className="animate-scroll-fade-up">
+                                    <GetawayCard getaway={getaway} />
+                                </div>
+                            ))}
+                        </div>
+                    </section>
+
+                    {/* ── Stats strip ── */}
+                    <section className="py-14 md:py-20 border-t border-slate-200">
+                        <div className="animate-scroll-blur-in grid gap-8 text-center sm:grid-cols-2 md:grid-cols-4">
+                            <div>
+                                <div className="text-4xl font-black text-accent-600">18+</div>
+                                <div className="mt-1 text-sm text-slate-500">Curated destinations</div>
+                            </div>
+                            <div>
+                                <div className="text-4xl font-black text-accent-600">12</div>
+                                <div className="mt-1 text-sm text-slate-500">Countries covered</div>
+                            </div>
+                            <div>
+                                <div className="text-4xl font-black text-accent-600">{festivalEvents.length}</div>
+                                <div className="mt-1 text-sm text-slate-500">Festivals & events</div>
+                            </div>
+                            <div>
+                                <div className="text-4xl font-black text-accent-600">6</div>
+                                <div className="mt-1 text-sm text-slate-500">Weekend getaways</div>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* ── Bottom CTA ── */}
+                    <section className="pb-16 md:pb-24 animate-scroll-scale-in">
+                        <div className="relative rounded-3xl bg-gradient-to-br from-accent-600 to-accent-800 px-8 py-14 text-center md:px-16 md:py-20 overflow-hidden">
+                            <div className="pointer-events-none absolute -top-20 -right-20 h-60 w-60 rounded-full bg-white/10 blur-[60px]" />
+                            <div className="pointer-events-none absolute -bottom-16 -left-16 h-48 w-48 rounded-full bg-accent-400/20 blur-[50px]" />
+
+                            <h2 className="relative text-3xl font-black tracking-tight text-white md:text-5xl" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>
+                                Feeling inspired?
+                            </h2>
+                            <p className="relative mx-auto mt-4 max-w-xl text-base text-accent-100 md:text-lg">
+                                Pick a destination and let our AI turn it into a day-by-day plan in seconds.
+                            </p>
+                            <Link
+                                to="/create-trip"
+                                className="relative mt-8 inline-block rounded-2xl bg-white px-8 py-3.5 text-base font-bold text-accent-700 shadow-lg transition-all hover:shadow-xl hover:bg-accent-50 hover:scale-[1.03] active:scale-[0.98]"
+                            >
+                                Start Planning Now
+                            </Link>
+                        </div>
+                    </section>
+                </>
+            )}
+        </MarketingLayout>
+    );
+};

--- a/pages/MarketingHomePage.tsx
+++ b/pages/MarketingHomePage.tsx
@@ -1,89 +1,17 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
-import { CalendarClock, MapPinned, Route, Sparkles } from 'lucide-react';
-import { trackEvent } from '../services/analyticsService';
-
-const featureCards = [
-    {
-        title: 'AI trip generation',
-        description: 'Draft a full route with city timing and activity suggestions in seconds.',
-        icon: Sparkles,
-    },
-    {
-        title: 'Map + timeline planning',
-        description: 'Adjust city durations and route flow visually while keeping trip context.',
-        icon: Route,
-    },
-    {
-        title: 'Share and collaborate',
-        description: 'Send view-only or editable links and keep versions in history.',
-        icon: MapPinned,
-    },
-    {
-        title: 'Print-ready itineraries',
-        description: 'Switch to print view for a cleaner itinerary export and travel brief.',
-        icon: CalendarClock,
-    },
-];
+import { HeroSection } from '../components/marketing/HeroSection';
+import { ExampleTripsCarousel } from '../components/marketing/ExampleTripsCarousel';
+import { FeatureShowcase } from '../components/marketing/FeatureShowcase';
+import { CtaBanner } from '../components/marketing/CtaBanner';
 
 export const MarketingHomePage: React.FC = () => {
-    const handleHeroCtaClick = (ctaName: string) => {
-        trackEvent('marketing_hero_cta_clicked', {
-            cta_name: ctaName,
-            page: 'home',
-        });
-    };
-
     return (
         <MarketingLayout>
-            <section className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white p-8 shadow-sm md:p-12">
-                <div className="pointer-events-none absolute -right-28 -top-24 h-72 w-72 rounded-full bg-accent-300/40 blur-3xl" />
-                <div className="pointer-events-none absolute -bottom-28 left-8 h-72 w-72 rounded-full bg-accent-200/50 blur-3xl" />
-
-                <div className="relative max-w-3xl">
-                    <span className="inline-flex rounded-full border border-accent-200 bg-accent-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-accent-700">
-                        Future-ready planning workspace
-                    </span>
-                    <h1 className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-5xl">
-                        Build better trips with less planning overhead
-                    </h1>
-                    <p className="mt-5 max-w-2xl text-base leading-7 text-slate-600">
-                        TravelFlow combines AI itinerary generation, timeline editing, map visualization, and collaboration links in one clean workflow.
-                    </p>
-                    <div className="mt-8 flex flex-wrap items-center gap-3">
-                        <Link
-                            to="/create-trip"
-                            onClick={() => handleHeroCtaClick('create_trip')}
-                            className="rounded-xl bg-accent-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
-                        >
-                            Create Trip
-                        </Link>
-                        <Link
-                            to="/features"
-                            onClick={() => handleHeroCtaClick('see_features')}
-                            className="rounded-xl border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-400 hover:text-slate-900"
-                        >
-                            See features
-                        </Link>
-                    </div>
-                </div>
-            </section>
-
-            <section className="mt-8 grid gap-4 md:grid-cols-2">
-                {featureCards.map((card) => {
-                    const Icon = card.icon;
-                    return (
-                        <article key={card.title} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-                            <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-slate-100 text-slate-700">
-                                <Icon size={18} />
-                            </span>
-                            <h2 className="mt-4 text-lg font-bold text-slate-900">{card.title}</h2>
-                            <p className="mt-2 text-sm leading-6 text-slate-600">{card.description}</p>
-                        </article>
-                    );
-                })}
-            </section>
+            <HeroSection />
+            <ExampleTripsCarousel />
+            <FeatureShowcase />
+            <CtaBanner />
         </MarketingLayout>
     );
 };

--- a/pages/inspirations/BestTimeToTravelPage.tsx
+++ b/pages/inspirations/BestTimeToTravelPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { CalendarDots, ArrowLeft } from '@phosphor-icons/react';
+import { MarketingLayout } from '../../components/marketing/MarketingLayout';
+
+export const BestTimeToTravelPage: React.FC = () => {
+    return (
+        <MarketingLayout>
+            <section className="pt-8 pb-8 md:pt-14 md:pb-12 animate-hero-entrance">
+                <Link
+                    to="/inspirations"
+                    className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-accent-700 transition-colors mb-6"
+                >
+                    <ArrowLeft size={14} weight="bold" />
+                    Back to Inspirations
+                </Link>
+                <span className="flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700 w-fit">
+                    <CalendarDots size={14} weight="duotone" />
+                    Best Time to Travel
+                </span>
+                <h1
+                    className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl"
+                    style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                >
+                    When to Go Where
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
+                    Every destination has a sweet spot — the month when weather, crowds, and prices align perfectly. Use our month-by-month guide to pick the ideal time for your next trip.
+                </p>
+            </section>
+
+            <section className="pb-16 md:pb-24">
+                <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+                    <span className="inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-900">
+                        Coming soon
+                    </span>
+                    <p className="mt-4 text-sm text-slate-500">
+                        Detailed seasonal guides with weather data, peak-season alerts, and budget tips for every month are on the way.
+                    </p>
+                </div>
+            </section>
+        </MarketingLayout>
+    );
+};

--- a/pages/inspirations/CountriesPage.tsx
+++ b/pages/inspirations/CountriesPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Globe, ArrowLeft } from '@phosphor-icons/react';
+import { MarketingLayout } from '../../components/marketing/MarketingLayout';
+
+export const CountriesPage: React.FC = () => {
+    return (
+        <MarketingLayout>
+            <section className="pt-8 pb-8 md:pt-14 md:pb-12 animate-hero-entrance">
+                <Link
+                    to="/inspirations"
+                    className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-accent-700 transition-colors mb-6"
+                >
+                    <ArrowLeft size={14} weight="bold" />
+                    Back to Inspirations
+                </Link>
+                <span className="flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700 w-fit">
+                    <Globe size={14} weight="duotone" />
+                    Browse by Country
+                </span>
+                <h1
+                    className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl"
+                    style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                >
+                    Explore Destinations by Country
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
+                    From Japan's cherry blossoms to Portugal's coastal charm — dive deep into country-specific travel guides with best-month recommendations, must-see cities, and local insider tips.
+                </p>
+            </section>
+
+            <section className="pb-16 md:pb-24">
+                <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+                    <span className="inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-900">
+                        Coming soon
+                    </span>
+                    <p className="mt-4 text-sm text-slate-500">
+                        In-depth country profiles with visa info, budget breakdowns, and curated multi-city routes are on the way.
+                    </p>
+                </div>
+            </section>
+        </MarketingLayout>
+    );
+};

--- a/pages/inspirations/CountryDetailPage.tsx
+++ b/pages/inspirations/CountryDetailPage.tsx
@@ -1,0 +1,110 @@
+import React, { useMemo } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { ArrowLeft, Globe, ArrowRight } from '@phosphor-icons/react';
+import { MarketingLayout } from '../../components/marketing/MarketingLayout';
+import { countryGroups } from '../../data/inspirationsData';
+
+export const CountryDetailPage: React.FC = () => {
+    const { countryName } = useParams<{ countryName: string }>();
+    const decoded = countryName ? decodeURIComponent(countryName) : '';
+
+    const country = useMemo(
+        () => countryGroups.find((g) => g.country.toLowerCase() === decoded.toLowerCase()),
+        [decoded],
+    );
+
+    if (!country) {
+        return (
+            <MarketingLayout>
+                <section className="py-20 text-center">
+                    <h1
+                        className="text-3xl font-black text-slate-900"
+                        style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                    >
+                        Country not found
+                    </h1>
+                    <p className="mt-4 text-slate-500">
+                        We don't have inspiration data for "{decoded}" yet.
+                    </p>
+                    <Link
+                        to="/inspirations"
+                        className="mt-6 inline-flex items-center gap-2 rounded-xl bg-accent-600 px-6 py-3 text-sm font-bold text-white shadow-lg transition-all hover:bg-accent-700"
+                    >
+                        <ArrowLeft size={16} weight="bold" />
+                        Back to Inspirations
+                    </Link>
+                </section>
+            </MarketingLayout>
+        );
+    }
+
+    return (
+        <MarketingLayout>
+            <section className="pt-8 pb-8 md:pt-14 md:pb-12 animate-hero-entrance">
+                <Link
+                    to="/inspirations#countries"
+                    className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-accent-700 transition-colors mb-6"
+                >
+                    <ArrowLeft size={14} weight="bold" />
+                    Back to Inspirations
+                </Link>
+                <span className="flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700 w-fit">
+                    <Globe size={14} weight="duotone" />
+                    Country Guide
+                </span>
+                <h1
+                    className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl"
+                    style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                >
+                    {country.flag} Travel to {country.country}
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
+                    Everything you need to plan your trip to {country.country} — best months to visit, popular itineraries, and travel tips.
+                </p>
+            </section>
+
+            {/* Quick facts */}
+            <section className="pb-10 animate-hero-stagger" style={{ '--stagger': '100ms' } as React.CSSProperties}>
+                <div className="flex flex-wrap gap-4">
+                    <div className="rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+                        <p className="text-xs font-bold uppercase tracking-wider text-slate-400">Best time</p>
+                        <p className="mt-1 text-sm font-semibold text-slate-800">{country.bestMonths}</p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+                        <p className="text-xs font-bold uppercase tracking-wider text-slate-400">Trip ideas</p>
+                        <p className="mt-1 text-sm font-semibold text-slate-800">{country.tripCount} itineraries</p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+                        <p className="text-xs font-bold uppercase tracking-wider text-slate-400">Tags</p>
+                        <div className="mt-1 flex flex-wrap gap-1">
+                            {country.tags.map((tag) => (
+                                <span key={tag} className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-500">
+                                    {tag}
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            {/* Placeholder content */}
+            <section className="pb-16 md:pb-24 animate-hero-stagger" style={{ '--stagger': '200ms' } as React.CSSProperties}>
+                <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+                    <span className="inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-900">
+                        Coming soon
+                    </span>
+                    <p className="mt-4 text-sm text-slate-500">
+                        Detailed guides for {country.country} — including city breakdowns, cultural tips, visa information, and curated multi-day itineraries — are on the way.
+                    </p>
+                    <Link
+                        to="/create-trip"
+                        className="mt-6 inline-flex items-center gap-1.5 rounded-xl bg-accent-600 px-5 py-2.5 text-sm font-bold text-white shadow-sm transition-all hover:bg-accent-700"
+                    >
+                        Plan a trip to {country.country}
+                        <ArrowRight size={14} weight="bold" />
+                    </Link>
+                </div>
+            </section>
+        </MarketingLayout>
+    );
+};

--- a/pages/inspirations/FestivalsPage.tsx
+++ b/pages/inspirations/FestivalsPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Confetti, ArrowLeft } from '@phosphor-icons/react';
+import { MarketingLayout } from '../../components/marketing/MarketingLayout';
+
+export const FestivalsPage: React.FC = () => {
+    return (
+        <MarketingLayout>
+            <section className="pt-8 pb-8 md:pt-14 md:pb-12 animate-hero-entrance">
+                <Link
+                    to="/inspirations"
+                    className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-accent-700 transition-colors mb-6"
+                >
+                    <ArrowLeft size={14} weight="bold" />
+                    Back to Inspirations
+                </Link>
+                <span className="flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700 w-fit">
+                    <Confetti size={14} weight="duotone" />
+                    Events & Festivals
+                </span>
+                <h1
+                    className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl"
+                    style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                >
+                    Plan Your Trip Around a Festival
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
+                    The world's greatest celebrations deserve more than a last-minute flight. Discover upcoming festivals sorted by date — from Carnival in Rio to lantern festivals in Taiwan — and build your itinerary around the event.
+                </p>
+            </section>
+
+            <section className="pb-16 md:pb-24">
+                <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+                    <span className="inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-900">
+                        Coming soon
+                    </span>
+                    <p className="mt-4 text-sm text-slate-500">
+                        Detailed festival guides with schedules, accommodation tips, and day-by-day itinerary suggestions are on the way.
+                    </p>
+                </div>
+            </section>
+        </MarketingLayout>
+    );
+};

--- a/pages/inspirations/ThemesPage.tsx
+++ b/pages/inspirations/ThemesPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Compass, ArrowLeft } from '@phosphor-icons/react';
+import { MarketingLayout } from '../../components/marketing/MarketingLayout';
+
+export const ThemesPage: React.FC = () => {
+    return (
+        <MarketingLayout>
+            <section className="pt-8 pb-8 md:pt-14 md:pb-12 animate-hero-entrance">
+                <Link
+                    to="/inspirations"
+                    className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-accent-700 transition-colors mb-6"
+                >
+                    <ArrowLeft size={14} weight="bold" />
+                    Back to Inspirations
+                </Link>
+                <span className="flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700 w-fit">
+                    <Compass size={14} weight="duotone" />
+                    Travel Themes
+                </span>
+                <h1
+                    className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl"
+                    style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                >
+                    Travel by Theme
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
+                    Whether you crave adrenaline-fueled adventures, immersive food trails, or serene photography escapes — find curated trip ideas that match your travel style.
+                </p>
+            </section>
+
+            <section className="pb-16 md:pb-24">
+                <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+                    <span className="inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-900">
+                        Coming soon
+                    </span>
+                    <p className="mt-4 text-sm text-slate-500">
+                        Full theme pages with detailed itineraries, packing lists, and insider tips are on the way.
+                    </p>
+                </div>
+            </section>
+        </MarketingLayout>
+    );
+};

--- a/pages/inspirations/WeekendGetawaysPage.tsx
+++ b/pages/inspirations/WeekendGetawaysPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Lightning, ArrowLeft } from '@phosphor-icons/react';
+import { MarketingLayout } from '../../components/marketing/MarketingLayout';
+
+export const WeekendGetawaysPage: React.FC = () => {
+    return (
+        <MarketingLayout>
+            <section className="pt-8 pb-8 md:pt-14 md:pb-12 animate-hero-entrance">
+                <Link
+                    to="/inspirations"
+                    className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-accent-700 transition-colors mb-6"
+                >
+                    <ArrowLeft size={14} weight="bold" />
+                    Back to Inspirations
+                </Link>
+                <span className="flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700 w-fit">
+                    <Lightning size={14} weight="duotone" />
+                    Weekend Getaways
+                </span>
+                <h1
+                    className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl"
+                    style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                >
+                    Quick Escapes for Busy Travelers
+                </h1>
+                <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
+                    You don't need two weeks off to have an unforgettable trip. These 2–3 day getaway ideas are designed for spontaneous adventurers — pack light, book fast, and make the most of a long weekend.
+                </p>
+            </section>
+
+            <section className="pb-16 md:pb-24">
+                <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+                    <span className="inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-900">
+                        Coming soon
+                    </span>
+                    <p className="mt-4 text-sm text-slate-500">
+                        Weekend itinerary templates with train/flight options, budget estimates, and packing checklists are on the way.
+                    </p>
+                </div>
+            </section>
+        </MarketingLayout>
+    );
+};

--- a/scripts/validate-blog.mjs
+++ b/scripts/validate-blog.mjs
@@ -1,0 +1,160 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const BLOG_DIR = path.resolve(process.cwd(), 'content/blog');
+const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
+
+const REQUIRED_FIELDS = [
+  'slug',
+  'title',
+  'date',
+  'published_at',
+  'author',
+  'tags',
+  'summary',
+  'cover_color',
+  'reading_time_min',
+  'status',
+];
+
+const stripQuotes = (value) => {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+};
+
+const parseFrontmatter = (raw) => {
+  const normalized = raw.replace(/\r\n/g, '\n');
+  const match = normalized.match(FRONTMATTER_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const meta = {};
+  for (const line of match[1].split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const separator = trimmed.indexOf(':');
+    if (separator === -1) continue;
+    const key = trimmed.slice(0, separator).trim().toLowerCase();
+    const value = stripQuotes(trimmed.slice(separator + 1));
+    meta[key] = value;
+  }
+
+  return { meta, body: match[2] };
+};
+
+const isValidDate = (value) => /^\d{4}-\d{2}-\d{2}$/.test(value) && Number.isFinite(Date.parse(`${value}T00:00:00Z`));
+const isValidDateTime = (value) => Number.isFinite(Date.parse(value));
+
+const validateFile = async (filePath) => {
+  const raw = await fs.readFile(filePath, 'utf8');
+  const parsed = parseFrontmatter(raw);
+  const errors = [];
+
+  if (!parsed) {
+    errors.push('missing or invalid frontmatter block');
+    return errors;
+  }
+
+  const { meta, body } = parsed;
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!(field in meta) || String(meta[field]).trim().length === 0) {
+      errors.push(`missing required field: ${field}`);
+    }
+  }
+
+  if (meta.date && !isValidDate(meta.date)) {
+    errors.push(`invalid date format (expected YYYY-MM-DD): ${meta.date}`);
+  }
+
+  if (meta.published_at && !isValidDateTime(meta.published_at)) {
+    errors.push(`invalid published_at datetime: ${meta.published_at}`);
+  }
+
+  if (meta.status && !['published', 'draft'].includes(meta.status.trim().toLowerCase())) {
+    errors.push(`invalid status (expected published|draft): ${meta.status}`);
+  }
+
+  if (meta.reading_time_min) {
+    const mins = Number(meta.reading_time_min);
+    if (!Number.isFinite(mins) || mins <= 0) {
+      errors.push(`invalid reading_time_min (expected positive number): ${meta.reading_time_min}`);
+    }
+  }
+
+  const bodyContent = body.trim();
+  if (bodyContent.length === 0) {
+    errors.push('blog post body content is empty');
+  }
+
+  return errors;
+};
+
+const main = async () => {
+  let entries;
+  try {
+    entries = await fs.readdir(BLOG_DIR, { withFileTypes: true });
+  } catch {
+    console.log('[blog:validate] No content/blog directory found — skipping');
+    return;
+  }
+
+  const files = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => path.join(BLOG_DIR, entry.name))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (files.length === 0) {
+    console.log('[blog:validate] No blog posts found — skipping');
+    return;
+  }
+
+  let hasErrors = false;
+  const slugs = new Map();
+
+  for (const file of files) {
+    const errors = await validateFile(file);
+    const raw = await fs.readFile(file, 'utf8');
+    const parsed = parseFrontmatter(raw);
+
+    if (parsed?.meta?.slug) {
+      const slug = String(parsed.meta.slug).trim();
+      const list = slugs.get(slug) || [];
+      list.push(file);
+      slugs.set(slug, list);
+    }
+
+    if (errors.length === 0) continue;
+
+    hasErrors = true;
+    const relative = path.relative(process.cwd(), file);
+    console.error(`\n[blog:validate] ${relative}`);
+    for (const error of errors) {
+      console.error(`  - ${error}`);
+    }
+  }
+
+  for (const [slug, matchingFiles] of slugs.entries()) {
+    if (matchingFiles.length <= 1) continue;
+    hasErrors = true;
+    console.error(`\n[blog:validate] duplicate slug detected: ${slug}`);
+    for (const file of matchingFiles) {
+      console.error(`  - ${path.relative(process.cwd(), file)}`);
+    }
+  }
+
+  if (hasErrors) {
+    process.exit(1);
+  }
+
+  console.log(`[blog:validate] validated ${files.length} blog post(s)`);
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/services/blogService.ts
+++ b/services/blogService.ts
@@ -1,0 +1,128 @@
+export type BlogStatus = 'published' | 'draft';
+
+export interface BlogPost {
+    slug: string;
+    title: string;
+    date: string;
+    publishedAt: string;
+    author: string;
+    tags: string[];
+    summary: string;
+    coverColor: string;
+    readingTimeMin: number;
+    status: BlogStatus;
+    content: string;
+    sourcePath: string;
+}
+
+const BLOG_FILES = import.meta.glob('../content/blog/*.md', {
+    eager: true,
+    import: 'default',
+    query: '?raw',
+}) as Record<string, string>;
+
+const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
+
+const stripQuotes = (value: string) => {
+    const trimmed = value.trim();
+    if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+        return trimmed.slice(1, -1);
+    }
+    return trimmed;
+};
+
+const parseFrontmatter = (raw: string) => {
+    const normalized = raw.replace(/\r\n/g, '\n');
+    const match = normalized.match(FRONTMATTER_REGEX);
+
+    if (!match) {
+        return { meta: {} as Record<string, string>, body: normalized };
+    }
+
+    const metaLines = match[1].split('\n');
+    const meta: Record<string, string> = {};
+
+    for (const line of metaLines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const separator = trimmed.indexOf(':');
+        if (separator === -1) continue;
+        const key = trimmed.slice(0, separator).trim().toLowerCase();
+        const value = stripQuotes(trimmed.slice(separator + 1));
+        meta[key] = value;
+    }
+
+    return { meta, body: match[2] };
+};
+
+const parseTags = (raw: string | undefined): string[] => {
+    if (!raw) return [];
+    const cleaned = raw.replace(/^\[/, '').replace(/\]$/, '');
+    return cleaned
+        .split(',')
+        .map((t) => stripQuotes(t.trim()))
+        .filter(Boolean);
+};
+
+const parseBlogFile = (sourcePath: string, raw: string): BlogPost | null => {
+    const { meta, body } = parseFrontmatter(raw);
+    const slug = meta.slug || '';
+    const title = meta.title || 'Untitled';
+    const date = meta.date || new Date(0).toISOString().slice(0, 10);
+    const publishedAt = meta.published_at || `${date}T00:00:00Z`;
+    const author = meta.author || 'TravelFlow Team';
+    const tags = parseTags(meta.tags);
+    const summary = meta.summary || '';
+    const coverColor = meta.cover_color || 'bg-slate-100';
+    const readingTimeMin = Number(meta.reading_time_min) || 5;
+
+    const statusValue = (meta.status || 'draft').trim().toLowerCase();
+    const status: BlogStatus = statusValue === 'published' ? 'published' : 'draft';
+
+    const parsedPublishedAt = Date.parse(publishedAt);
+    if (!Number.isFinite(parsedPublishedAt)) {
+        console.warn(`[blog] Invalid published_at in ${sourcePath}: ${publishedAt}`);
+        return null;
+    }
+
+    if (!slug) {
+        console.warn(`[blog] Missing slug in ${sourcePath}`);
+        return null;
+    }
+
+    return {
+        slug,
+        title,
+        date,
+        publishedAt,
+        author,
+        tags,
+        summary,
+        coverColor,
+        readingTimeMin,
+        status,
+        content: body.trim(),
+        sourcePath,
+    };
+};
+
+const allBlogPosts: BlogPost[] = Object.entries(BLOG_FILES)
+    .map(([sourcePath, raw]) => parseBlogFile(sourcePath, raw))
+    .filter((entry): entry is BlogPost => !!entry)
+    .sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt));
+
+export const getAllBlogPosts = (): BlogPost[] => allBlogPosts;
+
+export const getPublishedBlogPosts = (): BlogPost[] => {
+    return allBlogPosts.filter((post) => post.status === 'published');
+};
+
+export const getBlogPostBySlug = (slug: string): BlogPost | undefined => {
+    return allBlogPosts.find((post) => post.slug === slug);
+};
+
+export const getBlogPostsBySlugs = (slugs: string[]): BlogPost[] => {
+    if (!slugs || slugs.length === 0) return [];
+    const slugSet = new Set(slugs);
+    return allBlogPosts.filter((post) => slugSet.has(post.slug) && post.status === 'published');
+};


### PR DESCRIPTION
## Summary
- **Homepage redesign** — New hero section with animated hand-drawn zigzag underline, feature showcase grid, example trips carousel, and CTA banner
- **Blog system** — Markdown-powered blog with listing page (search + tag filtering), detail page with scroll-aware TOC sidebar, reading progress bar, and related articles
- **Inspirations overhaul** — Interactive month calendar tab bar, chronologically sorted festivals (limited to 6 with "view all" link), country detail pages (`/inspirations/country/:name`), dedicated section landing pages with SEO text, and right-aligned "explore all" links in every section header
- **UX improvements** — View Transition API for smooth page navigation (header stays static), scroll-to-top on route changes, early access dismissible banner, CSS scroll-driven animations throughout
- **New routes** — `/blog/:slug`, `/inspirations/themes`, `/inspirations/best-time-to-travel`, `/inspirations/countries`, `/inspirations/events-and-festivals`, `/inspirations/weekend-getaways`, `/inspirations/country/:countryName`

## Test plan
- [ ] Homepage: hero entrance animation plays, zigzag underline draws under "in seconds", example trips carousel scrolls, feature showcase and CTA render
- [ ] `/blog` — 5 posts visible, search filters by title/summary/tags, tag pills filter correctly
- [ ] `/blog/:slug` — markdown renders, TOC highlights active section on scroll, reading progress bar tracks scroll position, related posts show
- [ ] `/inspirations` — month calendar switches smoothly, festivals limited to 6 with "view all" button, country cards link to detail pages, section header links navigate to landing pages
- [ ] `/inspirations/country/Japan` — shows country info, 404 for unknown countries
- [ ] View transitions: pages animate on navigation, header stays static, no doubled content
- [ ] Early access banner dismisses and stays dismissed across page loads
- [ ] `npm run build` passes (updates + blog validation + vite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)