### PR TITLE
Unified navigation, mobile menu, pricing page & My Trips

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,8 @@ import { PrivacyPage } from './pages/PrivacyPage';
 import { TermsPage } from './pages/TermsPage';
 import { CookiesPage } from './pages/CookiesPage';
 import { AdminDashboardPage } from './pages/AdminDashboardPage';
+import { PricingPage } from './pages/PricingPage';
+import { TripManagerProvider } from './contexts/TripManagerContext';
 import { CookieConsentBanner } from './components/marketing/CookieConsentBanner';
 import { saveTrip, getTripById } from './services/storageService';
 import { appendHistoryEntry, findHistoryEntryByUrl } from './services/historyService';
@@ -549,7 +551,7 @@ const AppContent: React.FC = () => {
     };
 
     return (
-        <>
+        <TripManagerProvider openTripManager={() => setIsManagerOpen(true)}>
             <ScrollToTop />
             <ViewTransitionHandler />
             <Routes>
@@ -577,6 +579,7 @@ const AppContent: React.FC = () => {
                 <Route path="/updates" element={<UpdatesPage />} />
                 <Route path="/blog" element={<BlogPage />} />
                 <Route path="/blog/:slug" element={<BlogPostPage />} />
+                <Route path="/pricing" element={<PricingPage />} />
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/imprint" element={<ImprintPage />} />
                 <Route path="/privacy" element={<PrivacyPage />} />
@@ -638,7 +641,7 @@ const AppContent: React.FC = () => {
 
             <CookieConsentBanner />
             <GlobalTooltipLayer />
-        </>
+        </TripManagerProvider>
     );
 };
 

--- a/components/CreateTripForm.tsx
+++ b/components/CreateTripForm.tsx
@@ -10,11 +10,9 @@ import {
     Compass,
     DiceSix as Dice6,
     FilePlus,
-    Folder,
     Info,
     SpinnerGap as Loader2,
     MapPin,
-    AirplaneTilt as Plane,
     Plus,
     MagnifyingGlass as Search,
     GearSix as Settings,
@@ -22,7 +20,6 @@ import {
     MagicWand as Wand2,
     X,
 } from '@phosphor-icons/react';
-import { Link, NavLink } from 'react-router-dom';
 import { createPortal } from 'react-dom';
 import { CountrySelect } from './CountrySelect';
 import { DateRangePicker } from './DateRangePicker';
@@ -51,6 +48,7 @@ import { TripView } from './TripView';
 import { TripGenerationSkeleton } from './TripGenerationSkeleton';
 import { HeroWebGLBackground } from './HeroWebGLBackground';
 import { SiteFooter } from './marketing/SiteFooter';
+import { SiteHeader } from './navigation/SiteHeader';
 import {
     CountrySeasonEntry,
     getCommonBestMonths,
@@ -203,11 +201,6 @@ const WIZARD_LOGISTIC_CARDS: SelectionCardConfig[] = [
 
 const NOOP = () => {};
 
-const createNavLinkClass = ({ isActive }: { isActive: boolean }) => {
-    const baseClass = 'relative font-semibold text-slate-500 transition-colors hover:text-slate-900 after:pointer-events-none after:absolute after:-bottom-4 sm:after:-bottom-6 after:left-0 after:h-0.5 after:w-full after:origin-center after:scale-x-0 after:rounded-full after:bg-accent-600 after:transition-transform';
-    if (isActive) return `${baseClass} text-slate-900 after:scale-x-100`;
-    return baseClass;
-};
 
 const toIsoDate = (date: Date): string => {
     const y = date.getFullYear();
@@ -799,37 +792,11 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
             <div className="pointer-events-none absolute -left-24 top-20 z-[1] h-72 w-72 rounded-full bg-accent-200/30 blur-[80px]" />
             <div className="pointer-events-none absolute -right-10 bottom-20 z-[1] h-80 w-80 rounded-full bg-accent-300/30 blur-[80px]" />
 
-            <header className="absolute top-0 left-0 w-full p-4 sm:p-6 flex justify-between items-center z-20 gap-3">
-                <Link to="/" className="flex items-center gap-2">
-                    <div className="w-8 h-8 bg-accent-600 rounded-lg flex items-center justify-center shadow-accent-200 shadow-lg transform rotate-3">
-                        <Plane className="text-white transform -rotate-3" size={18} weight="duotone" />
-                    </div>
-                    <span className="font-bold text-xl tracking-tight text-gray-900 hidden sm:block">Travel<span className="text-accent-600">Flow</span></span>
-                </Link>
-                <nav className="hidden md:flex items-center gap-5 text-sm bg-white/75 backdrop-blur px-4 py-2 rounded-full border border-slate-200">
-                    <NavLink to="/features" className={createNavLinkClass}>Features</NavLink>
-                    <NavLink to="/inspirations" className={createNavLinkClass}>Inspirations</NavLink>
-                    <NavLink to="/updates" className={createNavLinkClass}>News & Updates</NavLink>
-                    <NavLink to="/blog" className={createNavLinkClass}>Blog</NavLink>
-                </nav>
-                <div className="flex items-center gap-2">
-                    <NavLink
-                        to="/login"
-                        className="hidden sm:inline-flex px-3 py-2 bg-white/80 backdrop-blur border border-gray-200 hover:border-accent-300 rounded-full text-sm font-medium text-gray-600 hover:text-accent-600 transition-all"
-                    >
-                        Login
-                    </NavLink>
-                    <button
-                        onClick={onOpenManager}
-                        className="flex items-center gap-2 px-4 py-2 bg-white/80 backdrop-blur border border-gray-200 hover:border-accent-300 hover:text-accent-600 rounded-full shadow-sm hover:shadow transition-all text-sm font-medium text-gray-600"
-                    >
-                        <Folder size={16} />
-                        <span>My Trips</span>
-                    </button>
-                </div>
-            </header>
+            <div className="relative z-20">
+                <SiteHeader variant="glass" hideCreateTrip onMyTripsClick={onOpenManager} />
+            </div>
 
-            <div className="relative z-10 flex-1 flex flex-col items-center justify-center p-4 pt-28 sm:pt-32 md:pt-36 overflow-y-auto w-full">
+            <div className="relative z-10 flex-1 flex flex-col items-center justify-center p-4 pt-6 sm:pt-8 md:pt-10 overflow-y-auto w-full">
                 <div className="text-center mb-6">
                     <h1 className="text-4xl font-extrabold text-gray-900 mb-2" style={{ fontFamily: "'Space Grotesk', sans-serif" }}>Plan your next adventure</h1>
                     <p className="text-gray-500">Choose a flow and generate your itinerary in seconds.</p>
@@ -1511,6 +1478,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
             <div className="relative z-[2] mt-auto">
                 <SiteFooter className="bg-white/75 backdrop-blur border-slate-200/70" />
             </div>
+
         </div>
     );
 };

--- a/components/marketing/MarketingLayout.tsx
+++ b/components/marketing/MarketingLayout.tsx
@@ -1,71 +1,26 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
-import { AirplaneTilt } from '@phosphor-icons/react';
 import { SiteFooter } from './SiteFooter';
 import { EarlyAccessBanner } from './EarlyAccessBanner';
-import { trackEvent } from '../../services/analyticsService';
+import { SiteHeader } from '../navigation/SiteHeader';
+import { useTripManager } from '../../contexts/TripManagerContext';
 
 interface MarketingLayoutProps {
     children: React.ReactNode;
 }
 
-const navLinkClass = ({ isActive }: { isActive: boolean }) => {
-    const baseClass = 'relative font-semibold text-slate-500 transition-colors hover:text-slate-900 after:pointer-events-none after:absolute after:-bottom-4 after:left-0 after:h-0.5 after:w-full after:origin-center after:scale-x-0 after:rounded-full after:bg-accent-600 after:transition-transform';
-    if (isActive) {
-        return `${baseClass} text-slate-900 after:scale-x-100`;
-    }
-    return baseClass;
-};
-
 export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) => {
-    const handleNavClick = (target: string) => {
-        trackEvent('marketing_nav_clicked', { target });
-    };
+    const { openTripManager } = useTripManager();
 
     return (
         <div className="min-h-screen scroll-smooth bg-slate-50 text-slate-900 flex flex-col">
             <div className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(14,165,233,0.18),_transparent_48%),radial-gradient(circle_at_80%_30%,_rgba(15,23,42,0.10),_transparent_35%)]" />
-            <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur" style={{ viewTransitionName: 'site-header' }}>
-                <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-5 py-4 md:px-8">
-                    <NavLink to="/" onClick={() => handleNavClick('brand')} className="flex items-center gap-2">
-                        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent-600 text-white shadow-lg shadow-accent-200">
-                            <AirplaneTilt size={16} weight="duotone" />
-                        </span>
-                        <span className="text-lg font-extrabold tracking-tight">TravelFlow</span>
-                    </NavLink>
-
-                    <nav className="hidden items-center gap-6 text-sm md:flex">
-                        <NavLink to="/features" onClick={() => handleNavClick('features')} className={navLinkClass}>Features</NavLink>
-                        <NavLink to="/inspirations" onClick={() => handleNavClick('inspirations')} className={navLinkClass}>Inspirations</NavLink>
-                        <NavLink to="/updates" onClick={() => handleNavClick('updates')} className={navLinkClass}>News & Updates</NavLink>
-                        <NavLink to="/blog" onClick={() => handleNavClick('blog')} className={navLinkClass}>Blog</NavLink>
-                    </nav>
-
-                    <div className="flex items-center gap-2">
-                        <NavLink
-                            to="/login"
-                            onClick={() => handleNavClick('login')}
-                            className="rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900"
-                        >
-                            Login
-                        </NavLink>
-                        <NavLink
-                            to="/create-trip"
-                            onClick={() => handleNavClick('create_trip')}
-                            className="rounded-lg bg-accent-600 px-3 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
-                        >
-                            Create Trip
-                        </NavLink>
-                    </div>
-                </div>
-            </header>
+            <SiteHeader onMyTripsClick={openTripManager} />
             <EarlyAccessBanner />
 
             <main className="mx-auto w-full max-w-7xl flex-1 px-5 pb-16 pt-10 md:px-8 md:pt-14">
                 {children}
             </main>
             <SiteFooter />
-
         </div>
     );
 };

--- a/components/navigation/MobileMenu.tsx
+++ b/components/navigation/MobileMenu.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect } from 'react';
+import { NavLink } from 'react-router-dom';
+import { X, AirplaneTilt } from '@phosphor-icons/react';
+import { NAV_ITEMS } from '../../config/navigation';
+import { useHasSavedTrips } from '../../hooks/useHasSavedTrips';
+import { trackEvent } from '../../services/analyticsService';
+
+interface MobileMenuProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onMyTripsClick?: () => void;
+}
+
+const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+    `block rounded-xl px-4 py-3 text-base font-semibold transition-colors ${
+        isActive
+            ? 'bg-accent-50 text-accent-700'
+            : 'text-slate-700 hover:bg-slate-100'
+    }`;
+
+export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTripsClick }) => {
+    const hasTrips = useHasSavedTrips();
+
+    useEffect(() => {
+        if (isOpen) {
+            trackEvent('mobile_menu_opened');
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.body.style.overflow = '';
+        }
+        return () => {
+            document.body.style.overflow = '';
+        };
+    }, [isOpen]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [isOpen, onClose]);
+
+    const handleNavClick = (target: string) => {
+        trackEvent('mobile_nav_clicked', { target });
+        onClose();
+    };
+
+    const visibleItems = NAV_ITEMS.filter((item) => !item.requiresTrips);
+
+    return (
+        <>
+            {/* Backdrop */}
+            <div
+                className={`fixed inset-0 z-50 bg-slate-900/50 backdrop-blur-sm transition-opacity duration-300 ${
+                    isOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+                }`}
+                onClick={onClose}
+                aria-hidden="true"
+            />
+
+            {/* Panel */}
+            <div
+                className={`fixed inset-y-0 right-0 z-50 w-[85vw] max-w-sm bg-white shadow-2xl transition-transform duration-300 ease-out ${
+                    isOpen ? 'translate-x-0' : 'translate-x-full'
+                }`}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Navigation menu"
+            >
+                <div className="flex h-full flex-col">
+                    {/* Header */}
+                    <div className="flex items-center justify-between border-b border-slate-100 px-5 py-4">
+                        <div className="flex items-center gap-2">
+                            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent-600 text-white shadow-lg shadow-accent-200">
+                                <AirplaneTilt size={16} weight="duotone" />
+                            </span>
+                            <span className="text-lg font-extrabold tracking-tight">TravelFlow</span>
+                        </div>
+                        <button
+                            onClick={onClose}
+                            className="flex h-9 w-9 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+                            aria-label="Close menu"
+                        >
+                            <X size={20} weight="bold" />
+                        </button>
+                    </div>
+
+                    {/* Nav links */}
+                    <nav className="flex-1 overflow-y-auto px-3 py-4">
+                        <div className="space-y-1">
+                            {visibleItems.map((item) => (
+                                <NavLink
+                                    key={item.to}
+                                    to={item.to}
+                                    className={navLinkClass}
+                                    onClick={() => handleNavClick(item.label.toLowerCase())}
+                                >
+                                    {item.label}
+                                </NavLink>
+                            ))}
+                        </div>
+                    </nav>
+
+                    {/* Footer CTA */}
+                    <div className="border-t border-slate-100 p-4 space-y-2">
+                        {onMyTripsClick && hasTrips ? (
+                            <button
+                                onClick={() => {
+                                    handleNavClick('my_trips');
+                                    onMyTripsClick();
+                                }}
+                                className="block w-full rounded-xl bg-accent-600 px-4 py-3 text-center text-base font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
+                            >
+                                My Trips
+                            </button>
+                        ) : (
+                            <NavLink
+                                to="/create-trip"
+                                onClick={() => handleNavClick('create_trip')}
+                                className="block w-full rounded-xl bg-accent-600 px-4 py-3 text-center text-base font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
+                            >
+                                Create Trip
+                            </NavLink>
+                        )}
+                        <NavLink
+                            to="/login"
+                            onClick={() => handleNavClick('login')}
+                            className="block w-full rounded-xl border border-slate-200 px-4 py-3 text-center text-base font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900"
+                        >
+                            Login
+                        </NavLink>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+};

--- a/components/navigation/SiteHeader.tsx
+++ b/components/navigation/SiteHeader.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { AirplaneTilt, List, Folder } from '@phosphor-icons/react';
+import { MobileMenu } from './MobileMenu';
+import { useHasSavedTrips } from '../../hooks/useHasSavedTrips';
+import { trackEvent } from '../../services/analyticsService';
+
+type HeaderVariant = 'solid' | 'glass';
+
+interface SiteHeaderProps {
+    variant?: HeaderVariant;
+    /** When provided, "My Trips" opens this callback instead of navigating. */
+    onMyTripsClick?: () => void;
+    /** Hide the "Create Trip" CTA (e.g. when already on the create-trip page). */
+    hideCreateTrip?: boolean;
+}
+
+const navLinkClass = ({ isActive }: { isActive: boolean }) => {
+    const baseClass = 'relative font-semibold text-slate-500 transition-colors hover:text-slate-900 after:pointer-events-none after:absolute after:-bottom-4 after:left-0 after:h-0.5 after:w-full after:origin-center after:scale-x-0 after:rounded-full after:bg-accent-600 after:transition-transform';
+    if (isActive) return `${baseClass} text-slate-900 after:scale-x-100`;
+    return baseClass;
+};
+
+export const SiteHeader: React.FC<SiteHeaderProps> = ({
+    variant = 'solid',
+    onMyTripsClick,
+    hideCreateTrip = false,
+}) => {
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const hasTrips = useHasSavedTrips();
+
+    const handleNavClick = (target: string) => {
+        trackEvent('marketing_nav_clicked', { target });
+    };
+
+    const isGlass = variant === 'glass';
+
+    const headerClass = isGlass
+        ? 'sticky top-0 z-40 border-b border-white/20 bg-white/80 backdrop-blur'
+        : 'sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur';
+
+    const loginClass = isGlass
+        ? 'hidden sm:inline-flex rounded-lg border border-slate-200/70 bg-white/60 px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900'
+        : 'hidden sm:inline-flex rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900';
+
+    const burgerClass = isGlass
+        ? 'flex h-9 w-9 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-white/60 hover:text-slate-900 md:hidden'
+        : 'flex h-9 w-9 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 md:hidden';
+
+    return (
+        <>
+            <header className={headerClass} style={{ viewTransitionName: 'site-header' }}>
+                <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-5 py-4 md:px-8">
+                    <NavLink to="/" onClick={() => handleNavClick('brand')} className="flex items-center gap-2">
+                        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent-600 text-white shadow-lg shadow-accent-200">
+                            <AirplaneTilt size={16} weight="duotone" />
+                        </span>
+                        <span className="text-lg font-extrabold tracking-tight">TravelFlow</span>
+                    </NavLink>
+
+                    <nav className="hidden items-center gap-6 text-sm md:flex">
+                        <NavLink to="/features" onClick={() => handleNavClick('features')} className={navLinkClass}>Features</NavLink>
+                        <NavLink to="/inspirations" onClick={() => handleNavClick('inspirations')} className={navLinkClass}>Inspirations</NavLink>
+                        <NavLink to="/updates" onClick={() => handleNavClick('updates')} className={navLinkClass}>News & Updates</NavLink>
+                        <NavLink to="/blog" onClick={() => handleNavClick('blog')} className={navLinkClass}>Blog</NavLink>
+                        <NavLink to="/pricing" onClick={() => handleNavClick('pricing')} className={navLinkClass}>Pricing</NavLink>
+                    </nav>
+
+                    <div className="flex items-center gap-2">
+                        <NavLink
+                            to="/login"
+                            onClick={() => handleNavClick('login')}
+                            className={loginClass}
+                        >
+                            Login
+                        </NavLink>
+                        {hideCreateTrip ? (
+                            hasTrips && onMyTripsClick && (
+                                <button
+                                    onClick={() => {
+                                        handleNavClick('my_trips');
+                                        onMyTripsClick();
+                                    }}
+                                    className="hidden sm:flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900"
+                                >
+                                    <Folder size={15} />
+                                    My Trips
+                                </button>
+                            )
+                        ) : (
+                            <NavLink
+                                to="/create-trip"
+                                onClick={() => handleNavClick('create_trip')}
+                                className="rounded-lg bg-accent-600 px-3 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
+                            >
+                                Create Trip
+                            </NavLink>
+                        )}
+                        <button
+                            onClick={() => setIsMobileMenuOpen(true)}
+                            className={burgerClass}
+                            aria-label="Open menu"
+                        >
+                            <List size={22} weight="bold" />
+                        </button>
+                    </div>
+                </div>
+            </header>
+
+            <MobileMenu
+                isOpen={isMobileMenuOpen}
+                onClose={() => setIsMobileMenuOpen(false)}
+                onMyTripsClick={onMyTripsClick}
+            />
+        </>
+    );
+};

--- a/config/navigation.ts
+++ b/config/navigation.ts
@@ -1,0 +1,12 @@
+export interface NavItem {
+    label: string;
+    to: string;
+}
+
+export const NAV_ITEMS: NavItem[] = [
+    { label: 'Features', to: '/features' },
+    { label: 'Inspirations', to: '/inspirations' },
+    { label: 'News & Updates', to: '/updates' },
+    { label: 'Blog', to: '/blog' },
+    { label: 'Pricing', to: '/pricing' },
+];

--- a/content/updates/2026-02-09-mobile-nav-pricing.md
+++ b/content/updates/2026-02-09-mobile-nav-pricing.md
@@ -1,0 +1,23 @@
+---
+id: rel-2026-02-09-mobile-nav-pricing
+version: v0.24.0
+title: "Unified navigation, mobile menu, pricing page & My Trips"
+date: 2026-02-09
+published_at: 2026-02-09T18:00:00Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "Consistent navigation across all pages, full mobile menu, a new Pricing page, and quick access to saved trips."
+---
+
+## Changes
+- [x] [New feature] 📱 Mobile navigation menu — slide-in burger menu on all marketing and create-trip pages with all nav links and CTAs.
+- [x] [New feature] 💰 New Pricing page with three-tier plan overview (Free, Casual, Globetrotter).
+- [x] [New feature] 📂 "My Trips" now appears in the navigation bar when you have saved trips, opening your trip library instantly.
+- [x] [Improved] 🧭 Pricing link added to desktop navigation on all pages.
+- [x] [Improved] 🎨 Unified navigation bar across all pages — marketing pages and trip creation now share the same header with a subtle glass effect on the create-trip page.
+- [x] [Improved] 🔒 Body scroll is locked while the mobile menu is open for a smoother experience.
+- [ ] [Internal] Extracted shared SiteHeader component used by MarketingLayout and CreateTripForm.
+- [ ] [Internal] Centralized navigation config for consistent links across layouts.
+- [ ] [Internal] Added TripManagerContext to avoid prop drilling for trip manager access.
+- [ ] [Internal] Storage service now dispatches custom events for reactive trip count updates.

--- a/contexts/TripManagerContext.tsx
+++ b/contexts/TripManagerContext.tsx
@@ -1,0 +1,22 @@
+import React, { createContext, useContext } from 'react';
+
+interface TripManagerContextValue {
+    openTripManager: () => void;
+}
+
+const TripManagerContext = createContext<TripManagerContextValue | null>(null);
+
+export const TripManagerProvider: React.FC<{
+    openTripManager: () => void;
+    children: React.ReactNode;
+}> = ({ openTripManager, children }) => (
+    <TripManagerContext.Provider value={{ openTripManager }}>
+        {children}
+    </TripManagerContext.Provider>
+);
+
+export const useTripManager = (): TripManagerContextValue => {
+    const ctx = useContext(TripManagerContext);
+    if (!ctx) throw new Error('useTripManager must be used within TripManagerProvider');
+    return ctx;
+};

--- a/hooks/useHasSavedTrips.ts
+++ b/hooks/useHasSavedTrips.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { getAllTrips } from '../services/storageService';
+
+export const useHasSavedTrips = (): boolean => {
+    const [hasTrips, setHasTrips] = useState(() => getAllTrips().length > 0);
+
+    useEffect(() => {
+        const check = () => setHasTrips(getAllTrips().length > 0);
+
+        window.addEventListener('storage', check);
+        window.addEventListener('tf:trips-updated', check);
+        return () => {
+            window.removeEventListener('storage', check);
+            window.removeEventListener('tf:trips-updated', check);
+        };
+    }, []);
+
+    return hasTrips;
+};

--- a/pages/PricingPage.tsx
+++ b/pages/PricingPage.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Check } from '@phosphor-icons/react';
+import { MarketingLayout } from '../components/marketing/MarketingLayout';
+
+interface PricingTier {
+    name: string;
+    price: string;
+    period: string;
+    badge: string;
+    badgeClass: string;
+    description: string;
+    accentClass: string;
+    ringClass: string;
+    features: string[];
+    notIncluded?: string[];
+    cta: string;
+    ctaLink?: string;
+    ctaDisabled?: boolean;
+    highlighted?: boolean;
+}
+
+const tiers: PricingTier[] = [
+    {
+        name: 'Free',
+        price: '$0',
+        period: '/mo',
+        badge: 'Current plan',
+        badgeClass: 'border-slate-300 bg-slate-100 text-slate-700',
+        description: 'Everything you need to plan your next trip.',
+        accentClass: 'from-slate-600 to-slate-800',
+        ringClass: 'ring-slate-900/5',
+        features: [
+            'AI trip generation (3 modes)',
+            'Interactive map & timeline',
+            'Drag-and-drop itinerary builder',
+            'Print-ready layouts',
+            'Up to 5 saved trips',
+            'Share via link',
+        ],
+        cta: 'Get Started',
+        ctaLink: '/create-trip',
+    },
+    {
+        name: 'Casual',
+        price: '$9',
+        period: '/mo',
+        badge: 'Coming Soon',
+        badgeClass: 'border-accent-300 bg-accent-100 text-accent-700',
+        description: 'For frequent travelers who want more power.',
+        accentClass: 'from-accent-500 to-accent-700',
+        ringClass: 'ring-accent-500/10',
+        features: [
+            'Everything in Free, plus:',
+            'Unlimited saved trips',
+            'Priority AI generation',
+            'PDF & calendar export',
+            'Advanced sharing controls',
+            'Custom map styles',
+        ],
+        cta: 'Coming Soon',
+        ctaDisabled: true,
+        highlighted: true,
+    },
+    {
+        name: 'Globetrotter',
+        price: '$19',
+        period: '/mo',
+        badge: 'Coming Soon',
+        badgeClass: 'border-amber-300 bg-amber-100 text-amber-700',
+        description: 'The ultimate travel planning experience.',
+        accentClass: 'from-amber-500 to-amber-700',
+        ringClass: 'ring-amber-500/10',
+        features: [
+            'Everything in Casual, plus:',
+            'Collaborative editing',
+            'Premium travel insights',
+            'Offline access',
+            'Premium support',
+            'Early access to new features',
+        ],
+        cta: 'Coming Soon',
+        ctaDisabled: true,
+    },
+];
+
+export const PricingPage: React.FC = () => {
+    return (
+        <MarketingLayout>
+            <div className="py-8 md:py-16">
+                <div className="mx-auto max-w-3xl text-center mb-12 md:mb-16">
+                    <h1
+                        className="text-4xl font-extrabold tracking-tight text-slate-900 sm:text-5xl"
+                        style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                    >
+                        Simple, transparent pricing
+                    </h1>
+                    <p className="mt-4 text-lg text-slate-500">
+                        Start for free and upgrade when you need more. No hidden fees, cancel anytime.
+                    </p>
+                </div>
+
+                <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-3 md:gap-8">
+                    {tiers.map((tier) => (
+                        <div
+                            key={tier.name}
+                            className={`relative flex flex-col rounded-2xl bg-white p-8 shadow-lg ring-1 ${tier.ringClass} ${
+                                tier.highlighted ? 'md:-mt-4 md:mb-0 md:pb-12 md:pt-10 scale-[1.02] md:scale-105 z-10' : ''
+                            }`}
+                        >
+                            {/* Accent bar */}
+                            <div className={`absolute inset-x-0 top-0 h-1 rounded-t-2xl bg-gradient-to-r ${tier.accentClass}`} />
+
+                            {/* Badge */}
+                            <span className={`inline-flex self-start rounded-full border px-3 py-1 text-xs font-semibold ${tier.badgeClass}`}>
+                                {tier.badge}
+                            </span>
+
+                            {/* Price */}
+                            <div className="mt-5 flex items-baseline gap-1">
+                                <span
+                                    className="text-4xl font-extrabold tracking-tight text-slate-900"
+                                    style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                                >
+                                    {tier.price}
+                                </span>
+                                <span className="text-sm font-medium text-slate-500">{tier.period}</span>
+                            </div>
+
+                            <p className="mt-2 text-sm text-slate-500">{tier.description}</p>
+
+                            {/* Features */}
+                            <ul className="mt-6 flex-1 space-y-3">
+                                {tier.features.map((feature) => (
+                                    <li key={feature} className="flex items-start gap-2.5 text-sm text-slate-700">
+                                        <Check size={16} weight="bold" className="mt-0.5 shrink-0 text-accent-600" />
+                                        {feature}
+                                    </li>
+                                ))}
+                            </ul>
+
+                            {/* CTA */}
+                            <div className="mt-8">
+                                {tier.ctaDisabled ? (
+                                    <button
+                                        disabled
+                                        className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-400 cursor-not-allowed"
+                                    >
+                                        {tier.cta}
+                                    </button>
+                                ) : (
+                                    <Link
+                                        to={tier.ctaLink || '/create-trip'}
+                                        className="block w-full rounded-xl bg-accent-600 px-4 py-3 text-center text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
+                                    >
+                                        {tier.cta}
+                                    </Link>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                <div className="mx-auto mt-16 max-w-2xl text-center">
+                    <p className="text-sm text-slate-400">
+                        Prices shown are for illustration only. TravelFlow is currently free during early access.
+                    </p>
+                </div>
+            </div>
+        </MarketingLayout>
+    );
+};

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -60,6 +60,7 @@ export const saveTrip = (trip: ITrip, options?: { preserveUpdatedAt?: boolean })
         }
         
         localStorage.setItem(STORAGE_KEY, JSON.stringify(trips));
+        window.dispatchEvent(new CustomEvent('tf:trips-updated'));
     } catch (e) {
         console.error("Failed to save trip", e);
     }
@@ -70,6 +71,7 @@ export const deleteTrip = (id: string): void => {
         const trips = getAllTrips();
         const filtered = trips.filter(t => t.id !== id);
         localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+        window.dispatchEvent(new CustomEvent('tf:trips-updated'));
     } catch (e) {
         console.error("Failed to delete trip", e);
     }
@@ -86,6 +88,7 @@ export const setAllTrips = (trips: ITrip[]): void => {
             .map(normalizeTrip)
             .filter((trip): trip is ITrip => Boolean(trip));
         localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+        window.dispatchEvent(new CustomEvent('tf:trips-updated'));
     } catch (e) {
         console.error("Failed to replace trips in storage", e);
     }


### PR DESCRIPTION
## Summary
- **Unified SiteHeader** component (`solid`/`glass` variants) replaces two separate navigations in MarketingLayout and CreateTripForm — consistent links, logo, and behavior everywhere.
- **Mobile navigation** — slide-in burger menu on all marketing and create-trip pages with nav links, CTAs, scroll lock, and analytics tracking.
- **Pricing page** (`/pricing`) — three-tier plan overview (Free, Casual, Globetrotter) with responsive card grid.
- **Conditional "My Trips"** — appears in the CTA slot on the create-trip page when the user has saved trips, opening the TripManager overlay.
- **TripManagerContext** to avoid prop-drilling for opening the trip manager from marketing pages.
- **Reactive `useHasSavedTrips` hook** powered by `tf:trips-updated` custom events dispatched from storageService.

## New files
| File | Purpose |
|---|---|
| `components/navigation/SiteHeader.tsx` | Shared header with solid/glass variants |
| `components/navigation/MobileMenu.tsx` | Slide-in mobile menu panel |
| `config/navigation.ts` | Centralized nav link config |
| `contexts/TripManagerContext.tsx` | Context for opening TripManager |
| `hooks/useHasSavedTrips.ts` | Reactive saved-trips check |
| `pages/PricingPage.tsx` | Three-tier pricing page |
| `content/updates/2026-02-09-mobile-nav-pricing.md` | v0.24.0 release notes |

## Test plan
- [ ] Resize below 768px → burger icon appears on marketing pages and create-trip
- [ ] Tap burger → menu slides in, body scroll locked, Escape/backdrop closes it
- [ ] Navigate via mobile menu → page loads, menu closes
- [ ] Create a trip → "My Trips" button appears in header CTA slot on `/create-trip`; delete all → disappears
- [ ] Visit `/pricing` → three-tier cards render responsively
- [ ] Desktop nav unchanged on marketing pages — all links + Pricing + Create Trip CTA
- [ ] TripView header unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)