### PR TITLE
feat: structured ISO destination codes, city prefill & system docs

### DIFF
--- a/content/updates/2026-02-09-inspiration-prefill-links.md
+++ b/content/updates/2026-02-09-inspiration-prefill-links.md
@@ -1,0 +1,29 @@
+---
+id: rel-2026-02-09-inspiration-prefill-links
+version: v0.25.0
+title: "Inspiration links now pre-fill the trip form"
+date: 2026-02-09
+published_at: 2026-02-09T22:00:00Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "Clicking any destination, festival, or getaway on the Inspirations page now pre-fills the create trip form with country, dates, and notes."
+---
+
+## Changes
+- [x] [New feature] 🗺️ Inspiration links pre-fill the create trip form with destination, dates, and travel notes.
+- [x] [Improved] 🌍 Multi-country trips like Patagonia now correctly select both Chile and Argentina in the form.
+- [x] [Improved] 🏝️ Island destinations like Bali & Lombok are selected individually instead of the parent country.
+- [x] [Improved] 🏙️ Inspiration cards now pre-fill specific cities (e.g. Tokyo, Kyoto, Osaka for the Cherry Blossom Trail).
+- [x] [Improved] 🎪 Festival cards suggest start and end dates based on the next occurrence.
+- [x] [Improved] 🏖️ Weekend getaway links default to the coming Saturday with the right duration.
+- [x] [Improved] 📅 Monthly destination pills set the start date to the selected month.
+- [x] [Improved] 💡 Quick-start ideas now carry country and duration into the form.
+- [x] [New feature] 🏷️ A dismissible attribution badge shows which inspiration pre-filled the form.
+- [x] [Fixed] 🏴󠁧󠁢󠁳󠁣󠁴󠁿 Edinburgh Highlands getaway now shows the correct Scotland flag.
+- [ ] [Internal] Added structured ISO destination codes to all inspiration data entries.
+- [ ] [Internal] Island destinations now use ISO 3166-2 codes where available (33 islands), slug fallback otherwise.
+- [ ] [Internal] Replaced string-matching destination resolver with code-based lookup.
+- [ ] [Internal] Added `TripPrefillData` type and Base64URL encode/decode utilities.
+- [ ] [Internal] Edge function strips `prefill` query param from canonical URL for SEO.
+- [ ] [Internal] Added `docs/DESTINATION_SYSTEM.md` — comprehensive LLM-optimized reference for the destination and ISO code system.

--- a/data/inspirationsData.ts
+++ b/data/inspirationsData.ts
@@ -20,6 +20,8 @@ export interface Destination {
     mapColor: string;
     mapAccent: string;
     tags: string[];
+    destinationCodes: string[];
+    cities?: string[];
 }
 
 export interface InspirationCategory {
@@ -37,6 +39,7 @@ export interface MonthEntry {
     monthIndex: number; // 0-based
     emoji: string;
     destinations: string[];
+    destinationCodes: string[];
     description: string;
     blogSlugs?: string[];
 }
@@ -51,6 +54,8 @@ export interface FestivalEvent {
     durationDays: number;
     description: string;
     mapColor: string;
+    destinationCodes: string[];
+    cities?: string[];
     blogSlugs?: string[];
 }
 
@@ -63,16 +68,26 @@ export interface WeekendGetaway {
     description: string;
     mapColor: string;
     mapAccent: string;
+    destinationCodes: string[];
+    cities?: string[];
     blogSlugs?: string[];
 }
 
 export interface CountryGroup {
     country: string;
     flag: string;
+    destinationCode: string;
     tripCount: number;
     bestMonths: string;
     tags: string[];
     blogSlugs?: string[];
+}
+
+export interface QuickIdea {
+    label: string;
+    dest: string;
+    days: number;
+    destinationCode: string;
 }
 
 /* ── Categories (by theme) ── */
@@ -85,9 +100,9 @@ export const categories: InspirationCategory[] = [
         subtitle: 'Hikes, summits, and wild landscapes',
         color: 'bg-emerald-50 text-emerald-600 ring-emerald-100',
         destinations: [
-            { title: 'South Island Wilderness', country: 'New Zealand', flag: '🇳🇿', durationDays: 21, cityCount: 7, description: 'Milford Sound, glaciers, and the Routeburn Track — three weeks of jaw-dropping scenery.', mapColor: 'bg-emerald-100', mapAccent: 'bg-emerald-400', tags: ['nature', 'hiking', 'new zealand'] },
-            { title: 'Andes & Amazon Explorer', country: 'Peru', flag: '🇵🇪', durationDays: 16, cityCount: 5, description: 'From Machu Picchu at altitude to the Amazon basin — a route that covers every elevation.', mapColor: 'bg-orange-100', mapAccent: 'bg-orange-400', tags: ['adventure', 'nature', 'peru'] },
-            { title: 'Patagonia Circuit', country: 'Chile & Argentina', flag: '🇨🇱', durationDays: 14, cityCount: 4, description: 'Torres del Paine, Perito Moreno, and El Chaltén — the ultimate southern trek.', mapColor: 'bg-sky-100', mapAccent: 'bg-sky-400', tags: ['hiking', 'nature', 'chile', 'argentina'] },
+            { title: 'South Island Wilderness', country: 'New Zealand', flag: '🇳🇿', durationDays: 21, cityCount: 7, description: 'Milford Sound fjords, Fox Glacier hikes, and lakeside Queenstown — three weeks of jaw-dropping South Island scenery.', mapColor: 'bg-emerald-100', mapAccent: 'bg-emerald-400', tags: ['nature', 'hiking', 'new zealand'], destinationCodes: ['NZ'], cities: ['Queenstown', 'Milford Sound', 'Wanaka', 'Franz Josef', 'Christchurch', 'Te Anau', 'Dunedin'] },
+            { title: 'Andes & Amazon Explorer', country: 'Peru', flag: '🇵🇪', durationDays: 16, cityCount: 5, description: 'From the colonial streets of Lima to the heights of Machu Picchu, then deep into the Amazon basin.', mapColor: 'bg-orange-100', mapAccent: 'bg-orange-400', tags: ['adventure', 'nature', 'peru'], destinationCodes: ['PE'], cities: ['Lima', 'Cusco', 'Sacred Valley', 'Machu Picchu', 'Puerto Maldonado'] },
+            { title: 'Patagonia Circuit', country: 'Chile & Argentina', flag: '🇨🇱', durationDays: 14, cityCount: 4, description: 'Torres del Paine, Perito Moreno glacier, and the trails of El Chaltén — the ultimate southern trek.', mapColor: 'bg-sky-100', mapAccent: 'bg-sky-400', tags: ['hiking', 'nature', 'chile', 'argentina'], destinationCodes: ['CL', 'AR'], cities: ['Punta Arenas', 'Torres del Paine', 'El Calafate', 'El Chaltén'] },
         ],
     },
     {
@@ -97,9 +112,9 @@ export const categories: InspirationCategory[] = [
         subtitle: 'Eat your way through history',
         color: 'bg-amber-50 text-amber-600 ring-amber-100',
         destinations: [
-            { title: 'Italian Grand Tour', country: 'Italy', flag: '🇮🇹', durationDays: 18, cityCount: 6, description: 'Rome, Florence, Bologna, and the Amalfi Coast — pasta, art, and espresso in every city.', mapColor: 'bg-amber-100', mapAccent: 'bg-amber-500', tags: ['food', 'art', 'italy'] },
-            { title: 'Cherry Blossom Trail', country: 'Japan', flag: '🇯🇵', durationDays: 14, cityCount: 5, description: 'Tokyo, Kyoto, Osaka, Hiroshima — ramen counters, temple gardens, and spring blossoms.', mapColor: 'bg-rose-100', mapAccent: 'bg-rose-400', tags: ['culture', 'food', 'japan'] },
-            { title: 'Medinas & Sahara Nights', country: 'Morocco', flag: '🇲🇦', durationDays: 9, cityCount: 4, description: 'Marrakech souks, Fez tanneries, and a night under the Saharan stars.', mapColor: 'bg-yellow-100', mapAccent: 'bg-yellow-500', tags: ['culture', 'food', 'morocco'] },
+            { title: 'Italian Grand Tour', country: 'Italy', flag: '🇮🇹', durationDays: 18, cityCount: 6, description: 'From the Colosseum to the canals of Venice — pasta, Renaissance art, and espresso-fuelled days along the way.', mapColor: 'bg-amber-100', mapAccent: 'bg-amber-500', tags: ['food', 'art', 'italy'], destinationCodes: ['IT'], cities: ['Rome', 'Florence', 'Bologna', 'Venice', 'Naples', 'Amalfi'] },
+            { title: 'Cherry Blossom Trail', country: 'Japan', flag: '🇯🇵', durationDays: 14, cityCount: 5, description: 'From modern, vibrant Tokyo to historic Hiroshima — ramen counters, temple gardens, and spring blossoms.', mapColor: 'bg-rose-100', mapAccent: 'bg-rose-400', tags: ['culture', 'food', 'japan'], destinationCodes: ['JP'], cities: ['Tokyo', 'Kyoto', 'Osaka', 'Hiroshima', 'Nara'] },
+            { title: 'Medinas & Sahara Nights', country: 'Morocco', flag: '🇲🇦', durationDays: 9, cityCount: 4, description: 'Marrakech souks, Fez tanneries, the blue alleys of Chefchaouen, and a night under Saharan stars.', mapColor: 'bg-yellow-100', mapAccent: 'bg-yellow-500', tags: ['culture', 'food', 'morocco'], destinationCodes: ['MA'], cities: ['Marrakech', 'Fez', 'Chefchaouen', 'Merzouga'] },
         ],
         blogSlugs: ['budget-travel-europe'],
     },
@@ -110,9 +125,9 @@ export const categories: InspirationCategory[] = [
         subtitle: 'Turquoise water, white sand, zero stress',
         color: 'bg-cyan-50 text-cyan-600 ring-cyan-100',
         destinations: [
-            { title: 'Temples & Beaches', country: 'Thailand', flag: '🇹🇭', durationDays: 12, cityCount: 4, description: 'Bangkok temples, Chiang Mai markets, then island-hop through Koh Samui and Krabi.', mapColor: 'bg-emerald-100', mapAccent: 'bg-emerald-400', tags: ['beach', 'food', 'thailand'] },
-            { title: 'Greek Island Hop', country: 'Greece', flag: '🇬🇷', durationDays: 10, cityCount: 4, description: 'Athens, Santorini, Naxos, and Crete — whitewashed villages above the Aegean.', mapColor: 'bg-blue-100', mapAccent: 'bg-blue-400', tags: ['beach', 'culture', 'greece'] },
-            { title: 'Bali & Lombok', country: 'Indonesia', flag: '🇮🇩', durationDays: 14, cityCount: 5, description: 'Rice terraces, surf breaks, and volcano sunrises — two islands, endless vibes.', mapColor: 'bg-lime-100', mapAccent: 'bg-lime-500', tags: ['beach', 'adventure', 'indonesia'] },
+            { title: 'Temples & Beaches', country: 'Thailand', flag: '🇹🇭', durationDays: 12, cityCount: 4, description: 'Bangkok temples, Chiang Mai markets, then island-hop through Koh Samui and Krabi.', mapColor: 'bg-emerald-100', mapAccent: 'bg-emerald-400', tags: ['beach', 'food', 'thailand'], destinationCodes: ['TH'], cities: ['Bangkok', 'Chiang Mai', 'Koh Samui', 'Krabi'] },
+            { title: 'Greek Island Hop', country: 'Greece', flag: '🇬🇷', durationDays: 10, cityCount: 4, description: 'Athens, Santorini, Naxos, and Crete — whitewashed villages above the Aegean.', mapColor: 'bg-blue-100', mapAccent: 'bg-blue-400', tags: ['beach', 'culture', 'greece'], destinationCodes: ['GR-santorini', 'GR-naxos', 'GR-M'], cities: ['Athens'] },
+            { title: 'Bali & Lombok', country: 'Indonesia', flag: '🇮🇩', durationDays: 14, cityCount: 5, description: 'Rice terraces, surf breaks, and volcano sunrises on Bali, then hop to Lombok for quieter shores.', mapColor: 'bg-lime-100', mapAccent: 'bg-lime-500', tags: ['beach', 'adventure', 'indonesia'], destinationCodes: ['ID-BA', 'ID-lombok'], cities: ['Ubud', 'Seminyak', 'Canggu', 'Senggigi', 'Kuta Lombok'] },
         ],
     },
     {
@@ -122,9 +137,9 @@ export const categories: InspirationCategory[] = [
         subtitle: 'Weekend escapes and urban deep-dives',
         color: 'bg-violet-50 text-violet-600 ring-violet-100',
         destinations: [
-            { title: 'Atlantic Coast Road Trip', country: 'Portugal', flag: '🇵🇹', durationDays: 10, cityCount: 4, description: "Lisbon's tiles, Porto's port cellars, and the wild surf beaches of the Algarve.", mapColor: 'bg-sky-100', mapAccent: 'bg-sky-400', tags: ['city', 'surf', 'portugal'] },
-            { title: 'Nordic Design Circuit', country: 'Denmark & Sweden', flag: '🇩🇰', durationDays: 7, cityCount: 3, description: "Copenhagen canals, Malmö bridges, and Stockholm's old town — Scandinavian cool in one week.", mapColor: 'bg-slate-100', mapAccent: 'bg-slate-400', tags: ['city', 'design', 'denmark', 'sweden'] },
-            { title: 'Ring Road Circuit', country: 'Iceland', flag: '🇮🇸', durationDays: 7, cityCount: 3, description: 'Waterfalls, geysers, and black-sand beaches — the full island loop in a week.', mapColor: 'bg-indigo-100', mapAccent: 'bg-indigo-400', tags: ['nature', 'road trip', 'iceland'] },
+            { title: 'Atlantic Coast Road Trip', country: 'Portugal', flag: '🇵🇹', durationDays: 10, cityCount: 4, description: "Lisbon's tiled streets, Porto's port cellars, and the wild surf beaches of the Algarve coast.", mapColor: 'bg-sky-100', mapAccent: 'bg-sky-400', tags: ['city', 'surf', 'portugal'], destinationCodes: ['PT'], cities: ['Lisbon', 'Porto', 'Sintra', 'Lagos'] },
+            { title: 'Nordic Design Circuit', country: 'Denmark & Sweden', flag: '🇩🇰', durationDays: 7, cityCount: 3, description: "Copenhagen canals, Malmö bridges, and Stockholm's old town — Scandinavian cool in one week.", mapColor: 'bg-slate-100', mapAccent: 'bg-slate-400', tags: ['city', 'design', 'denmark', 'sweden'], destinationCodes: ['DK', 'SE'], cities: ['Copenhagen', 'Malmö', 'Stockholm'] },
+            { title: 'Ring Road Circuit', country: 'Iceland', flag: '🇮🇸', durationDays: 7, cityCount: 3, description: 'Waterfalls, geysers, and black-sand beaches — the full island loop from Reykjavik and back.', mapColor: 'bg-indigo-100', mapAccent: 'bg-indigo-400', tags: ['nature', 'road trip', 'iceland'], destinationCodes: ['IS'], cities: ['Reykjavik', 'Vik', 'Akureyri'] },
         ],
         blogSlugs: ['how-to-plan-multi-city-trip'],
     },
@@ -135,9 +150,9 @@ export const categories: InspirationCategory[] = [
         subtitle: 'Fewer moves, deeper immersion',
         color: 'bg-rose-50 text-rose-600 ring-rose-100',
         destinations: [
-            { title: 'Tuscan Countryside', country: 'Italy', flag: '🇮🇹', durationDays: 10, cityCount: 3, description: 'A farmhouse base near Siena with day trips to hilltop villages, vineyards, and Florence.', mapColor: 'bg-amber-100', mapAccent: 'bg-amber-400', tags: ['slow travel', 'food', 'italy'] },
-            { title: 'Sri Lanka Coast to Hills', country: 'Sri Lanka', flag: '🇱🇰', durationDays: 14, cityCount: 4, description: 'Beach mornings in Mirissa, tea plantations in Ella, and train rides through the highlands.', mapColor: 'bg-teal-100', mapAccent: 'bg-teal-400', tags: ['slow travel', 'nature', 'sri lanka'] },
-            { title: 'Oaxaca & Pacific Coast', country: 'Mexico', flag: '🇲🇽', durationDays: 12, cityCount: 3, description: 'Mezcal, mole, and markets in Oaxaca city, then surf and sea turtles in Puerto Escondido.', mapColor: 'bg-red-100', mapAccent: 'bg-red-400', tags: ['food', 'beach', 'mexico'] },
+            { title: 'Tuscan Countryside', country: 'Italy', flag: '🇮🇹', durationDays: 10, cityCount: 3, description: 'A farmhouse base near Siena with day trips to hilltop villages, vineyards, and Florence.', mapColor: 'bg-amber-100', mapAccent: 'bg-amber-400', tags: ['slow travel', 'food', 'italy'], destinationCodes: ['IT'], cities: ['Siena', 'Florence', 'San Gimignano'] },
+            { title: 'Sri Lanka Coast to Hills', country: 'Sri Lanka', flag: '🇱🇰', durationDays: 14, cityCount: 4, description: 'Colonial Galle fort, beach mornings in Mirissa, tea plantations in Ella, and train rides through the highlands.', mapColor: 'bg-teal-100', mapAccent: 'bg-teal-400', tags: ['slow travel', 'nature', 'sri lanka'], destinationCodes: ['LK'], cities: ['Colombo', 'Galle', 'Mirissa', 'Ella'] },
+            { title: 'Oaxaca & Pacific Coast', country: 'Mexico', flag: '🇲🇽', durationDays: 12, cityCount: 3, description: 'Mezcal, mole, and markets in Oaxaca city, then surf and sea turtles on the Pacific coast.', mapColor: 'bg-red-100', mapAccent: 'bg-red-400', tags: ['food', 'beach', 'mexico'], destinationCodes: ['MX'], cities: ['Oaxaca', 'Puerto Escondido', 'Mazunte'] },
         ],
     },
     {
@@ -147,9 +162,9 @@ export const categories: InspirationCategory[] = [
         subtitle: 'Golden hours and epic backdrops',
         color: 'bg-fuchsia-50 text-fuchsia-600 ring-fuchsia-100',
         destinations: [
-            { title: 'Northern Lights Chase', country: 'Norway', flag: '🇳🇴', durationDays: 7, cityCount: 3, description: 'Tromsø fjords, Lofoten fishing villages, and aurora borealis on winter nights.', mapColor: 'bg-indigo-100', mapAccent: 'bg-indigo-500', tags: ['photography', 'nature', 'norway'] },
-            { title: 'Cappadocia & Istanbul', country: 'Turkey', flag: '🇹🇷', durationDays: 8, cityCount: 3, description: 'Hot-air balloons at sunrise, fairy chimneys, and the Bosphorus at golden hour.', mapColor: 'bg-orange-100', mapAccent: 'bg-orange-500', tags: ['photography', 'culture', 'turkey'] },
-            { title: 'Rajasthan Heritage Trail', country: 'India', flag: '🇮🇳', durationDays: 12, cityCount: 5, description: "Jaipur's pink city, Jodhpur's blue lanes, and the Thar Desert under the stars.", mapColor: 'bg-yellow-100', mapAccent: 'bg-yellow-600', tags: ['photography', 'culture', 'india'] },
+            { title: 'Northern Lights Chase', country: 'Norway', flag: '🇳🇴', durationDays: 7, cityCount: 3, description: 'Tromsø fjords, Lofoten fishing villages, and aurora borealis dancing across Arctic winter skies.', mapColor: 'bg-indigo-100', mapAccent: 'bg-indigo-500', tags: ['photography', 'nature', 'norway'], destinationCodes: ['NO'], cities: ['Tromsø', 'Svolvær', 'Reine'] },
+            { title: 'Cappadocia & Istanbul', country: 'Turkey', flag: '🇹🇷', durationDays: 8, cityCount: 3, description: 'Hot-air balloons over Cappadocia at sunrise, fairy chimneys, and the Bosphorus skyline at golden hour.', mapColor: 'bg-orange-100', mapAccent: 'bg-orange-500', tags: ['photography', 'culture', 'turkey'], destinationCodes: ['TR'], cities: ['Istanbul', 'Göreme', 'Ankara'] },
+            { title: 'Rajasthan Heritage Trail', country: 'India', flag: '🇮🇳', durationDays: 12, cityCount: 5, description: "Jaipur's pink palaces, Jodhpur's blue lanes, and golden Jaisalmer at the edge of the Thar Desert.", mapColor: 'bg-yellow-100', mapAccent: 'bg-yellow-600', tags: ['photography', 'culture', 'india'], destinationCodes: ['IN'], cities: ['Delhi', 'Jaipur', 'Jodhpur', 'Udaipur', 'Jaisalmer'] },
         ],
     },
 ];
@@ -157,84 +172,84 @@ export const categories: InspirationCategory[] = [
 /* ── By month ── */
 
 export const monthEntries: MonthEntry[] = [
-    { month: 'January', monthIndex: 0, emoji: '❄️', destinations: ['Thailand', 'Sri Lanka', 'Mexico'], description: 'Escape winter — tropical heat, dry season beaches, and far-flung new year vibes.' },
-    { month: 'February', monthIndex: 1, emoji: '🎭', destinations: ['Brazil', 'Italy', 'Japan'], description: 'Carnival in Rio, Venice masquerade, and early plum blossom season in Kyoto.' },
-    { month: 'March', monthIndex: 2, emoji: '🌸', destinations: ['Japan', 'Morocco', 'Portugal'], description: 'Cherry blossoms peak, Sahara is still comfortable, and Lisbon starts warming up.', blogSlugs: ['best-time-visit-japan'] },
-    { month: 'April', monthIndex: 3, emoji: '🌷', destinations: ['Netherlands', 'Greece', 'Peru'], description: 'Tulip fields, Greek islands before the crowds, and dry-season Inca Trail.' },
-    { month: 'May', monthIndex: 4, emoji: '☀️', destinations: ['Italy', 'Croatia', 'Iceland'], description: 'Mediterranean shoulder season — perfect temps, smaller crowds, longer days.', blogSlugs: ['budget-travel-europe'] },
-    { month: 'June', monthIndex: 5, emoji: '🌅', destinations: ['Norway', 'Turkey', 'Indonesia'], description: 'Midnight sun in the Nordics, Cappadocia hot-air balloons, and Bali dry season.' },
-    { month: 'July', monthIndex: 6, emoji: '🏖️', destinations: ['Greece', 'France', 'Canada'], description: 'Peak summer in the Med, lavender fields in Provence, and Canadian Rockies.' },
-    { month: 'August', monthIndex: 7, emoji: '🌊', destinations: ['Iceland', 'Tanzania', 'Sweden'], description: 'Ring Road weather window, Great Migration, and Swedish archipelago sailing.' },
-    { month: 'September', monthIndex: 8, emoji: '🍂', destinations: ['Italy', 'Japan', 'New Zealand'], description: 'Wine harvest in Tuscany, autumn leaves in Kyoto, and NZ spring wildflowers.', blogSlugs: ['best-time-visit-japan'] },
-    { month: 'October', monthIndex: 9, emoji: '🎃', destinations: ['Mexico', 'Morocco', 'Portugal'], description: 'Día de los Muertos, comfortable desert temps, and Algarve autumn sun.', blogSlugs: ['festival-travel-guide'] },
-    { month: 'November', monthIndex: 10, emoji: '🍁', destinations: ['India', 'Thailand', 'Chile'], description: 'Rajasthan festival season, Thai loy krathong lanterns, and Patagonia spring.' },
-    { month: 'December', monthIndex: 11, emoji: '🎄', destinations: ['Austria', 'Thailand', 'New Zealand'], description: 'Christmas markets in Vienna, tropical island escapes, and NZ summer hiking.' },
+    { month: 'January', monthIndex: 0, emoji: '❄️', destinations: ['Thailand', 'Sri Lanka', 'Mexico'], destinationCodes: ['TH', 'LK', 'MX'], description: 'Escape winter — tropical heat, dry season beaches, and far-flung new year vibes.' },
+    { month: 'February', monthIndex: 1, emoji: '🎭', destinations: ['Brazil', 'Italy', 'Japan'], destinationCodes: ['BR', 'IT', 'JP'], description: 'Carnival in Rio, Venice masquerade, and early plum blossom season in Kyoto.' },
+    { month: 'March', monthIndex: 2, emoji: '🌸', destinations: ['Japan', 'Morocco', 'Portugal'], destinationCodes: ['JP', 'MA', 'PT'], description: 'Cherry blossoms peak, Sahara is still comfortable, and Lisbon starts warming up.', blogSlugs: ['best-time-visit-japan'] },
+    { month: 'April', monthIndex: 3, emoji: '🌷', destinations: ['Netherlands', 'Greece', 'Peru'], destinationCodes: ['NL', 'GR', 'PE'], description: 'Tulip fields, Greek islands before the crowds, and dry-season Inca Trail.' },
+    { month: 'May', monthIndex: 4, emoji: '☀️', destinations: ['Italy', 'Croatia', 'Iceland'], destinationCodes: ['IT', 'HR', 'IS'], description: 'Mediterranean shoulder season — perfect temps, smaller crowds, longer days.', blogSlugs: ['budget-travel-europe'] },
+    { month: 'June', monthIndex: 5, emoji: '🌅', destinations: ['Norway', 'Turkey', 'Indonesia'], destinationCodes: ['NO', 'TR', 'ID'], description: 'Midnight sun in the Nordics, Cappadocia hot-air balloons, and Bali dry season.' },
+    { month: 'July', monthIndex: 6, emoji: '🏖️', destinations: ['Greece', 'France', 'Canada'], destinationCodes: ['GR', 'FR', 'CA'], description: 'Peak summer in the Med, lavender fields in Provence, and Canadian Rockies.' },
+    { month: 'August', monthIndex: 7, emoji: '🌊', destinations: ['Iceland', 'Tanzania', 'Sweden'], destinationCodes: ['IS', 'TZ', 'SE'], description: 'Ring Road weather window, Great Migration, and Swedish archipelago sailing.' },
+    { month: 'September', monthIndex: 8, emoji: '🍂', destinations: ['Italy', 'Japan', 'New Zealand'], destinationCodes: ['IT', 'JP', 'NZ'], description: 'Wine harvest in Tuscany, autumn leaves in Kyoto, and NZ spring wildflowers.', blogSlugs: ['best-time-visit-japan'] },
+    { month: 'October', monthIndex: 9, emoji: '🎃', destinations: ['Mexico', 'Morocco', 'Portugal'], destinationCodes: ['MX', 'MA', 'PT'], description: 'Día de los Muertos, comfortable desert temps, and Algarve autumn sun.', blogSlugs: ['festival-travel-guide'] },
+    { month: 'November', monthIndex: 10, emoji: '🍁', destinations: ['India', 'Thailand', 'Chile'], destinationCodes: ['IN', 'TH', 'CL'], description: 'Rajasthan festival season, Thai loy krathong lanterns, and Patagonia spring.' },
+    { month: 'December', monthIndex: 11, emoji: '🎄', destinations: ['Austria', 'Thailand', 'New Zealand'], destinationCodes: ['AT', 'TH', 'NZ'], description: 'Christmas markets in Vienna, tropical island escapes, and NZ summer hiking.' },
 ];
 
 /* ── Festivals & events ── */
 
 export const festivalEvents: FestivalEvent[] = [
-    { name: 'Cherry Blossom Festival', country: 'Japan', flag: '🇯🇵', months: 'Mar–Apr', startMonth: 2, startDay: 20, description: 'Sakura season transforms parks and temples into clouds of pink — picnic under the blossoms in Kyoto and Tokyo.', mapColor: 'bg-rose-100', durationDays: 10, blogSlugs: ['best-time-visit-japan'] },
-    { name: 'Carnival', country: 'Brazil', flag: '🇧🇷', months: 'Feb', startMonth: 1, startDay: 25, description: 'The world\'s biggest party — samba parades, street blocos, and non-stop energy across Rio and Salvador.', mapColor: 'bg-yellow-100', durationDays: 5, blogSlugs: ['festival-travel-guide'] },
-    { name: 'Holi', country: 'India', flag: '🇮🇳', months: 'Mar', startMonth: 2, startDay: 14, description: 'The festival of colors — join locals throwing vibrant powders in Jaipur, Varanasi, and Mathura.', mapColor: 'bg-fuchsia-100', durationDays: 3, blogSlugs: ['festival-travel-guide'] },
-    { name: 'Día de los Muertos', country: 'Mexico', flag: '🇲🇽', months: 'Oct–Nov', startMonth: 9, startDay: 31, description: 'Marigold-decked altars, painted skulls, and candlelit cemetery vigils honoring the departed in Oaxaca.', mapColor: 'bg-orange-100', durationDays: 4, blogSlugs: ['festival-travel-guide'] },
-    { name: 'Oktoberfest', country: 'Germany', flag: '🇩🇪', months: 'Sep–Oct', startMonth: 8, startDay: 20, description: 'Munich\'s legendary beer festival — lederhosen, brass bands, pretzels, and 6 million visitors.', mapColor: 'bg-amber-100', durationDays: 4, blogSlugs: ['festival-travel-guide', 'budget-travel-europe'] },
-    { name: 'Loy Krathong', country: 'Thailand', flag: '🇹🇭', months: 'Nov', startMonth: 10, startDay: 5, description: 'Thousands of floating lanterns and candle-lit lotus boats released on rivers and lakes across Thailand.', mapColor: 'bg-emerald-100', durationDays: 3 },
-    { name: 'Northern Lights Season', country: 'Norway / Iceland', flag: '🇳🇴', months: 'Sep–Mar', startMonth: 8, startDay: 15, description: 'Chase the aurora borealis from Tromsø fjords or Icelandic lava fields — best viewed on clear winter nights.', mapColor: 'bg-indigo-100', durationDays: 7 },
-    { name: 'La Tomatina', country: 'Spain', flag: '🇪🇸', months: 'Aug', startMonth: 7, startDay: 27, description: 'The world\'s largest tomato fight in Buñol — an hour of pure, pulpy chaos followed by paella.', mapColor: 'bg-red-100', durationDays: 2, blogSlugs: ['festival-travel-guide'] },
-    { name: 'Songkran Water Festival', country: 'Thailand', flag: '🇹🇭', months: 'Apr', startMonth: 3, startDay: 13, description: 'Thai New Year celebrated with city-wide water fights, temple visits, and street food marathons.', mapColor: 'bg-cyan-100', durationDays: 4 },
-    { name: 'Venice Carnival', country: 'Italy', flag: '🇮🇹', months: 'Feb', startMonth: 1, startDay: 8, description: 'Ornate masks, gondola parades, and grand masquerade balls in the floating city.', mapColor: 'bg-violet-100', durationDays: 5, blogSlugs: ['festival-travel-guide', 'budget-travel-europe'] },
-    { name: 'Running of the Bulls', country: 'Spain', flag: '🇪🇸', months: 'Jul', startMonth: 6, startDay: 6, description: 'San Fermín festival in Pamplona — encierro runs, parades, fireworks, and non-stop Basque celebrations.', mapColor: 'bg-red-100', durationDays: 9, blogSlugs: ['festival-travel-guide'] },
-    { name: 'Chinese New Year', country: 'China', flag: '🇨🇳', months: 'Jan–Feb', startMonth: 0, startDay: 29, description: 'Dragon dances, lantern displays, and spectacular fireworks across Beijing, Shanghai, and Hong Kong.', mapColor: 'bg-red-100', durationDays: 7 },
-    { name: 'Glastonbury Festival', country: 'United Kingdom', flag: '🇬🇧', months: 'Jun', startMonth: 5, startDay: 25, description: 'The world\'s most iconic music festival — five days of legendary performances on a Somerset farm.', mapColor: 'bg-lime-100', durationDays: 5 },
-    { name: 'Burning Man', country: 'USA', flag: '🇺🇸', months: 'Aug–Sep', startMonth: 7, startDay: 24, description: 'A temporary city in the Nevada desert — radical self-expression, art installations, and the burning of the Man.', mapColor: 'bg-orange-100', durationDays: 9 },
-    { name: 'Diwali', country: 'India', flag: '🇮🇳', months: 'Oct–Nov', startMonth: 9, startDay: 20, description: 'The festival of lights — fireworks, oil lamps, rangoli art, and sweet feasts illuminate India for five days.', mapColor: 'bg-amber-100', durationDays: 5, blogSlugs: ['festival-travel-guide'] },
-    { name: "St. Patrick's Day", country: 'Ireland', flag: '🇮🇪', months: 'Mar', startMonth: 2, startDay: 17, description: 'Dublin turns green — parades, live music, and the best pints of Guinness you\'ll ever have.', mapColor: 'bg-emerald-100', durationDays: 3 },
-    { name: 'Mardi Gras', country: 'USA', flag: '🇺🇸', months: 'Feb', startMonth: 1, startDay: 17, description: 'New Orleans erupts with jazz, floats, beads, and king cake — weeks of parades building to Fat Tuesday.', mapColor: 'bg-purple-100', durationDays: 14 },
-    { name: 'Lantern Festival', country: 'Taiwan', flag: '🇹🇼', months: 'Feb', startMonth: 1, startDay: 12, description: 'Thousands of sky lanterns released over Pingxi — a mesmerizing sea of light drifting into the night sky.', mapColor: 'bg-amber-100', durationDays: 3 },
-    { name: 'Inti Raymi', country: 'Peru', flag: '🇵🇪', months: 'Jun', startMonth: 5, startDay: 24, description: 'The Inca festival of the sun — a grand ceremony at Sacsayhuamán fortress above Cusco with music and dance.', mapColor: 'bg-yellow-100', durationDays: 3 },
-    { name: 'Edinburgh Fringe', country: 'United Kingdom', flag: '🏴󠁧󠁢󠁳󠁣󠁴󠁿', months: 'Aug', startMonth: 7, startDay: 1, description: 'The world\'s largest arts festival — thousands of shows from comedy to theatre across Edinburgh\'s venues.', mapColor: 'bg-violet-100', durationDays: 25 },
+    { name: 'Cherry Blossom Festival', country: 'Japan', flag: '🇯🇵', months: 'Mar–Apr', startMonth: 2, startDay: 20, description: 'Sakura season transforms parks and temples into clouds of pink — picnic under the blossoms in Kyoto and Tokyo.', mapColor: 'bg-rose-100', durationDays: 10, destinationCodes: ['JP'], cities: ['Kyoto', 'Tokyo'], blogSlugs: ['best-time-visit-japan'] },
+    { name: 'Carnival', country: 'Brazil', flag: '🇧🇷', months: 'Feb', startMonth: 1, startDay: 25, description: 'The world\'s biggest party — samba parades, street blocos, and non-stop energy across Rio and Salvador.', mapColor: 'bg-yellow-100', durationDays: 5, destinationCodes: ['BR'], cities: ['Rio de Janeiro', 'Salvador'], blogSlugs: ['festival-travel-guide'] },
+    { name: 'Holi', country: 'India', flag: '🇮🇳', months: 'Mar', startMonth: 2, startDay: 14, description: 'The festival of colors — join locals throwing vibrant powders in Jaipur, Varanasi, and Mathura.', mapColor: 'bg-fuchsia-100', durationDays: 3, destinationCodes: ['IN'], cities: ['Jaipur', 'Varanasi'], blogSlugs: ['festival-travel-guide'] },
+    { name: 'Día de los Muertos', country: 'Mexico', flag: '🇲🇽', months: 'Oct–Nov', startMonth: 9, startDay: 31, description: 'Marigold-decked altars, painted skulls, and candlelit cemetery vigils honoring the departed in Oaxaca.', mapColor: 'bg-orange-100', durationDays: 4, destinationCodes: ['MX'], cities: ['Oaxaca'], blogSlugs: ['festival-travel-guide'] },
+    { name: 'Oktoberfest', country: 'Germany', flag: '🇩🇪', months: 'Sep–Oct', startMonth: 8, startDay: 20, description: 'Munich\'s legendary beer festival — lederhosen, brass bands, pretzels, and 6 million visitors.', mapColor: 'bg-amber-100', durationDays: 4, destinationCodes: ['DE'], cities: ['Munich'], blogSlugs: ['festival-travel-guide', 'budget-travel-europe'] },
+    { name: 'Loy Krathong', country: 'Thailand', flag: '🇹🇭', months: 'Nov', startMonth: 10, startDay: 5, description: 'Thousands of floating lanterns and candle-lit lotus boats released on rivers and lakes across Thailand.', mapColor: 'bg-emerald-100', durationDays: 3, destinationCodes: ['TH'], cities: ['Chiang Mai'] },
+    { name: 'Northern Lights Season', country: 'Norway / Iceland', flag: '🇳🇴', months: 'Sep–Mar', startMonth: 8, startDay: 15, description: 'Chase the aurora borealis from Tromsø fjords or Icelandic lava fields — best viewed on clear winter nights.', mapColor: 'bg-indigo-100', durationDays: 7, destinationCodes: ['NO', 'IS'], cities: ['Tromsø'] },
+    { name: 'La Tomatina', country: 'Spain', flag: '🇪🇸', months: 'Aug', startMonth: 7, startDay: 27, description: 'The world\'s largest tomato fight in Buñol — an hour of pure, pulpy chaos followed by paella.', mapColor: 'bg-red-100', durationDays: 2, destinationCodes: ['ES'], cities: ['Valencia'], blogSlugs: ['festival-travel-guide'] },
+    { name: 'Songkran Water Festival', country: 'Thailand', flag: '🇹🇭', months: 'Apr', startMonth: 3, startDay: 13, description: 'Thai New Year celebrated with city-wide water fights, temple visits, and street food marathons.', mapColor: 'bg-cyan-100', durationDays: 4, destinationCodes: ['TH'], cities: ['Bangkok', 'Chiang Mai'] },
+    { name: 'Venice Carnival', country: 'Italy', flag: '🇮🇹', months: 'Feb', startMonth: 1, startDay: 8, description: 'Ornate masks, gondola parades, and grand masquerade balls in the floating city.', mapColor: 'bg-violet-100', durationDays: 5, destinationCodes: ['IT'], cities: ['Venice'], blogSlugs: ['festival-travel-guide', 'budget-travel-europe'] },
+    { name: 'Running of the Bulls', country: 'Spain', flag: '🇪🇸', months: 'Jul', startMonth: 6, startDay: 6, description: 'San Fermín festival in Pamplona — encierro runs, parades, fireworks, and non-stop Basque celebrations.', mapColor: 'bg-red-100', durationDays: 9, destinationCodes: ['ES'], cities: ['Pamplona'], blogSlugs: ['festival-travel-guide'] },
+    { name: 'Chinese New Year', country: 'China', flag: '🇨🇳', months: 'Jan–Feb', startMonth: 0, startDay: 29, description: 'Dragon dances, lantern displays, and spectacular fireworks across Beijing, Shanghai, and Hong Kong.', mapColor: 'bg-red-100', durationDays: 7, destinationCodes: ['CN'], cities: ['Beijing', 'Shanghai'] },
+    { name: 'Glastonbury Festival', country: 'United Kingdom', flag: '🇬🇧', months: 'Jun', startMonth: 5, startDay: 25, description: 'The world\'s most iconic music festival — five days of legendary performances on a Somerset farm.', mapColor: 'bg-lime-100', durationDays: 5, destinationCodes: ['GB'] },
+    { name: 'Burning Man', country: 'USA', flag: '🇺🇸', months: 'Aug–Sep', startMonth: 7, startDay: 24, description: 'A temporary city in the Nevada desert — radical self-expression, art installations, and the burning of the Man.', mapColor: 'bg-orange-100', durationDays: 9, destinationCodes: ['US'] },
+    { name: 'Diwali', country: 'India', flag: '🇮🇳', months: 'Oct–Nov', startMonth: 9, startDay: 20, description: 'The festival of lights — fireworks, oil lamps, rangoli art, and sweet feasts illuminate India for five days.', mapColor: 'bg-amber-100', durationDays: 5, destinationCodes: ['IN'], cities: ['Jaipur', 'Varanasi'], blogSlugs: ['festival-travel-guide'] },
+    { name: "St. Patrick's Day", country: 'Ireland', flag: '🇮🇪', months: 'Mar', startMonth: 2, startDay: 17, description: 'Dublin turns green — parades, live music, and the best pints of Guinness you\'ll ever have.', mapColor: 'bg-emerald-100', durationDays: 3, destinationCodes: ['IE'], cities: ['Dublin'] },
+    { name: 'Mardi Gras', country: 'USA', flag: '🇺🇸', months: 'Feb', startMonth: 1, startDay: 17, description: 'New Orleans erupts with jazz, floats, beads, and king cake — weeks of parades building to Fat Tuesday.', mapColor: 'bg-purple-100', durationDays: 14, destinationCodes: ['US'], cities: ['New Orleans'] },
+    { name: 'Lantern Festival', country: 'Taiwan', flag: '🇹🇼', months: 'Feb', startMonth: 1, startDay: 12, description: 'Thousands of sky lanterns released over Pingxi — a mesmerizing sea of light drifting into the night sky.', mapColor: 'bg-amber-100', durationDays: 3, destinationCodes: ['TW'] },
+    { name: 'Inti Raymi', country: 'Peru', flag: '🇵🇪', months: 'Jun', startMonth: 5, startDay: 24, description: 'The Inca festival of the sun — a grand ceremony at Sacsayhuamán fortress above Cusco with music and dance.', mapColor: 'bg-yellow-100', durationDays: 3, destinationCodes: ['PE'], cities: ['Cusco'] },
+    { name: 'Edinburgh Fringe', country: 'United Kingdom', flag: '🏴󠁧󠁢󠁳󠁣󠁴󠁿', months: 'Aug', startMonth: 7, startDay: 1, description: 'The world\'s largest arts festival — thousands of shows from comedy to theatre across Edinburgh\'s venues.', mapColor: 'bg-violet-100', durationDays: 25, destinationCodes: ['GB'], cities: ['Edinburgh'] },
 ];
 
 /* ── Weekend getaways ── */
 
 export const weekendGetaways: WeekendGetaway[] = [
-    { title: 'Barcelona Express', from: 'Anywhere in Europe', to: 'Barcelona, Spain', flag: '🇪🇸', durationDays: 3, description: 'Gaudí, tapas crawl through El Born, and sunset from Bunkers del Carmel.', mapColor: 'bg-orange-100', mapAccent: 'bg-orange-400', blogSlugs: ['weekend-getaway-tips'] },
-    { title: 'Prague Old Town', from: 'Central Europe', to: 'Prague, Czech Republic', flag: '🇨🇿', durationDays: 3, description: 'Charles Bridge at dawn, beer halls, and the astronomical clock — Europe\'s most photogenic city break.', mapColor: 'bg-amber-100', mapAccent: 'bg-amber-500', blogSlugs: ['weekend-getaway-tips', 'budget-travel-europe'] },
-    { title: 'Marrakech Medina', from: 'Europe / North Africa', to: 'Marrakech, Morocco', flag: '🇲🇦', durationDays: 3, description: 'Get lost in the souks, sip mint tea on a riad rooftop, and visit the Jardin Majorelle.', mapColor: 'bg-yellow-100', mapAccent: 'bg-yellow-500', blogSlugs: ['weekend-getaway-tips'] },
-    { title: 'Amsterdam Canals', from: 'Northern Europe', to: 'Amsterdam, Netherlands', flag: '🇳🇱', durationDays: 2, description: 'Bike the canal ring, Rijksmuseum, and Jordaan neighbourhood brunch spots.', mapColor: 'bg-sky-100', mapAccent: 'bg-sky-400', blogSlugs: ['weekend-getaway-tips'] },
-    { title: 'Edinburgh Highlands', from: 'UK / Ireland', to: 'Edinburgh, Scotland', flag: '🏴\u200d☠️', durationDays: 3, description: 'Arthur\'s Seat hike, whisky tasting on the Royal Mile, and a day trip into the Highlands.', mapColor: 'bg-emerald-100', mapAccent: 'bg-emerald-500', blogSlugs: ['weekend-getaway-tips'] },
-    { title: 'Istanbul Bosphorus', from: 'Europe / Middle East', to: 'Istanbul, Turkey', flag: '🇹🇷', durationDays: 3, description: 'Hagia Sophia, Grand Bazaar haggling, and ferry rides between two continents.', mapColor: 'bg-rose-100', mapAccent: 'bg-rose-400', blogSlugs: ['weekend-getaway-tips'] },
+    { title: 'Barcelona Express', from: 'Anywhere in Europe', to: 'Barcelona, Spain', flag: '🇪🇸', durationDays: 3, description: 'Gaudí, tapas crawl through El Born, and sunset from Bunkers del Carmel.', mapColor: 'bg-orange-100', mapAccent: 'bg-orange-400', destinationCodes: ['ES'], cities: ['Barcelona'], blogSlugs: ['weekend-getaway-tips'] },
+    { title: 'Prague Old Town', from: 'Central Europe', to: 'Prague, Czech Republic', flag: '🇨🇿', durationDays: 3, description: 'Charles Bridge at dawn, beer halls, and the astronomical clock — Europe\'s most photogenic city break.', mapColor: 'bg-amber-100', mapAccent: 'bg-amber-500', destinationCodes: ['CZ'], cities: ['Prague'], blogSlugs: ['weekend-getaway-tips', 'budget-travel-europe'] },
+    { title: 'Marrakech Medina', from: 'Europe / North Africa', to: 'Marrakech, Morocco', flag: '🇲🇦', durationDays: 3, description: 'Get lost in the souks, sip mint tea on a riad rooftop, and visit the Jardin Majorelle.', mapColor: 'bg-yellow-100', mapAccent: 'bg-yellow-500', destinationCodes: ['MA'], cities: ['Marrakech'], blogSlugs: ['weekend-getaway-tips'] },
+    { title: 'Amsterdam Canals', from: 'Northern Europe', to: 'Amsterdam, Netherlands', flag: '🇳🇱', durationDays: 2, description: 'Bike the canal ring, Rijksmuseum, and Jordaan neighbourhood brunch spots.', mapColor: 'bg-sky-100', mapAccent: 'bg-sky-400', destinationCodes: ['NL'], cities: ['Amsterdam'], blogSlugs: ['weekend-getaway-tips'] },
+    { title: 'Edinburgh Highlands', from: 'UK / Ireland', to: 'Edinburgh, Scotland', flag: '🏴󠁧󠁢󠁳󠁣󠁴󠁿', durationDays: 3, description: 'Arthur\'s Seat hike, whisky tasting on the Royal Mile, and a day trip into the Highlands.', mapColor: 'bg-emerald-100', mapAccent: 'bg-emerald-500', destinationCodes: ['GB'], cities: ['Edinburgh'], blogSlugs: ['weekend-getaway-tips'] },
+    { title: 'Istanbul Bosphorus', from: 'Europe / Middle East', to: 'Istanbul, Turkey', flag: '🇹🇷', durationDays: 3, description: 'Hagia Sophia, Grand Bazaar haggling, and ferry rides between two continents.', mapColor: 'bg-rose-100', mapAccent: 'bg-rose-400', destinationCodes: ['TR'], cities: ['Istanbul'], blogSlugs: ['weekend-getaway-tips'] },
 ];
 
 /* ── By country ── */
 
 export const countryGroups: CountryGroup[] = [
-    { country: 'Japan', flag: '🇯🇵', tripCount: 3, bestMonths: 'Mar–May, Oct–Nov', tags: ['Culture', 'Food', 'Nature'], blogSlugs: ['best-time-visit-japan'] },
-    { country: 'Italy', flag: '🇮🇹', tripCount: 3, bestMonths: 'Apr–Jun, Sep–Oct', tags: ['Food', 'Art', 'History'], blogSlugs: ['budget-travel-europe'] },
-    { country: 'Thailand', flag: '🇹🇭', tripCount: 2, bestMonths: 'Nov–Feb', tags: ['Beach', 'Food', 'Adventure'] },
-    { country: 'Portugal', flag: '🇵🇹', tripCount: 2, bestMonths: 'Mar–Jun, Sep–Oct', tags: ['Surf', 'Wine', 'City'], blogSlugs: ['budget-travel-europe'] },
-    { country: 'Peru', flag: '🇵🇪', tripCount: 1, bestMonths: 'May–Sep', tags: ['Adventure', 'History', 'Nature'] },
-    { country: 'Iceland', flag: '🇮🇸', tripCount: 2, bestMonths: 'Jun–Aug', tags: ['Nature', 'Road Trip', 'Photography'] },
-    { country: 'Morocco', flag: '🇲🇦', tripCount: 2, bestMonths: 'Mar–May, Sep–Nov', tags: ['Culture', 'Food', 'Desert'] },
-    { country: 'India', flag: '🇮🇳', tripCount: 2, bestMonths: 'Oct–Mar', tags: ['Culture', 'Photography', 'Food'] },
-    { country: 'Greece', flag: '🇬🇷', tripCount: 1, bestMonths: 'May–Jun, Sep–Oct', tags: ['Beach', 'Culture', 'Islands'], blogSlugs: ['budget-travel-europe'] },
-    { country: 'New Zealand', flag: '🇳🇿', tripCount: 1, bestMonths: 'Nov–Mar', tags: ['Nature', 'Hiking', 'Road Trip'] },
-    { country: 'Norway', flag: '🇳🇴', tripCount: 1, bestMonths: 'Jun–Aug, Sep–Mar (aurora)', tags: ['Nature', 'Photography', 'Fjords'] },
-    { country: 'Mexico', flag: '🇲🇽', tripCount: 2, bestMonths: 'Oct–Apr', tags: ['Food', 'Beach', 'Culture'] },
+    { country: 'Japan', flag: '🇯🇵', destinationCode: 'JP', tripCount: 3, bestMonths: 'Mar–May, Oct–Nov', tags: ['Culture', 'Food', 'Nature'], blogSlugs: ['best-time-visit-japan'] },
+    { country: 'Italy', flag: '🇮🇹', destinationCode: 'IT', tripCount: 3, bestMonths: 'Apr–Jun, Sep–Oct', tags: ['Food', 'Art', 'History'], blogSlugs: ['budget-travel-europe'] },
+    { country: 'Thailand', flag: '🇹🇭', destinationCode: 'TH', tripCount: 2, bestMonths: 'Nov–Feb', tags: ['Beach', 'Food', 'Adventure'] },
+    { country: 'Portugal', flag: '🇵🇹', destinationCode: 'PT', tripCount: 2, bestMonths: 'Mar–Jun, Sep–Oct', tags: ['Surf', 'Wine', 'City'], blogSlugs: ['budget-travel-europe'] },
+    { country: 'Peru', flag: '🇵🇪', destinationCode: 'PE', tripCount: 1, bestMonths: 'May–Sep', tags: ['Adventure', 'History', 'Nature'] },
+    { country: 'Iceland', flag: '🇮🇸', destinationCode: 'IS', tripCount: 2, bestMonths: 'Jun–Aug', tags: ['Nature', 'Road Trip', 'Photography'] },
+    { country: 'Morocco', flag: '🇲🇦', destinationCode: 'MA', tripCount: 2, bestMonths: 'Mar–May, Sep–Nov', tags: ['Culture', 'Food', 'Desert'] },
+    { country: 'India', flag: '🇮🇳', destinationCode: 'IN', tripCount: 2, bestMonths: 'Oct–Mar', tags: ['Culture', 'Photography', 'Food'] },
+    { country: 'Greece', flag: '🇬🇷', destinationCode: 'GR', tripCount: 1, bestMonths: 'May–Jun, Sep–Oct', tags: ['Beach', 'Culture', 'Islands'], blogSlugs: ['budget-travel-europe'] },
+    { country: 'New Zealand', flag: '🇳🇿', destinationCode: 'NZ', tripCount: 1, bestMonths: 'Nov–Mar', tags: ['Nature', 'Hiking', 'Road Trip'] },
+    { country: 'Norway', flag: '🇳🇴', destinationCode: 'NO', tripCount: 1, bestMonths: 'Jun–Aug, Sep–Mar (aurora)', tags: ['Nature', 'Photography', 'Fjords'] },
+    { country: 'Mexico', flag: '🇲🇽', destinationCode: 'MX', tripCount: 2, bestMonths: 'Oct–Apr', tags: ['Food', 'Beach', 'Culture'] },
 ];
 
 /* ── Quick starts ── */
 
-export const quickIdeas = [
-    { label: '🇯🇵 7 Days in Japan', dest: 'Japan', days: 7 },
-    { label: '🇮🇹 2 Weeks in Italy', dest: 'Italy', days: 14 },
-    { label: '🇹🇭 10 Days in Thailand', dest: 'Thailand', days: 10 },
-    { label: '🇮🇸 Iceland Ring Road', dest: 'Iceland', days: 7 },
-    { label: '🇵🇹 Portugal Road Trip', dest: 'Portugal', days: 10 },
-    { label: '🇬🇷 Greek Islands', dest: 'Greece', days: 10 },
-    { label: '🇲🇦 Morocco Discovery', dest: 'Morocco', days: 9 },
-    { label: '🇳🇿 NZ Adventure', dest: 'New Zealand', days: 21 },
+export const quickIdeas: QuickIdea[] = [
+    { label: '🇯🇵 7 Days in Japan', dest: 'Japan', days: 7, destinationCode: 'JP' },
+    { label: '🇮🇹 2 Weeks in Italy', dest: 'Italy', days: 14, destinationCode: 'IT' },
+    { label: '🇹🇭 10 Days in Thailand', dest: 'Thailand', days: 10, destinationCode: 'TH' },
+    { label: '🇮🇸 Iceland Ring Road', dest: 'Iceland', days: 7, destinationCode: 'IS' },
+    { label: '🇵🇹 Portugal Road Trip', dest: 'Portugal', days: 10, destinationCode: 'PT' },
+    { label: '🇬🇷 Greek Islands', dest: 'Greece', days: 10, destinationCode: 'GR' },
+    { label: '🇲🇦 Morocco Discovery', dest: 'Morocco', days: 9, destinationCode: 'MA' },
+    { label: '🇳🇿 NZ Adventure', dest: 'New Zealand', days: 21, destinationCode: 'NZ' },
 ];
 
 /* ── Helpers ── */

--- a/data/popularIslandDestinations.json
+++ b/data/popularIslandDestinations.json
@@ -4,7 +4,7 @@
   { "name": "Saadiyat Island", "countryCode": "AE" },
   { "name": "Sir Bani Yas Island", "countryCode": "AE" },
 
-  { "name": "Tasmania", "countryCode": "AU" },
+  { "name": "Tasmania", "countryCode": "AU", "code": "AU-TAS" },
   { "name": "Kangaroo Island", "countryCode": "AU" },
   { "name": "K'gari", "countryCode": "AU", "aliases": ["Fraser Island"] },
   { "name": "Whitsunday Island", "countryCode": "AU" },
@@ -45,8 +45,8 @@
   { "name": "Tobacco Caye", "countryCode": "BZ" },
 
   { "name": "Vancouver Island", "countryCode": "CA" },
-  { "name": "Newfoundland", "countryCode": "CA" },
-  { "name": "Prince Edward Island", "countryCode": "CA" },
+  { "name": "Newfoundland", "countryCode": "CA", "code": "CA-NL" },
+  { "name": "Prince Edward Island", "countryCode": "CA", "code": "CA-PE" },
   { "name": "Cape Breton Island", "countryCode": "CA" },
   { "name": "Baffin Island", "countryCode": "CA" },
   { "name": "Manitoulin Island", "countryCode": "CA" },
@@ -55,7 +55,7 @@
   { "name": "Chiloe Island", "countryCode": "CL" },
   { "name": "Robinson Crusoe Island", "countryCode": "CL" },
 
-  { "name": "Hainan", "countryCode": "CN" },
+  { "name": "Hainan", "countryCode": "CN", "code": "CN-HI" },
   { "name": "Hong Kong Island", "countryCode": "CN" },
   { "name": "Lantau Island", "countryCode": "CN" },
 
@@ -67,7 +67,7 @@
   { "name": "Isla Tortuga", "countryCode": "CR" },
   { "name": "Cocos Island (Costa Rica)", "countryCode": "CR" },
 
-  { "name": "Isla de la Juventud", "countryCode": "CU" },
+  { "name": "Isla de la Juventud", "countryCode": "CU", "code": "CU-99" },
   { "name": "Cayo Coco", "countryCode": "CU" },
   { "name": "Cayo Guillermo", "countryCode": "CU" },
   { "name": "Cayo Santa Maria", "countryCode": "CU" },
@@ -112,12 +112,12 @@
   { "name": "Mamanuca Islands", "countryCode": "FJ" },
   { "name": "Kadavu", "countryCode": "FJ" },
 
-  { "name": "Aland Islands", "countryCode": "FI" },
+  { "name": "Aland Islands", "countryCode": "FI", "code": "FI-AL" },
 
   { "name": "Corsica", "countryCode": "FR" },
-  { "name": "Reunion", "countryCode": "FR" },
-  { "name": "Guadeloupe", "countryCode": "FR" },
-  { "name": "Martinique", "countryCode": "FR" },
+  { "name": "Reunion", "countryCode": "FR", "code": "FR-RE" },
+  { "name": "Guadeloupe", "countryCode": "FR", "code": "FR-GP" },
+  { "name": "Martinique", "countryCode": "FR", "code": "FR-MQ" },
   { "name": "Saint Martin", "countryCode": "FR" },
   { "name": "Tahiti", "countryCode": "FR" },
   { "name": "Bora Bora", "countryCode": "FR" },
@@ -137,10 +137,10 @@
   { "name": "Isle of Wight", "countryCode": "GB" },
   { "name": "Anglesey", "countryCode": "GB" },
   { "name": "Lewis and Harris", "countryCode": "GB" },
-  { "name": "Orkney Mainland", "countryCode": "GB" },
-  { "name": "Shetland Mainland", "countryCode": "GB" },
+  { "name": "Orkney Mainland", "countryCode": "GB", "code": "GB-ORK" },
+  { "name": "Shetland Mainland", "countryCode": "GB", "code": "GB-ZET" },
 
-  { "name": "Crete", "countryCode": "GR", "aliases": ["Kreta"] },
+  { "name": "Crete", "countryCode": "GR", "code": "GR-M", "aliases": ["Kreta"] },
   { "name": "Rhodes", "countryCode": "GR" },
   { "name": "Corfu", "countryCode": "GR", "aliases": ["Kerkyra"] },
   { "name": "Kos", "countryCode": "GR" },
@@ -175,7 +175,7 @@
   { "name": "Mljet", "countryCode": "HR" },
   { "name": "Rab", "countryCode": "HR" },
 
-  { "name": "Bali", "countryCode": "ID" },
+  { "name": "Bali", "countryCode": "ID", "code": "ID-BA" },
   { "name": "Lombok", "countryCode": "ID" },
   { "name": "Gili Trawangan", "countryCode": "ID" },
   { "name": "Gili Air", "countryCode": "ID" },
@@ -233,8 +233,8 @@
   { "name": "Qeshm Island", "countryCode": "IR" },
   { "name": "Hormuz Island", "countryCode": "IR" },
 
-  { "name": "Sicily", "countryCode": "IT", "aliases": ["Sicilia"] },
-  { "name": "Sardinia", "countryCode": "IT", "aliases": ["Sardegna"] },
+  { "name": "Sicily", "countryCode": "IT", "code": "IT-82", "aliases": ["Sicilia"] },
+  { "name": "Sardinia", "countryCode": "IT", "code": "IT-88", "aliases": ["Sardegna"] },
   { "name": "Capri", "countryCode": "IT" },
   { "name": "Ischia", "countryCode": "IT" },
   { "name": "Procida", "countryCode": "IT" },
@@ -247,11 +247,11 @@
   { "name": "Salina", "countryCode": "IT" },
   { "name": "Favignana", "countryCode": "IT" },
 
-  { "name": "Hokkaido", "countryCode": "JP" },
+  { "name": "Hokkaido", "countryCode": "JP", "code": "JP-01" },
   { "name": "Honshu", "countryCode": "JP" },
   { "name": "Shikoku", "countryCode": "JP" },
   { "name": "Kyushu", "countryCode": "JP" },
-  { "name": "Okinawa", "countryCode": "JP" },
+  { "name": "Okinawa", "countryCode": "JP", "code": "JP-47" },
   { "name": "Ishigaki", "countryCode": "JP" },
   { "name": "Iriomote", "countryCode": "JP" },
   { "name": "Miyakojima", "countryCode": "JP" },
@@ -269,7 +269,7 @@
   { "name": "Tarawa", "countryCode": "KI" },
   { "name": "Kiritimati", "countryCode": "KI", "aliases": ["Christmas Island (Kiribati)"] },
 
-  { "name": "Jeju Island", "countryCode": "KR", "aliases": ["Jeju"] },
+  { "name": "Jeju Island", "countryCode": "KR", "code": "KR-49", "aliases": ["Jeju"] },
   { "name": "Ulleungdo", "countryCode": "KR" },
 
   { "name": "Nosy Be", "countryCode": "MG" },
@@ -294,7 +294,7 @@
   { "name": "Baa Atoll", "countryCode": "MV" },
   { "name": "Ari Atoll", "countryCode": "MV" },
 
-  { "name": "Penang", "countryCode": "MY" },
+  { "name": "Penang", "countryCode": "MY", "code": "MY-07" },
   { "name": "Langkawi", "countryCode": "MY" },
   { "name": "Tioman", "countryCode": "MY" },
   { "name": "Redang", "countryCode": "MY" },
@@ -322,7 +322,7 @@
   { "name": "Aruba", "countryCode": "NL" },
   { "name": "Sint Maarten", "countryCode": "NL" },
 
-  { "name": "Svalbard", "countryCode": "NO" },
+  { "name": "Svalbard", "countryCode": "NO", "code": "NO-21" },
   { "name": "Senja", "countryCode": "NO" },
   { "name": "Lofoten Islands", "countryCode": "NO", "aliases": ["Lofoten"] },
 
@@ -345,28 +345,28 @@
   { "name": "Manus Island", "countryCode": "PG" },
 
   { "name": "Luzon", "countryCode": "PH" },
-  { "name": "Palawan", "countryCode": "PH" },
+  { "name": "Palawan", "countryCode": "PH", "code": "PH-PLW" },
   { "name": "Boracay", "countryCode": "PH" },
-  { "name": "Cebu", "countryCode": "PH" },
-  { "name": "Bohol", "countryCode": "PH" },
+  { "name": "Cebu", "countryCode": "PH", "code": "PH-CEB" },
+  { "name": "Bohol", "countryCode": "PH", "code": "PH-BOH" },
   { "name": "Siargao", "countryCode": "PH" },
   { "name": "Coron Island", "countryCode": "PH" },
   { "name": "Busuanga", "countryCode": "PH" },
-  { "name": "Camiguin", "countryCode": "PH" },
+  { "name": "Camiguin", "countryCode": "PH", "code": "PH-CAM" },
   { "name": "Mindoro", "countryCode": "PH" },
   { "name": "Negros", "countryCode": "PH" },
   { "name": "Panay", "countryCode": "PH" },
   { "name": "Samar", "countryCode": "PH" },
-  { "name": "Leyte", "countryCode": "PH" },
+  { "name": "Leyte", "countryCode": "PH", "code": "PH-LEY" },
   { "name": "Bantayan", "countryCode": "PH" },
   { "name": "Malapascua", "countryCode": "PH" },
-  { "name": "Siquijor", "countryCode": "PH" },
-  { "name": "Catanduanes", "countryCode": "PH" },
+  { "name": "Siquijor", "countryCode": "PH", "code": "PH-SIG" },
+  { "name": "Catanduanes", "countryCode": "PH", "code": "PH-CAT" },
   { "name": "Dinagat Islands", "countryCode": "PH" },
 
   { "name": "Astola Island", "countryCode": "PK" },
 
-  { "name": "Madeira", "countryCode": "PT" },
+  { "name": "Madeira", "countryCode": "PT", "code": "PT-30" },
   { "name": "Porto Santo", "countryCode": "PT" },
   { "name": "Sao Miguel", "countryCode": "PT" },
   { "name": "Terceira", "countryCode": "PT" },
@@ -398,12 +398,12 @@
   { "name": "Denis Island", "countryCode": "SC" },
   { "name": "Bird Island", "countryCode": "SC" },
 
-  { "name": "Gotland", "countryCode": "SE" },
+  { "name": "Gotland", "countryCode": "SE", "code": "SE-I" },
   { "name": "Oland", "countryCode": "SE", "aliases": ["Oland"] },
 
   { "name": "Sentosa", "countryCode": "SG" },
 
-  { "name": "Phuket", "countryCode": "TH" },
+  { "name": "Phuket", "countryCode": "TH", "code": "TH-83" },
   { "name": "Koh Samui", "countryCode": "TH" },
   { "name": "Koh Phangan", "countryCode": "TH", "aliases": ["Ko Pha Ngan"] },
   { "name": "Koh Tao", "countryCode": "TH" },
@@ -431,12 +431,12 @@
   { "name": "Bozcaada", "countryCode": "TR" },
   { "name": "Gokceada", "countryCode": "TR", "aliases": ["Gokceada"] },
 
-  { "name": "Tobago", "countryCode": "TT" },
+  { "name": "Tobago", "countryCode": "TT", "code": "TT-TOB" },
 
-  { "name": "Penghu", "countryCode": "TW" },
+  { "name": "Penghu", "countryCode": "TW", "code": "TW-PEN" },
   { "name": "Green Island (Taiwan)", "countryCode": "TW" },
   { "name": "Orchid Island", "countryCode": "TW" },
-  { "name": "Kinmen", "countryCode": "TW" },
+  { "name": "Kinmen", "countryCode": "TW", "code": "TW-KIN" },
   { "name": "Matsu Islands", "countryCode": "TW" },
 
   { "name": "Zanzibar", "countryCode": "TZ", "aliases": ["Unguja"] },

--- a/docs/DESTINATION_SYSTEM.md
+++ b/docs/DESTINATION_SYSTEM.md
@@ -1,0 +1,233 @@
+# Destination & ISO Code System
+
+This document describes how TravelFlow stores, resolves, and uses destination data across the app. It covers the two-tier destination model, ISO code conventions, inspiration data structures, and the trip prefill pipeline.
+
+---
+
+## Architecture Overview
+
+```
+COUNTRIES (utils.ts)                    popularIslandDestinations.json
+  ~195 entries                            ~414 entries
+  { name, code: ISO 3166-1, flag }        { name, countryCode, code?: ISO 3166-2, aliases? }
+        │                                        │
+        │  .map(→ DestinationOption)             │  buildIslandDestination(seed)
+        ▼                                        ▼
+   DESTINATION_OPTIONS[]  ◄──── merged array ────┘
+        │
+        ├── DESTINATION_BY_NAME   (Map: lowercase name → DestinationOption)
+        ├── DESTINATION_BY_ALIAS  (Map: lowercase alias → DestinationOption)
+        └── DESTINATION_BY_CODE   (Map: lowercase code → DestinationOption)
+```
+
+All lookup maps live in `utils.ts` and are built once at module load time.
+
+---
+
+## Data Sources
+
+### 1. `COUNTRIES` array — `utils.ts:782`
+
+Static array of ~195 sovereign countries. Each entry:
+
+```ts
+{ name: "Japan", code: "JP", flag: "🇯🇵" }
+```
+
+- `code` = **ISO 3166-1 alpha-2** (uppercase, 2 chars)
+- Used directly in the destination picker (`CountrySelect`)
+
+### 2. `popularIslandDestinations.json` — `data/popularIslandDestinations.json`
+
+~414 island/sub-national destination entries. Each entry:
+
+```ts
+{ "name": "Bali", "countryCode": "ID", "code": "ID-BA", "aliases": [] }
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Display name shown in picker |
+| `countryCode` | Yes | ISO 3166-1 code of the parent country |
+| `code` | No | Explicit ISO 3166-2 subdivision code. When absent, a slug is generated: `{parentCode}-{slugified-name}` |
+| `aliases` | No | Alternative names for search matching (e.g. `["Fraser Island"]` for K'gari) |
+
+### Code generation logic (`utils.ts:1003`)
+
+```
+If seed.code exists  →  use it verbatim       (e.g. "ID-BA")
+Else                 →  buildIslandCode()      (e.g. "ID-bali")
+                        = parentCode + "-" + slugified lowercase name
+```
+
+33 islands currently have explicit ISO 3166-2 codes (e.g. Tasmania = `AU-TAS`, Crete = `GR-M`, Bali = `ID-BA`). All others use the slug fallback.
+
+**Important constraint:** `DESTINATION_BY_CODE` is a `Map`. Duplicate codes silently overwrite. Never assign the same ISO 3166-2 code to multiple islands. Some real ISO codes cover multiple islands (e.g. Ecuador's `EC-W` covers all Galapagos islands) — these must NOT be assigned since they'd collide.
+
+### 3. `DestinationOption` interface — `utils.ts:984`
+
+The unified type for all destinations:
+
+```ts
+interface DestinationOption {
+    name: string;              // "Japan" or "Bali"
+    code: string;              // "JP" or "ID-BA"
+    flag: string;              // emoji flag
+    kind: 'country' | 'island';
+    parentCountryName?: string;  // island only: "Indonesia"
+    parentCountryCode?: string;  // island only: "ID"
+    aliases?: string[];          // island only
+}
+```
+
+---
+
+## Lookup Functions — `utils.ts`
+
+| Function | Input | Returns | Use case |
+|----------|-------|---------|----------|
+| `getDestinationOptionByName(name)` | `"Bali"` or `"Fraser Island"` | `DestinationOption \| undefined` | Form validation, name-based search |
+| `getDestinationOptionByCode(code)` | `"ID-BA"` or `"JP"` | `DestinationOption \| undefined` | Resolving inspiration data codes |
+| `resolveDestinationCodes(codes)` | `["CL", "AR"]` | `["Chile", "Argentina"]` | Converting stored codes to picker-compatible names |
+| `searchDestinationOptions(query)` | `"bal"` | `DestinationOption[]` | Typeahead in destination picker |
+
+All lookups are **case-insensitive**.
+
+---
+
+## Inspiration Data — `data/inspirationsData.ts`
+
+Six data collections, all using structured ISO codes for destination resolution.
+
+### Types and their code fields
+
+| Type | Code field(s) | Cardinality | Example |
+|------|--------------|-------------|---------|
+| `Destination` | `destinationCodes: string[]` | 1+ codes | `["CL", "AR"]` for Patagonia |
+| `FestivalEvent` | `destinationCodes: string[]` | 1+ codes | `["NO", "IS"]` for Northern Lights |
+| `WeekendGetaway` | `destinationCodes: string[]` | 1+ codes | `["ES"]` for Barcelona |
+| `MonthEntry` | `destinationCodes: string[]` | parallel to `destinations[]` | `["TH", "LK", "MX"]` |
+| `CountryGroup` | `destinationCode: string` | exactly 1 | `"JP"` |
+| `QuickIdea` | `destinationCode: string` | exactly 1 | `"JP"` |
+
+### Optional `cities` field
+
+`Destination`, `FestivalEvent`, and `WeekendGetaway` have an optional `cities?: string[]` for pre-filling specific cities in the trip form. When present, the card UI shows a city count badge (`cities.length`). When absent, no badge is shown.
+
+Cities are free-text display names (not codes). They're passed to the form as a comma-separated string via `TripPrefillData.cities`.
+
+### Display fields vs logic fields
+
+Each type has **display-only** text fields that are NOT used for destination resolution:
+
+| Type | Display field | Purpose |
+|------|--------------|---------|
+| `Destination` | `country` | Card subtitle (e.g. "Chile & Argentina") |
+| `FestivalEvent` | `country` | Card subtitle |
+| `WeekendGetaway` | `from`, `to` | Card route label |
+| `MonthEntry` | `destinations[]` | Pill labels |
+| `QuickIdea` | `dest` | Button label |
+| `CountryGroup` | `country` | Section header |
+
+These are purely for rendering. All form prefill logic uses `destinationCodes` / `destinationCode` exclusively.
+
+---
+
+## Trip Prefill Pipeline
+
+```
+Inspiration card click
+        │
+        │  resolveDestinationCodes(card.destinationCodes)
+        │  → ["Chile", "Argentina"]   (destination names)
+        ▼
+   buildCreateTripUrl({
+       countries: ["Chile", "Argentina"],
+       cities: "Torres del Paine, El Chaltén",
+       startDate, endDate, notes, meta
+   })
+        │
+        │  encodeTripPrefill(data) → Base64URL string
+        ▼
+   /create-trip?prefill=eyJjb3Vud...
+        │
+        │  decodeTripPrefill(encoded) → TripPrefillData
+        │  (validates country names against DESTINATION_OPTIONS)
+        ▼
+   CreateTripForm pre-fills fields
+```
+
+### `TripPrefillData` — `types.ts:139`
+
+```ts
+interface TripPrefillData {
+    countries?: string[];   // destination names (not codes!)
+    startDate?: string;     // ISO date
+    endDate?: string;
+    budget?: string;
+    pace?: string;
+    cities?: string;        // comma-separated city names
+    notes?: string;
+    roundTrip?: boolean;
+    mode?: 'classic' | 'wizard';
+    styles?: string[];
+    vibes?: string[];
+    logistics?: string[];
+    meta?: { source?: string; author?: string; label?: string; [key: string]: unknown };
+}
+```
+
+**Key detail:** `countries` contains resolved **names** (e.g. `"Bali"`, not `"ID-BA"`). The `resolveDestinationCodes()` call in `InspirationsPage.tsx` converts codes to names before encoding.
+
+### Encoding — `utils.ts:1166`
+
+`encodeTripPrefill`: JSON → UTF-8 bytes → Base64URL (no padding, `-_` instead of `+/`).
+
+### Decoding — `utils.ts:1174`
+
+`decodeTripPrefill`: Base64URL → JSON → validated `TripPrefillData`. Country names are validated against `DESTINATION_OPTIONS` names — unknown names are silently dropped.
+
+### SEO
+
+The edge function `netlify/edge-functions/site-og-meta.ts` strips the `prefill` query param from the canonical URL to prevent duplicate indexing.
+
+---
+
+## Adding a New Inspiration Entry
+
+1. Choose the correct `destinationCodes`:
+   - Country: use ISO 3166-1 alpha-2 (e.g. `"JP"`)
+   - Island with explicit code in JSON: use that code (e.g. `"ID-BA"`)
+   - Island without explicit code: use `{parentCode}-{slug}` (e.g. `"PH-palawan"`)
+   - Multi-country: use array (e.g. `["CL", "AR"]`)
+
+2. Verify codes resolve: `resolveDestinationCodes(["YOUR-CODE"])` must return a non-empty array.
+
+3. Add `cities` only when specific cities add value. Keep the array to real stops a traveler would visit.
+
+4. The `description` field is for card UI — keep it evocative, max ~120 chars (CSS `line-clamp-2`). Don't try to list all cities in the description.
+
+5. Display fields (`country`, `to`, `dest`) are independent of codes — set them to whatever reads well on the card.
+
+## Adding a New Island Destination
+
+1. Add entry to `data/popularIslandDestinations.json` with at minimum `name` and `countryCode`.
+2. If the island is an ISO 3166-2 administrative subdivision, add the `code` field (e.g. `"AU-TAS"`).
+3. If the island has common alternative names, add `aliases` (e.g. `["Fraser Island"]`).
+4. Verify no code collision: search the JSON for any existing entry with the same `code` value.
+5. The island will automatically appear in `DESTINATION_OPTIONS` and be available in the picker and for prefill resolution.
+
+---
+
+## File Reference
+
+| File | Role |
+|------|------|
+| `utils.ts` | `COUNTRIES`, `ISLAND_DESTINATIONS`, `DESTINATION_OPTIONS`, all lookup maps and functions, prefill encode/decode |
+| `types.ts` | `TripPrefillData`, `DestinationOption` consumer types |
+| `data/popularIslandDestinations.json` | Island seed data with optional ISO 3166-2 codes |
+| `data/inspirationsData.ts` | All inspiration content: categories, months, festivals, getaways, country groups, quick ideas |
+| `pages/InspirationsPage.tsx` | Renders cards, calls `resolveDestinationCodes()`, builds prefill URLs |
+| `components/CreateTripForm.tsx` | Reads `?prefill=` param, pre-fills form fields |
+| `components/CountrySelect.tsx` | Destination picker, searches `DESTINATION_OPTIONS` |
+| `netlify/edge-functions/site-og-meta.ts` | Strips `prefill` from canonical URLs |

--- a/netlify/edge-functions/site-og-meta.ts
+++ b/netlify/edge-functions/site-og-meta.ts
@@ -134,14 +134,22 @@ const injectMetaTags = (html: string, meta: Metadata): string => {
   return cleaned.replace(/<\/head>/i, `${buildMetaTags(meta)}\n</head>`);
 };
 
+const buildCanonicalSearch = (url: URL): string => {
+  const params = new URLSearchParams(url.search);
+  params.delete("prefill");
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+};
+
 const buildMetadata = (url: URL): Metadata => {
   const page = getPageDefinition(url.pathname);
   const title = page.title === SITE_NAME ? SITE_NAME : `${page.title} | ${SITE_NAME}`;
-  const canonicalUrl = new URL(url.pathname + url.search, url.origin).toString();
+  const canonicalSearch = buildCanonicalSearch(url);
+  const canonicalUrl = new URL(url.pathname + canonicalSearch, url.origin).toString();
   const ogImage = new URL("/api/og/site", url.origin);
   ogImage.searchParams.set("title", page.title);
   ogImage.searchParams.set("description", page.description);
-  ogImage.searchParams.set("path", url.pathname + url.search);
+  ogImage.searchParams.set("path", url.pathname + canonicalSearch);
 
   return {
     pageTitle: title,

--- a/types.ts
+++ b/types.ts
@@ -136,6 +136,27 @@ export interface IUserSettings {
     timelineHeight?: number;
 }
 
+export interface TripPrefillData {
+    countries?: string[];
+    startDate?: string;
+    endDate?: string;
+    budget?: string;
+    pace?: string;
+    cities?: string;
+    notes?: string;
+    roundTrip?: boolean;
+    mode?: 'classic' | 'wizard';
+    styles?: string[];
+    vibes?: string[];
+    logistics?: string[];
+    meta?: {
+        source?: string;
+        author?: string;
+        label?: string;
+        [key: string]: unknown;
+    };
+}
+
 export interface ITripShareRecord {
     id: string;
     tripId: string;


### PR DESCRIPTION
## Summary
- Replace fragile string-matching destination resolver with structured ISO code-based lookup across all inspiration data (~76 entries)
- Add ISO 3166-2 subdivision codes to 33 island destinations in `popularIslandDestinations.json`
- Add `destinationCodes` and optional `cities` arrays to all inspiration types (Destination, FestivalEvent, WeekendGetaway, MonthEntry, CountryGroup, QuickIdea)
- Inspiration cards now show accurate city count badges derived from `cities.length`
- Add comprehensive `docs/DESTINATION_SYSTEM.md` covering the full destination architecture, ISO code conventions, and prefill pipeline

## Test plan
- [ ] Click Patagonia card → form shows Chile + Argentina selected
- [ ] Click Bali & Lombok card → form shows Bali + Lombok (not Indonesia)
- [ ] Click Cherry Blossom Trail → form shows Japan, cities = "Tokyo, Kyoto, Osaka, Hiroshima, Nara"
- [ ] Click Barcelona Express getaway → form shows Spain, cities = "Barcelona"
- [ ] Click month "Thailand" pill → form shows Thailand selected
- [ ] Click quick idea "Japan" → form shows Japan selected
- [ ] City count badges on cards match actual cities arrays
- [ ] Cards without cities show no city badge
- [ ] Vite build passes with no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)