### PR TITLE
Fix blog OG default tint to brand indigo

### DIFF
--- a/content/updates/2026-02-10-inspirations-photo-cards.md
+++ b/content/updates/2026-02-10-inspirations-photo-cards.md
@@ -1,13 +1,13 @@
 ---
 id: rel-2026-02-10-inspirations-photo-cards
-version: v0.40.0
+version: v0.41.0
 title: "Travel photography now powers inspiration and blog previews"
 date: 2026-02-10
-published_at: 2026-02-10T10:11:29Z
+published_at: 2026-02-10T10:24:25Z
 status: published
 notify_in_app: true
 in_app_hours: 24
-summary: "Inspiration and blog cards now use realistic generated travel photography, with a default 60% accent tint gradient on blog OG previews and controllable tint settings."
+summary: "Inspiration and blog cards now use realistic generated travel photography, with a default 60% brand tint gradient on blog OG previews and controllable tint settings."
 ---
 
 ## Changes
@@ -23,6 +23,7 @@ summary: "Inspiration and blog cards now use realistic generated travel photogra
 - [x] [Improved] 🔗 Blog post social previews now render article-specific photography with a soft accent tint in Open Graph cards.
 - [x] [Improved] 🗜️ Blog Open Graph previews now render below common 600 KB crawler warning thresholds through heavier OG-source compression and tuned side-panel composition.
 - [x] [Improved] 🎨 Blog Open Graph previews now default to a 60% accent tint treatment for blog pages, with optional color and intensity overrides.
+- [x] [Fixed] 🎯 Blog Open Graph default tint now uses the global brand indigo color across all blog posts (instead of per-post accent colors).
 - [x] [Improved] 🎛️ OG Playground now includes native blog tint controls (enable toggle, color picker, and intensity slider) for faster visual testing.
 - [x] [Fixed] 🔄 Blog OG tint previews now redraw reliably on each render and correctly reflect color/intensity changes.
 - [x] [Fixed] ☀️ Blog OG images now render without a dark overlay when tint is disabled, preserving the original photo brightness.

--- a/netlify/edge-functions/site-og-meta.ts
+++ b/netlify/edge-functions/site-og-meta.ts
@@ -1,9 +1,10 @@
 import { escapeHtml } from "../edge-lib/trip-og-data.ts";
-import { BLOG_OG_IMAGE_REVISION, getBlogImageAccentTint, getBlogImageMedia } from "../../data/blogImageMedia.ts";
+import { BLOG_OG_IMAGE_REVISION, getBlogImageMedia } from "../../data/blogImageMedia.ts";
 
 const SITE_NAME = "TravelFlow";
 const DEFAULT_DESCRIPTION = "Plan and share travel routes with timeline and map previews in TravelFlow.";
 const SITE_CACHE_CONTROL = "public, max-age=0, s-maxage=900, stale-while-revalidate=86400";
+const DEFAULT_BLOG_OG_TINT = "#6366f1";
 
 interface Metadata {
   pageTitle: string;
@@ -174,7 +175,7 @@ const getPageDefinition = (pathname: string): PageDefinition => {
   if (blogMatch) {
     const slug = blogMatch[1];
     const blog = BLOG_META[slug];
-    const media = getBlogImageMedia(slug, blog ? blog.title : pathToTitle(pathname), getBlogImageAccentTint(slug));
+    const media = getBlogImageMedia(slug, blog ? blog.title : pathToTitle(pathname));
     return {
       title: blog ? blog.title : pathToTitle(pathname),
       description: blog ? blog.description : "Read this article on the TravelFlow blog.",
@@ -182,7 +183,7 @@ const getPageDefinition = (pathname: string): PageDefinition => {
       ogDescription: blog?.ogDescription,
       pill: "BLOG",
       blogOgImagePath: media.ogVertical.source,
-      blogAccentTint: media.accentTint,
+      blogAccentTint: DEFAULT_BLOG_OG_TINT,
       blogTintIntensity: 60,
     };
   }
@@ -299,7 +300,7 @@ const buildMetadata = (url: URL): Metadata => {
   if (page.blogOgImagePath) {
     ogImage.searchParams.set("blog_image", page.blogOgImagePath);
     ogImage.searchParams.set("blog_rev", BLOG_OG_IMAGE_REVISION);
-    ogImage.searchParams.set("blog_tint", page.blogAccentTint || "#6366f1");
+    ogImage.searchParams.set("blog_tint", page.blogAccentTint || DEFAULT_BLOG_OG_TINT);
     ogImage.searchParams.set("blog_tint_intensity", String(page.blogTintIntensity ?? 60));
   }
 


### PR DESCRIPTION
## Summary
- fix blog OG default tint source so all blog pages use brand indigo (`#6366f1`) by default
- keep tint intensity default at 60 and preserve per-request override support via `blog_tint` and `blog_tint_intensity`
- remove the unintended per-post accent tint inheritance in metadata generation

## Validation
- `npm run edge:validate`
- `npm run updates:validate`
- `npm run build`
