### PR TITLE
feat: BEM analytics convention + comprehensive tracking

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -524,7 +524,7 @@ const AppContent: React.FC = () => {
         const cityCount = newTrip.items.filter((item) => item.type === 'city').length;
         const activityCount = newTrip.items.filter((item) => item.type === 'activity').length;
         const travelSegmentCount = newTrip.items.filter((item) => item.type === 'travel').length;
-        trackEvent('trip_created', {
+        trackEvent('app__trip--create', {
             city_count: cityCount,
             activity_count: activityCount,
             travel_segment_count: travelSegmentCount,

--- a/components/marketing/CookieConsentBanner.tsx
+++ b/components/marketing/CookieConsentBanner.tsx
@@ -11,7 +11,9 @@ export const CookieConsentBanner: React.FC = () => {
         setConsent(choice);
         saveConsent(choice);
         if (choice === 'all') {
-            trackEvent('consent_accept_all_clicked', { source: 'cookie_banner' });
+            trackEvent('consent__banner--accept', { source: 'cookie_banner' });
+        } else {
+            trackEvent('consent__banner--reject', { source: 'cookie_banner' });
         }
     };
 

--- a/components/marketing/CtaBanner.tsx
+++ b/components/marketing/CtaBanner.tsx
@@ -19,10 +19,7 @@ export const CtaBanner: React.FC = () => {
                 <Link
                     to="/create-trip"
                     onClick={() =>
-                        trackEvent('marketing_hero_cta_clicked', {
-                            cta_name: 'cta_banner',
-                            page: 'home',
-                        })
+                        trackEvent('home__bottom_cta')
                     }
                     className="relative mt-8 inline-block rounded-2xl bg-white px-8 py-3.5 text-base font-bold text-accent-700 shadow-lg transition-all hover:shadow-xl hover:bg-accent-50 hover:scale-[1.03] active:scale-[0.98]"
                 >

--- a/components/marketing/EarlyAccessBanner.tsx
+++ b/components/marketing/EarlyAccessBanner.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { X, Flask } from '@phosphor-icons/react';
+import { trackEvent } from '../../services/analyticsService';
 
 const STORAGE_KEY = 'tf_early_access_dismissed';
 
@@ -16,6 +17,7 @@ export const EarlyAccessBanner: React.FC = () => {
 
     const handleDismiss = () => {
         setDismissed(true);
+        trackEvent('banner__early_access--dismiss');
         try {
             localStorage.setItem(STORAGE_KEY, '1');
         } catch {

--- a/components/marketing/HeroSection.tsx
+++ b/components/marketing/HeroSection.tsx
@@ -32,10 +32,7 @@ const ZigzagUnderline: React.FC = () => (
 
 export const HeroSection: React.FC = () => {
     const handleCtaClick = (ctaName: string) => {
-        trackEvent('marketing_hero_cta_clicked', {
-            cta_name: ctaName,
-            page: 'home',
-        });
+        trackEvent(`home__hero_cta--${ctaName}`);
     };
 
     return (

--- a/components/marketing/SiteFooter.tsx
+++ b/components/marketing/SiteFooter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+import { trackEvent } from '../../services/analyticsService';
 
 interface SiteFooterProps {
     className?: string;
@@ -8,16 +9,20 @@ interface SiteFooterProps {
 export const SiteFooter: React.FC<SiteFooterProps> = ({ className }) => {
     const year = new Date().getFullYear();
 
+    const handleFooterClick = (target: string) => {
+        trackEvent(`footer__${target}`);
+    };
+
     return (
         <footer className={`border-t border-slate-200 bg-white/90 ${className || ''}`.trim()}>
             <div className="mx-auto w-full max-w-6xl px-5 py-8 md:px-8">
                 <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                     <p className="text-sm text-slate-600">© {year} TravelFlow. All rights reserved.</p>
                     <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
-                        <NavLink to="/imprint" className="text-slate-600 hover:text-slate-900">Imprint</NavLink>
-                        <NavLink to="/privacy" className="text-slate-600 hover:text-slate-900">Privacy</NavLink>
-                        <NavLink to="/terms" className="text-slate-600 hover:text-slate-900">Terms</NavLink>
-                        <NavLink to="/cookies" className="text-slate-600 hover:text-slate-900">Cookies</NavLink>
+                        <NavLink to="/imprint" onClick={() => handleFooterClick('imprint')} className="text-slate-600 hover:text-slate-900">Imprint</NavLink>
+                        <NavLink to="/privacy" onClick={() => handleFooterClick('privacy')} className="text-slate-600 hover:text-slate-900">Privacy</NavLink>
+                        <NavLink to="/terms" onClick={() => handleFooterClick('terms')} className="text-slate-600 hover:text-slate-900">Terms</NavLink>
+                        <NavLink to="/cookies" onClick={() => handleFooterClick('cookies')} className="text-slate-600 hover:text-slate-900">Cookies</NavLink>
                     </div>
                 </div>
                 <p className="mt-3 text-xs text-slate-400">

--- a/components/navigation/MobileMenu.tsx
+++ b/components/navigation/MobileMenu.tsx
@@ -23,7 +23,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTri
 
     useEffect(() => {
         if (isOpen) {
-            trackEvent('mobile_menu_opened');
+            trackEvent('mobile_nav__menu--open');
             document.body.style.overflow = 'hidden';
         } else {
             document.body.style.overflow = '';
@@ -43,7 +43,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTri
     }, [isOpen, onClose]);
 
     const handleNavClick = (target: string) => {
-        trackEvent('mobile_nav_clicked', { target });
+        trackEvent(`mobile_nav__${target}`);
         onClose();
     };
 

--- a/components/navigation/SiteHeader.tsx
+++ b/components/navigation/SiteHeader.tsx
@@ -30,7 +30,7 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
     const hasTrips = useHasSavedTrips();
 
     const handleNavClick = (target: string) => {
-        trackEvent('marketing_nav_clicked', { target });
+        trackEvent(`navigation__${target}`);
     };
 
     const isGlass = variant === 'glass';

--- a/content/updates/2026-02-09-bem-analytics-events.md
+++ b/content/updates/2026-02-09-bem-analytics-events.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-02-09-bem-analytics-events
+version: v0.29.0
+title: "Comprehensive analytics tracking"
+date: 2026-02-09
+published_at: 2026-02-09T23:45:00Z
+status: published
+notify_in_app: false
+in_app_hours: 24
+summary: "Consistent BEM-style analytics events now cover all interactive elements across the site."
+---
+
+## Changes
+- [ ] [Internal] 📐 Introduced BEM-inspired analytics naming convention (`page__element` / `page__element--detail`) with TypeScript template literal enforcement and documented in `docs/ANALYTICS_CONVENTION.md`.
+- [ ] [Internal] 🔄 Migrated 8 existing analytics events to the new naming convention.
+- [ ] [Internal] 📊 Added 13 new tracking events across footer, early access banner, consent reject buttons, features CTA, pricing tier CTA, and all inspirations page interactive elements.

--- a/docs/ANALYTICS_CONVENTION.md
+++ b/docs/ANALYTICS_CONVENTION.md
@@ -1,0 +1,107 @@
+# Analytics Event Naming Convention
+
+All analytics events use a **BEM-inspired** naming format enforced by a TypeScript template literal type in `services/analyticsService.ts`.
+
+## Format
+
+```
+{page}__{element}
+{page}__{element}--{detail}
+```
+
+| Segment   | Purpose | Examples |
+|-----------|---------|----------|
+| `page`    | Page or persistent UI region | `home`, `navigation`, `mobile_nav`, `footer`, `features`, `pricing`, `inspirations`, `consent`, `app`, `banner` |
+| `element` | Specific widget interacted with | `hero_cta`, `bottom_cta`, `carousel_card`, `destination_card`, `tier`, `menu` |
+| `detail`  | *(optional)* Finite qualifier — meaningful action **or** known target | `accept`, `reject`, `dismiss`, `open`, `create`, `themes`, `free` |
+
+## Rules
+
+1. **Clicks are implicit** — never add `--click`. If a user taps a card, the event is just `inspirations__destination_card`, not `inspirations__destination_card--click`.
+2. **Use `--{detail}` only for finite, known qualifiers:**
+   - Actions that differentiate: `consent__banner--accept` vs `consent__banner--reject`
+   - Known navigation targets (< ~15 items): `navigation__features`, `footer__privacy`
+   - Named tiers/modes: `pricing__tier--free`
+3. **Variable / open-ended data goes in the payload**, not the event name. If the set is large or user-generated, keep the event name stable and pass specifics as properties:
+   ```ts
+   trackEvent('inspirations__destination_card', { title: 'Backpacking Southeast Asia', country: 'Thailand' });
+   ```
+4. **Use `snake_case`** within each segment, separated by `__` and `--`.
+5. **Prefix grouping** — all events from a page share the same prefix (`inspirations__*`), making dashboard filtering trivial.
+
+## When to use payload vs `--detail`
+
+| Set size | Example | Approach |
+|----------|---------|----------|
+| Small & stable (< ~15) | Nav links, footer links, pricing tiers, sections | `--{detail}` in event name |
+| Large or open-ended | Destinations, festivals, countries, user content | Stable event name + payload |
+| No meaningful qualifier | Bottom CTA, generic actions | Two-part name only |
+
+## Filtering in Umami
+
+| Question | Dashboard filter |
+|----------|-----------------|
+| All inspirations activity | Events starting with `inspirations__` |
+| All destination card clicks | Event = `inspirations__destination_card` |
+| Which countries get clicked most? | Event = `inspirations__destination_card`, group by `country` payload property |
+| Japan clicks specifically? | Event = `inspirations__destination_card`, property `country` = `Japan` |
+
+## Current event catalog
+
+### Navigation
+| Event | Detail | Payload | File |
+|-------|--------|---------|------|
+| `navigation__{target}` | target = `brand`, `features`, `inspirations`, `updates`, `blog`, `pricing`, `login`, `create_trip`, `my_trips` | — | `SiteHeader.tsx` |
+| `mobile_nav__menu--open` | — | — | `MobileMenu.tsx` |
+| `mobile_nav__{target}` | same targets as above | — | `MobileMenu.tsx` |
+
+### Home
+| Event | Detail | Payload | File |
+|-------|--------|---------|------|
+| `home__hero_cta--{cta}` | `start_planning`, `see_examples` | — | `HeroSection.tsx` |
+| `home__bottom_cta` | — | — | `CtaBanner.tsx` |
+| `home__carousel_card` | — | `{ template }` | `ExampleTripsCarousel.tsx` |
+
+### Consent
+| Event | Detail | Payload | File |
+|-------|--------|---------|------|
+| `consent__banner--accept` | — | `{ source }` | `CookieConsentBanner.tsx` |
+| `consent__banner--reject` | — | `{ source }` | `CookieConsentBanner.tsx` |
+| `consent__page--accept` | — | `{ source }` | `CookiesPage.tsx` |
+| `consent__page--reject` | — | `{ source }` | `CookiesPage.tsx` |
+
+### Footer & Banners
+| Event | Detail | Payload | File |
+|-------|--------|---------|------|
+| `footer__{target}` | `imprint`, `privacy`, `terms`, `cookies` | — | `SiteFooter.tsx` |
+| `banner__early_access--dismiss` | — | — | `EarlyAccessBanner.tsx` |
+
+### Features & Pricing
+| Event | Detail | Payload | File |
+|-------|--------|---------|------|
+| `features__bottom_cta` | — | — | `FeaturesPage.tsx` |
+| `pricing__tier--{name}` | `free` (others disabled) | — | `PricingPage.tsx` |
+
+### Inspirations
+| Event | Detail | Payload | File |
+|-------|--------|---------|------|
+| `inspirations__destination_card` | — | `{ title, country }` | `InspirationsPage.tsx` |
+| `inspirations__festival_card` | — | `{ name, country }` | `InspirationsPage.tsx` |
+| `inspirations__getaway_card` | — | `{ title, destination }` | `InspirationsPage.tsx` |
+| `inspirations__country_pill` | — | `{ country }` | `InspirationsPage.tsx` |
+| `inspirations__quick_pill` | — | `{ label }` | `InspirationsPage.tsx` |
+| `inspirations__section--{name}` | `themes`, `months`, `countries`, `festivals`, `weekends` | — | `InspirationsPage.tsx` |
+| `inspirations__bottom_cta` | — | — | `InspirationsPage.tsx` |
+
+### App
+| Event | Detail | Payload | File |
+|-------|--------|---------|------|
+| `app__trip--create` | — | `{ city_count, activity_count, travel_segment_count, total_item_count }` | `App.tsx` |
+
+## Adding new events
+
+1. Pick the `page` prefix matching where the element lives.
+2. Choose an `element` name that describes the widget.
+3. Decide: is the qualifier finite (< ~15 values) and stable? → use `--{detail}`. Otherwise → payload.
+4. Add a `trackEvent(...)` call and update the catalog table above.
+5. Run `npm run build` — the TypeScript type catches malformed names at compile time.

--- a/pages/CookiesPage.tsx
+++ b/pages/CookiesPage.tsx
@@ -10,7 +10,9 @@ export const CookiesPage: React.FC = () => {
         setConsent(choice);
         saveConsent(choice);
         if (choice === 'all') {
-            trackEvent('consent_accept_all_clicked', { source: 'cookies_page' });
+            trackEvent('consent__page--accept', { source: 'cookies_page' });
+        } else {
+            trackEvent('consent__page--reject', { source: 'cookies_page' });
         }
     };
 

--- a/pages/FeaturesPage.tsx
+++ b/pages/FeaturesPage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@phosphor-icons/react';
 import type { Icon } from '@phosphor-icons/react';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
+import { trackEvent } from '../services/analyticsService';
 
 interface Feature {
     icon: Icon;
@@ -243,6 +244,7 @@ export const FeaturesPage: React.FC = () => {
                     </p>
                     <Link
                         to="/create-trip"
+                        onClick={() => trackEvent('features__bottom_cta')}
                         className="relative mt-8 inline-block rounded-2xl bg-white px-8 py-3.5 text-base font-bold text-accent-700 shadow-lg transition-all hover:shadow-xl hover:bg-accent-50 hover:scale-[1.03] active:scale-[0.98]"
                     >
                         Start Planning — Free

--- a/pages/InspirationsPage.tsx
+++ b/pages/InspirationsPage.tsx
@@ -15,6 +15,7 @@ import {
     Article,
 } from '@phosphor-icons/react';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
+import { trackEvent } from '../services/analyticsService';
 import {
     categories,
     monthEntries,
@@ -114,6 +115,7 @@ const DestinationCard: React.FC<{ destination: Destination }> = ({ destination }
     return (
     <Link
         to={prefillUrl}
+        onClick={() => trackEvent('inspirations__destination_card', { title: destination.title, country: destination.country })}
         className="group block rounded-2xl border border-slate-200 bg-white shadow-sm transition-all hover:shadow-lg hover:-translate-y-1"
     >
         <div className={`relative h-32 rounded-t-2xl ${destination.mapColor} overflow-hidden`}>
@@ -159,6 +161,7 @@ const FestivalCard: React.FC<{ event: FestivalEventType; nextDate: Date }> = ({ 
     return (
     <Link
         to={prefillUrl}
+        onClick={() => trackEvent('inspirations__festival_card', { name: event.name, country: event.country })}
         className="group flex flex-col rounded-2xl border border-slate-200 bg-white shadow-sm transition-all hover:shadow-lg hover:-translate-y-1"
     >
         <div className={`relative h-24 rounded-t-2xl ${event.mapColor} overflow-hidden flex items-center justify-center`}>
@@ -204,6 +207,7 @@ const GetawayCard: React.FC<{ getaway: WeekendGetawayType }> = ({ getaway }) => 
     return (
     <Link
         to={prefillUrl}
+        onClick={() => trackEvent('inspirations__getaway_card', { title: getaway.title, destination: getaway.to })}
         className="group flex items-start gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition-all hover:shadow-lg hover:-translate-y-0.5"
     >
         <div className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-xl ${getaway.mapColor}`}>
@@ -229,6 +233,7 @@ const GetawayCard: React.FC<{ getaway: WeekendGetawayType }> = ({ getaway }) => 
 const CountryPill: React.FC<{ group: CountryGroup }> = ({ group }) => (
     <Link
         to={`/inspirations/country/${encodeURIComponent(group.country)}`}
+        onClick={() => trackEvent('inspirations__country_pill', { country: group.country })}
         className="group flex items-center gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition-all hover:shadow-lg hover:-translate-y-0.5"
     >
         <span className="text-3xl">{group.flag}</span>
@@ -411,6 +416,7 @@ export const InspirationsPage: React.FC = () => {
                                     <Link
                                         key={idea.label}
                                         to={buildCreateTripUrl({ countries, startDate: toIso(start), endDate: toIso(end), meta: { source: 'inspirations', label: idea.label } })}
+                                        onClick={() => trackEvent('inspirations__quick_pill', { label: idea.label })}
                                         className="rounded-full border border-slate-200 bg-white px-3.5 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition-all hover:border-accent-300 hover:text-accent-700 hover:shadow-md hover:scale-[1.03] active:scale-[0.98]"
                                     >
                                         {idea.label}
@@ -434,7 +440,7 @@ export const InspirationsPage: React.FC = () => {
                                             <div className="flex items-start justify-between gap-4">
                                                 <h2 className="text-2xl font-black tracking-tight text-slate-900 md:text-3xl">{category.title}</h2>
                                                 {idx === 0 && (
-                                                    <Link to="/inspirations/themes" className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
+                                                    <Link to="/inspirations/themes" onClick={() => trackEvent('inspirations__section--themes')} className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
                                                         All themes
                                                         <ArrowRight size={14} weight="bold" />
                                                     </Link>
@@ -470,7 +476,7 @@ export const InspirationsPage: React.FC = () => {
                                 <div className="min-w-0 flex-1">
                                     <div className="flex items-start justify-between gap-4">
                                         <h2 className="text-2xl font-black tracking-tight text-slate-900 md:text-3xl">Best Time to Travel</h2>
-                                        <Link to="/inspirations/best-time-to-travel" className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
+                                        <Link to="/inspirations/best-time-to-travel" onClick={() => trackEvent('inspirations__section--months')} className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
                                             Month guide
                                             <ArrowRight size={14} weight="bold" />
                                         </Link>
@@ -546,7 +552,7 @@ export const InspirationsPage: React.FC = () => {
                                 <div className="min-w-0 flex-1">
                                     <div className="flex items-start justify-between gap-4">
                                         <h2 className="text-2xl font-black tracking-tight text-slate-900 md:text-3xl">Browse by Country</h2>
-                                        <Link to="/inspirations/countries" className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
+                                        <Link to="/inspirations/countries" onClick={() => trackEvent('inspirations__section--countries')} className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
                                             All countries
                                             <ArrowRight size={14} weight="bold" />
                                         </Link>
@@ -574,7 +580,7 @@ export const InspirationsPage: React.FC = () => {
                                 <div className="min-w-0 flex-1">
                                     <div className="flex items-start justify-between gap-4">
                                         <h2 className="text-2xl font-black tracking-tight text-slate-900 md:text-3xl">Upcoming Events & Festivals</h2>
-                                        <Link to="/inspirations/events-and-festivals" className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
+                                        <Link to="/inspirations/events-and-festivals" onClick={() => trackEvent('inspirations__section--festivals')} className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
                                             All events
                                             <ArrowRight size={14} weight="bold" />
                                         </Link>
@@ -615,7 +621,7 @@ export const InspirationsPage: React.FC = () => {
                                 <div className="min-w-0 flex-1">
                                     <div className="flex items-start justify-between gap-4">
                                         <h2 className="text-2xl font-black tracking-tight text-slate-900 md:text-3xl">Spontaneous Weekend Getaways</h2>
-                                        <Link to="/inspirations/weekend-getaways" className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
+                                        <Link to="/inspirations/weekend-getaways" onClick={() => trackEvent('inspirations__section--weekends')} className="shrink-0 mt-1 inline-flex items-center gap-1 text-sm font-semibold text-accent-600 hover:text-accent-800 transition-colors">
                                             All getaways
                                             <ArrowRight size={14} weight="bold" />
                                         </Link>
@@ -669,6 +675,7 @@ export const InspirationsPage: React.FC = () => {
                             </p>
                             <Link
                                 to="/create-trip"
+                                onClick={() => trackEvent('inspirations__bottom_cta')}
                                 className="relative mt-8 inline-block rounded-2xl bg-white px-8 py-3.5 text-base font-bold text-accent-700 shadow-lg transition-all hover:shadow-xl hover:bg-accent-50 hover:scale-[1.03] active:scale-[0.98]"
                             >
                                 Start Planning Now

--- a/pages/PricingPage.tsx
+++ b/pages/PricingPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Check } from '@phosphor-icons/react';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
+import { trackEvent } from '../services/analyticsService';
 
 interface PricingTier {
     name: string;
@@ -151,6 +152,7 @@ export const PricingPage: React.FC = () => {
                                 ) : (
                                     <Link
                                         to={tier.ctaLink || '/create-trip'}
+                                        onClick={() => trackEvent(`pricing__tier--${tier.name.toLowerCase()}`)}
                                         className="block w-full rounded-xl bg-accent-600 px-4 py-3 text-center text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
                                     >
                                         {tier.cta}

--- a/services/analyticsService.ts
+++ b/services/analyticsService.ts
@@ -126,7 +126,26 @@ export const trackPageView = (path: string): void => {
     });
 };
 
-export const trackEvent = (eventName: string, payload?: Record<string, unknown>): void => {
+/**
+ * BEM-inspired analytics event name.
+ *
+ * Format: `{page}__{element}` or `{page}__{element}--{detail}`
+ *   - page:    page or persistent UI region (e.g. home, navigation, footer, pricing)
+ *   - element: specific widget interacted with (e.g. hero_cta, bottom_cta, tier)
+ *   - detail:  (optional) finite qualifier — meaningful action or known target
+ *
+ * Rules:
+ *   - Clicks are implicit — do NOT add `--click`.
+ *   - Use `--{detail}` only when the detail differentiates (e.g. accept/reject,
+ *     open/dismiss, a known finite target like a nav item or tier name).
+ *   - Variable/open-ended data (titles, countries from large sets) goes in payload.
+ *   - Use snake_case within each segment.
+ *
+ * See docs/ANALYTICS_CONVENTION.md for the full reference.
+ */
+type AnalyticsEventName = `${string}__${string}--${string}` | `${string}__${string}`;
+
+export const trackEvent = (eventName: AnalyticsEventName, payload?: Record<string, unknown>): void => {
     const sanitizedEventName = eventName.trim();
     if (!sanitizedEventName) return;
 


### PR DESCRIPTION
## Summary
- Introduces a BEM-inspired analytics naming convention (`page__element` / `page__element--detail`) enforced by a TypeScript template literal type in `analyticsService.ts`
- Migrates all 8 existing events to the new convention and adds 12 new tracking events across the site
- Documents the full convention, event catalog, and decision rules in `docs/ANALYTICS_CONVENTION.md`

## Convention highlights
- **Clicks are implicit** — no `--click` suffix
- **`--detail`** for finite qualifiers: `consent__banner--accept`, `navigation__features`, `pricing__tier--free`
- **Payload** for open-ended data: `inspirations__destination_card` + `{ title, country }`
- **Prefix grouping** enables easy dashboard filtering (`inspirations__*`)

## New events added
| Area | Events |
|------|--------|
| Footer | `footer__{target}` (imprint, privacy, terms, cookies) |
| Banner | `banner__early_access--dismiss` |
| Consent | `consent__banner--reject`, `consent__page--reject` |
| Features | `features__bottom_cta` |
| Pricing | `pricing__tier--{name}` |
| Inspirations | `destination_card`, `festival_card`, `getaway_card`, `country_pill`, `quick_pill`, `section--{name}`, `bottom_cta` |

## Test plan
- [x] `npm run build` passes — TS type catches malformed event names
- [x] Grep confirms zero remaining old-style event names
- [ ] Spot-check in browser: click footer link, features CTA, inspirations card — verify events fire in Umami

🤖 Generated with [Claude Code](https://claude.com/claude-code)