### PR TITLE
Fix nav breakpoint & defer DB sync to trip routes

### DIFF
--- a/components/navigation/SiteHeader.tsx
+++ b/components/navigation/SiteHeader.tsx
@@ -44,13 +44,13 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
         : 'hidden sm:inline-flex rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900';
 
     const burgerClass = isGlass
-        ? 'flex h-9 w-9 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-white/60 hover:text-slate-900 md:hidden'
-        : 'flex h-9 w-9 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 md:hidden';
+        ? 'flex h-9 w-9 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-white/60 hover:text-slate-900 lg:hidden'
+        : 'flex h-9 w-9 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 lg:hidden';
 
     return (
         <>
             <header className={headerClass} style={{ viewTransitionName: 'site-header' }}>
-                <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-5 py-4 md:px-8">
+                <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-5 py-4 lg:px-8">
                     <NavLink to="/" onClick={() => handleNavClick('brand')} className="flex items-center gap-2">
                         <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent-600 text-white shadow-lg shadow-accent-200">
                             <AirplaneTilt size={16} weight="duotone" />
@@ -58,7 +58,7 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
                         <span className="text-lg font-extrabold tracking-tight">TravelFlow</span>
                     </NavLink>
 
-                    <nav className="hidden items-center gap-6 text-sm md:flex">
+                    <nav className="hidden items-center gap-4 text-sm lg:flex xl:gap-6">
                         <NavLink to="/features" onClick={() => handleNavClick('features')} className={navLinkClass}>Features</NavLink>
                         <NavLink to="/inspirations" onClick={() => handleNavClick('inspirations')} className={navLinkClass}>Inspirations</NavLink>
                         <NavLink to="/updates" onClick={() => handleNavClick('updates')} className={navLinkClass}>News & Updates</NavLink>

--- a/content/updates/2026-02-09-nav-breakpoints-lazy-db.md
+++ b/content/updates/2026-02-09-nav-breakpoints-lazy-db.md
@@ -1,0 +1,18 @@
+---
+id: rel-2026-02-09-nav-breakpoints-lazy-db
+version: v0.26.0
+title: "Navigation spacing fix & faster marketing page loads"
+date: 2026-02-09
+published_at: 2026-02-09T23:00:00Z
+status: published
+notify_in_app: false
+in_app_hours: 24
+summary: "Fixed cramped navigation on medium screens and eliminated unnecessary database calls on marketing pages."
+---
+
+## Changes
+- [x] [Fixed] 🧭 Navigation items no longer overlap the logo on medium-width screens (~790px).
+- [x] [Improved] ⚡ Marketing pages (homepage, features, blog, etc.) now load faster — database sync is deferred until you open a trip.
+- [ ] [Internal] Raised desktop nav breakpoint from md (768px) to lg (1024px) with tighter gap at lg and wider gap at xl.
+- [ ] [Internal] Extracted useDbSync hook to run DB bootstrap (session, upload, sync, settings) once per session and only on trip-related routes.
+- [ ] [Internal] Skipped initial-mount DB user settings write to prevent unnecessary auth on marketing pages.

--- a/hooks/useDbSync.ts
+++ b/hooks/useDbSync.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react';
+import {
+    DB_ENABLED,
+    applyUserSettingsToLocalStorage,
+    dbGetUserSettings,
+    ensureDbSession,
+    syncTripsFromDb,
+    uploadLocalTripsToDb,
+} from '../services/dbService';
+import { AppLanguage } from '../types';
+
+/** Has the DB sync already run in this session? */
+let hasSynced = false;
+
+/**
+ * Runs the DB bootstrap (session, upload local trips, sync from DB, load user
+ * settings) exactly once per browser session. Safe to call from multiple
+ * components — the first invocation wins, subsequent calls are no-ops.
+ */
+export const useDbSync = (onLanguageLoaded?: (lang: AppLanguage) => void) => {
+    const calledRef = useRef(false);
+
+    useEffect(() => {
+        if (!DB_ENABLED) return;
+        if (hasSynced || calledRef.current) return;
+        calledRef.current = true;
+        hasSynced = true;
+
+        let cancelled = false;
+
+        const init = async () => {
+            await ensureDbSession();
+            await uploadLocalTripsToDb();
+            await syncTripsFromDb();
+            const settings = await dbGetUserSettings();
+            if (!cancelled && settings) {
+                applyUserSettingsToLocalStorage(settings);
+                if (settings.language && onLanguageLoaded) {
+                    onLanguageLoaded(settings.language);
+                }
+            }
+        };
+
+        void init();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+};


### PR DESCRIPTION
## Summary
- **Navigation fix**: Raised desktop nav breakpoint from `md` (768px) to `lg` (1024px) so items no longer crowd the logo at ~790px widths. Added tighter gap at `lg` with wider spacing at `xl`.
- **Performance**: Moved the DB bootstrap (anonymous session, `uploadLocalTripsToDb`, `syncTripsFromDb`, user settings fetch) out of the global `AppContent` mount into a `useDbSync` hook that only runs on trip-related routes (`/create-trip`, `/trip/:id`, `/s/:token`). Marketing pages now load with zero Supabase calls.
- **Bonus**: Skipped the initial-mount `dbUpsertUserSettings` write that was triggering auth on every page load.

## Test plan
- [ ] Visit homepage, features, blog, pricing — verify no `upsert_trip` or Supabase auth calls in Network tab
- [ ] Visit `/create-trip` — verify DB sync fires (session + upload + sync)
- [ ] Open an existing trip (`/trip/:id`) — verify trip loads and DB sync runs
- [ ] Resize browser to ~790px — verify hamburger menu is shown, no cramped nav items
- [ ] At 1024px+ width, verify desktop nav displays with proper spacing
- [ ] Change app language in settings on a trip page — verify it persists to DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)