### PR TITLE
feat: page-specific OG meta and pill badges for all marketing pages

### DIFF
--- a/content/updates/2026-02-09-og-meta-all-pages.md
+++ b/content/updates/2026-02-09-og-meta-all-pages.md
@@ -1,0 +1,19 @@
+---
+id: rel-2026-02-09-og-meta-all-pages
+version: v0.30.0
+title: "Better social previews for every page"
+date: 2026-02-09
+published_at: 2026-02-09T23:59:00Z
+status: published
+notify_in_app: false
+in_app_hours: 24
+summary: "Every marketing page now shows the right title, description, and branded badge when shared on social media."
+---
+
+## Changes
+- [x] [Improved] 🔗 Sharing links to Inspirations, Pricing, and Blog pages now show accurate titles and descriptions instead of generic fallbacks.
+- [x] [Improved] 🏷️ Social preview images display a page-specific badge (e.g. "TRIP INSPIRATIONS", "PRICING", "BLOG") instead of always showing "TravelFlow".
+- [x] [Improved] 🌍 Country-specific inspiration pages (e.g. /inspirations/country/Japan) generate dynamic OG meta with the country name.
+- [x] [Improved] 📝 Blog post social previews now pull real titles and summaries for richer link cards.
+- [ ] [Internal] Added edge function routes for /inspirations/*, /pricing, and /blog/* in netlify.toml.
+- [ ] [Internal] Extended PageDefinition with optional pill field and added BLOG_META static map for blog post metadata.

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,6 +14,10 @@
   targetPort = 5173
 
 [[edge_functions]]
+  path = "/api/trip-map-preview"
+  function = "trip-map-preview"
+
+[[edge_functions]]
   path = "/api/og/trip"
   function = "trip-og-image"
 
@@ -71,6 +75,22 @@
 
 [[edge_functions]]
   path = "/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/blog/*"
   function = "site-og-meta"
 
 [[edge_functions]]

--- a/netlify/edge-functions/site-og-image.tsx
+++ b/netlify/edge-functions/site-og-image.tsx
@@ -98,6 +98,7 @@ export default async (request: Request): Promise<Response> => {
 
     const title = sanitizeText(url.searchParams.get("title"), 110) || DEFAULT_TITLE;
     const subline = sanitizeText(url.searchParams.get("description"), 160) || DEFAULT_SUBLINE;
+    const pillText = sanitizeText(url.searchParams.get("pill"), 30) || "TravelFlow";
     const pagePath = normalizePath(url.searchParams.get("path"));
     const displayUrl = truncateText(`${url.host}${pagePath}`, 62);
 
@@ -142,7 +143,7 @@ export default async (request: Request): Promise<Response> => {
               }}
             >
               <img src={FOOTER_PLANE_ICON_URI} alt="" style={{ width: 16, height: 16, display: "flex" }} />
-              TravelFlow
+              {pillText}
             </div>
 
             <div

--- a/netlify/edge-functions/site-og-meta.ts
+++ b/netlify/edge-functions/site-og-meta.ts
@@ -16,28 +16,34 @@ interface PageDefinition {
   title: string;
   description: string;
   robots?: string;
+  pill?: string;
 }
 
 const PAGE_META: Record<string, PageDefinition> = {
   "/": {
     title: "TravelFlow",
     description: "Plan smarter trips with timeline + map routing and share them beautifully.",
+    pill: "TRAVELFLOW",
   },
   "/create-trip": {
     title: "Create Trip",
     description: "Build your itinerary with flexible stops, routes, and timeline planning.",
+    pill: "TRIP PLANNER",
   },
   "/features": {
     title: "Features",
     description: "See everything TravelFlow offers for planning and sharing better adventures.",
+    pill: "FEATURES",
   },
   "/updates": {
     title: "Product Updates",
     description: "Catch the latest TravelFlow improvements and recently shipped features.",
+    pill: "PRODUCT UPDATES",
   },
   "/blog": {
     title: "TravelFlow Blog",
     description: "Guides, trip-planning ideas, and practical workflow tips from the TravelFlow team.",
+    pill: "BLOG",
   },
   "/login": {
     title: "Login",
@@ -59,6 +65,64 @@ const PAGE_META: Record<string, PageDefinition> = {
     title: "Cookie Policy",
     description: "Understand how TravelFlow uses cookies and similar technologies.",
   },
+  "/inspirations": {
+    title: "Where Will You Go Next?",
+    description: "Browse curated trip ideas by theme, month, country, or upcoming festivals.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/inspirations/themes": {
+    title: "Travel by Theme",
+    description: "Find curated trip ideas that match your travel style — adventure, food, photography, and more.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/inspirations/best-time-to-travel": {
+    title: "When to Go Where",
+    description: "Month-by-month guide to the best time to visit destinations around the world.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/inspirations/countries": {
+    title: "Explore by Country",
+    description: "Country-specific travel guides with best-month picks, top cities, and local tips.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/inspirations/events-and-festivals": {
+    title: "Plan Around a Festival",
+    description: "Discover upcoming festivals and build your itinerary around the event.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/inspirations/weekend-getaways": {
+    title: "Quick Escapes for Busy Travelers",
+    description: "2–3 day getaway ideas for spontaneous adventurers — pack light and make the most of a long weekend.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/pricing": {
+    title: "Simple, Transparent Pricing",
+    description: "Start for free and upgrade when you need more. No hidden fees, cancel anytime.",
+    pill: "PRICING",
+  },
+};
+
+const BLOG_META: Record<string, { title: string; description: string }> = {
+  "best-time-visit-japan": {
+    title: "The Best Time to Visit Japan — A Month-by-Month Guide",
+    description: "Japan transforms with every season. From cherry blossoms to powder snow, here's when to go.",
+  },
+  "budget-travel-europe": {
+    title: "Budget Travel Hacks for Europe",
+    description: "Smart timing, local habits, and a few practical tricks can cut your Europe costs in half.",
+  },
+  "festival-travel-guide": {
+    title: "How to Plan a Trip Around a Festival",
+    description: "Festival-centered trips are some of the most memorable journeys. Here's how to plan one.",
+  },
+  "how-to-plan-multi-city-trip": {
+    title: "How to Plan the Perfect Multi-City Trip",
+    description: "Practical advice on route planning, timing, and logistics for multi-destination travel.",
+  },
+  "weekend-getaway-tips": {
+    title: "Weekend Getaway Planning: From Idea to Boarding Pass",
+    description: "How to squeeze the most out of a 2–3 day trip without the stress.",
+  },
 };
 
 const pathToTitle = (pathname: string): string => {
@@ -73,6 +137,7 @@ const pathToTitle = (pathname: string): string => {
 
 const getPageDefinition = (pathname: string): PageDefinition => {
   if (PAGE_META[pathname]) return PAGE_META[pathname];
+
   if (pathname.startsWith("/admin")) {
     return {
       title: "Admin Dashboard",
@@ -80,6 +145,42 @@ const getPageDefinition = (pathname: string): PageDefinition => {
       robots: "noindex,nofollow,max-image-preview:large",
     };
   }
+
+  // /blog/:slug — look up static blog meta or fall back to pathToTitle
+  const blogMatch = pathname.match(/^\/blog\/([^/]+)\/?$/);
+  if (blogMatch) {
+    const slug = blogMatch[1];
+    const blog = BLOG_META[slug];
+    return {
+      title: blog ? blog.title : pathToTitle(pathname),
+      description: blog ? blog.description : "Read this article on the TravelFlow blog.",
+      pill: "BLOG",
+    };
+  }
+
+  // /inspirations/country/:countryName
+  const countryMatch = pathname.match(/^\/inspirations\/country\/([^/]+)\/?$/);
+  if (countryMatch) {
+    const country = decodeURIComponent(countryMatch[1])
+      .split(/[-_]+/)
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+      .join(" ");
+    return {
+      title: `Travel to ${country}`,
+      description: `Plan your trip to ${country} — best months, itineraries, and tips.`,
+      pill: "TRIP INSPIRATIONS",
+    };
+  }
+
+  // /inspirations/* catch-all
+  if (pathname.startsWith("/inspirations")) {
+    return {
+      title: pathToTitle(pathname),
+      description: "Explore curated trip ideas and travel inspiration on TravelFlow.",
+      pill: "TRIP INSPIRATIONS",
+    };
+  }
+
   return {
     title: pathToTitle(pathname),
     description: DEFAULT_DESCRIPTION,
@@ -150,6 +251,9 @@ const buildMetadata = (url: URL): Metadata => {
   ogImage.searchParams.set("title", page.title);
   ogImage.searchParams.set("description", page.description);
   ogImage.searchParams.set("path", url.pathname + canonicalSearch);
+  if (page.pill) {
+    ogImage.searchParams.set("pill", page.pill);
+  }
 
   return {
     pageTitle: title,


### PR DESCRIPTION
## Summary
- Every marketing page now gets correct `og:title`, `og:description`, and a custom pill badge in the social preview image instead of the generic "TravelFlow" fallback
- Adds edge-function routes for `/inspirations/*`, `/pricing`, and `/blog/*` with dynamic country and blog-slug matching
- Includes static `BLOG_META` map for all 5 existing blog posts and a `TRIP INSPIRATIONS` pill for all inspiration sub-pages

## Test plan
- [ ] Hit `/api/og/site?title=Where+Will+You+Go+Next?&description=Browse+curated+trip+ideas...&path=/inspirations&pill=TRIP+INSPIRATIONS` and verify pill shows "TRIP INSPIRATIONS"
- [ ] `curl` `/inspirations`, `/inspirations/themes`, `/inspirations/country/Japan`, `/pricing`, `/blog/best-time-visit-japan`, `/blog/unknown-slug` and verify `<head>` meta tags
- [ ] Verify `/`, `/features`, `/blog` still produce correct meta (regression)
- [ ] After deploy, test with Twitter Card Validator / Facebook Sharing Debugger

🤖 Generated with [Claude Code](https://claude.com/claude-code)