### PR TITLE
Unify trip info modal across desktop and mobile

### DIFF
--- a/components/CountryInfo.tsx
+++ b/components/CountryInfo.tsx
@@ -1,14 +1,12 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ICountryInfo } from '../types';
-import { Banknote, Globe, Zap, FileText, ExternalLink, ArrowRightLeft, ChevronDown, ChevronUp } from 'lucide-react';
+import { Banknote, Globe, Zap, FileText, ExternalLink, ArrowRightLeft } from 'lucide-react';
 
 interface CountryInfoProps {
     info: ICountryInfo;
-    isExpanded?: boolean;
-    onExpandedChange?: (expanded: boolean) => void;
 }
 
-export const CountryInfo: React.FC<CountryInfoProps> = ({ info, isExpanded: isExpandedProp, onExpandedChange }) => {
+export const CountryInfo: React.FC<CountryInfoProps> = ({ info }) => {
     // Converter State with Persistence
     const [amount, setAmount] = useState<number>(() => {
         if (typeof window === 'undefined') return 1;
@@ -23,20 +21,6 @@ export const CountryInfo: React.FC<CountryInfoProps> = ({ info, isExpanded: isEx
         return (saved === 'eurToLocal' || saved === 'localToEur') ? saved : 'eurToLocal';
     });
 
-    const [localIsExpanded, setLocalIsExpanded] = useState(() => {
-        if (typeof window === 'undefined') return true;
-        const saved = localStorage.getItem('tf_country_info_expanded');
-        return saved !== null ? saved === 'true' : true;
-    });
-    const isExpanded = typeof isExpandedProp === 'boolean' ? isExpandedProp : localIsExpanded;
-
-    const setExpanded = useCallback((expanded: boolean) => {
-        if (typeof isExpandedProp !== 'boolean') {
-            setLocalIsExpanded(expanded);
-        }
-        onExpandedChange?.(expanded);
-    }, [isExpandedProp, onExpandedChange]);
-
     // Persistence Effects
     useEffect(() => {
         localStorage.setItem('tf_country_amount', amount.toString());
@@ -46,114 +30,101 @@ export const CountryInfo: React.FC<CountryInfoProps> = ({ info, isExpanded: isEx
         localStorage.setItem('tf_country_dir', direction);
     }, [direction]);
 
-    useEffect(() => {
-        localStorage.setItem('tf_country_info_expanded', String(isExpanded));
-    }, [isExpanded]);
-
     const convertedValue = direction === 'eurToLocal' 
         ? amount * info.exchangeRate 
         : amount / info.exchangeRate;
 
     return (
-        <div className="bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm mb-6 min-w-[300px] transition-all duration-300 ease-in-out">
-            <div 
-                className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex items-center justify-between cursor-pointer hover:bg-gray-100 transition-colors"
-                onClick={() => setExpanded(!isExpanded)}
-            >
+        <div className="bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm">
+            <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex items-center justify-between">
                 <h3 className="font-bold text-gray-800 text-sm uppercase tracking-wider flex items-center gap-2">
                     <Globe size={16} className="text-accent-600"/> Destination Info
                 </h3>
-                <button type="button" className="text-gray-400 hover:text-gray-600" aria-label={isExpanded ? 'Collapse destination info' : 'Expand destination info'}>
-                    {isExpanded ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
-                </button>
             </div>
-            
-            {isExpanded && (
-                <div className="p-4 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 animate-in slide-in-from-top-2 duration-200">
-                    {/* Currency Converter */}
-                    <div className="space-y-2 min-w-0">
-                        <label className="text-xs font-bold text-gray-400 uppercase flex items-center gap-1">
-                            <Banknote size={12} /> Currency Converter
-                        </label>
-                        <div className="flex items-center gap-2 bg-gray-50 p-2 rounded-lg border border-gray-200">
-                            <div className="flex-1 min-w-0">
-                                <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
-                                    <span>{direction === 'eurToLocal' ? 'EUR' : info.currencyCode}</span>
-                                </div>
-                                <input 
-                                    type="number" 
-                                    value={amount}
-                                    onChange={(e) => setAmount(Number(e.target.value))}
-                                    className="w-full bg-transparent font-bold text-gray-800 outline-none min-w-0"
-                                />
+            <div className="p-4 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+                {/* Currency Converter */}
+                <div className="space-y-2 min-w-0">
+                    <label className="text-xs font-bold text-gray-400 uppercase flex items-center gap-1">
+                        <Banknote size={12} /> Currency Converter
+                    </label>
+                    <div className="flex items-center gap-2 bg-gray-50 p-2 rounded-lg border border-gray-200">
+                        <div className="flex-1 min-w-0">
+                            <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+                                <span>{direction === 'eurToLocal' ? 'EUR' : info.currencyCode}</span>
                             </div>
-                            <button 
-                                onClick={(e) => { e.stopPropagation(); setDirection(direction === 'eurToLocal' ? 'localToEur' : 'eurToLocal'); }}
-                                className="p-1.5 bg-white shadow-sm border border-gray-200 rounded-full hover:bg-gray-100 text-accent-600 flex-shrink-0" aria-label="Swap conversion direction"
-                            >
-                                <ArrowRightLeft size={14} />
-                            </button>
-                            <div className="flex-1 text-right min-w-0">
-                                <div className="text-xs text-gray-500 mb-1">
-                                    <span>{direction === 'eurToLocal' ? info.currencyCode : 'EUR'}</span>
-                                </div>
-                                <div className="font-bold text-gray-800 truncate">
-                                    {convertedValue.toLocaleString(undefined, { maximumFractionDigits: 2 })}
-                                </div>
+                            <input 
+                                type="number" 
+                                value={amount}
+                                onChange={(e) => setAmount(Number(e.target.value))}
+                                className="w-full bg-transparent font-bold text-gray-800 outline-none min-w-0"
+                            />
+                        </div>
+                        <button 
+                            onClick={() => setDirection(direction === 'eurToLocal' ? 'localToEur' : 'eurToLocal')}
+                            className="p-1.5 bg-white shadow-sm border border-gray-200 rounded-full hover:bg-gray-100 text-accent-600 flex-shrink-0" aria-label="Swap conversion direction"
+                        >
+                            <ArrowRightLeft size={14} />
+                        </button>
+                        <div className="flex-1 text-right min-w-0">
+                            <div className="text-xs text-gray-500 mb-1">
+                                <span>{direction === 'eurToLocal' ? info.currencyCode : 'EUR'}</span>
+                            </div>
+                            <div className="font-bold text-gray-800 truncate">
+                                {convertedValue.toLocaleString(undefined, { maximumFractionDigits: 2 })}
                             </div>
                         </div>
-                        <div className="text-[10px] text-gray-400 text-center truncate">
-                            Rate: 1 EUR ≈ {info.exchangeRate.toFixed(2)} {info.currencyCode}
-                        </div>
                     </div>
-
-                    {/* Languages */}
-                    <div className="space-y-2 min-w-0">
-                        <label className="text-xs font-bold text-gray-400 uppercase flex items-center gap-1">
-                            <Globe size={12} /> Languages
-                        </label>
-                        <div className="flex flex-wrap gap-1">
-                            {info.languages.map((lang, i) => (
-                                <span key={i} className="px-2 py-1 bg-accent-50 text-accent-700 text-xs font-medium rounded-md border border-accent-100 whitespace-nowrap">
-                                    {lang}
-                                </span>
-                            ))}
-                        </div>
-                    </div>
-
-                    {/* Sockets */}
-                    <div className="space-y-2 min-w-0">
-                        <label className="text-xs font-bold text-gray-400 uppercase flex items-center gap-1">
-                            <Zap size={12} /> Electric Sockets
-                        </label>
-                        <div className="p-2 bg-gray-50 rounded-lg border border-gray-200 text-sm text-gray-800 break-words">
-                            {info.electricSockets}
-                        </div>
-                    </div>
-
-                    {/* Links */}
-                    <div className="space-y-2 min-w-0">
-                        <label className="text-xs font-bold text-gray-400 uppercase flex items-center gap-1">
-                            <FileText size={12} /> Important Links
-                        </label>
-                        <div className="flex flex-col gap-2">
-                            {info.visaInfoUrl && (
-                                <a href={info.visaInfoUrl} target="_blank" rel="noreferrer" className="text-xs text-accent-600 hover:underline flex items-center gap-1 truncate">
-                                    <ExternalLink size={10} className="flex-shrink-0" /> Visa Information
-                                </a>
-                            )}
-                            {info.auswaertigesAmtUrl && (
-                                <a href={info.auswaertigesAmtUrl} target="_blank" rel="noreferrer" className="text-xs text-accent-600 hover:underline flex items-center gap-1 truncate">
-                                    <ExternalLink size={10} className="flex-shrink-0" /> Auswärtiges Amt (DE)
-                                </a>
-                            )}
-                            {!info.visaInfoUrl && !info.auswaertigesAmtUrl && (
-                                <span className="text-xs text-gray-400 italic">No specific links available</span>
-                            )}
-                        </div>
+                    <div className="text-[10px] text-gray-400 text-center truncate">
+                        Rate: 1 EUR ≈ {info.exchangeRate.toFixed(2)} {info.currencyCode}
                     </div>
                 </div>
-            )}
+
+                {/* Languages */}
+                <div className="space-y-2 min-w-0">
+                    <label className="text-xs font-bold text-gray-400 uppercase flex items-center gap-1">
+                        <Globe size={12} /> Languages
+                    </label>
+                    <div className="flex flex-wrap gap-1">
+                        {info.languages.map((lang, i) => (
+                            <span key={i} className="px-2 py-1 bg-accent-50 text-accent-700 text-xs font-medium rounded-md border border-accent-100 whitespace-nowrap">
+                                {lang}
+                            </span>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Sockets */}
+                <div className="space-y-2 min-w-0">
+                    <label className="text-xs font-bold text-gray-400 uppercase flex items-center gap-1">
+                        <Zap size={12} /> Electric Sockets
+                    </label>
+                    <div className="p-2 bg-gray-50 rounded-lg border border-gray-200 text-sm text-gray-800 break-words">
+                        {info.electricSockets}
+                    </div>
+                </div>
+
+                {/* Links */}
+                <div className="space-y-2 min-w-0">
+                    <label className="text-xs font-bold text-gray-400 uppercase flex items-center gap-1">
+                        <FileText size={12} /> Important Links
+                    </label>
+                    <div className="flex flex-col gap-2">
+                        {info.visaInfoUrl && (
+                            <a href={info.visaInfoUrl} target="_blank" rel="noreferrer" className="text-xs text-accent-600 hover:underline flex items-center gap-1 truncate">
+                                <ExternalLink size={10} className="flex-shrink-0" /> Visa Information
+                            </a>
+                        )}
+                        {info.auswaertigesAmtUrl && (
+                            <a href={info.auswaertigesAmtUrl} target="_blank" rel="noreferrer" className="text-xs text-accent-600 hover:underline flex items-center gap-1 truncate">
+                                <ExternalLink size={10} className="flex-shrink-0" /> Auswärtiges Amt (DE)
+                            </a>
+                        )}
+                        {!info.visaInfoUrl && !info.auswaertigesAmtUrl && (
+                            <span className="text-xs text-gray-400 italic">No specific links available</span>
+                        )}
+                    </div>
+                </div>
+            </div>
         </div>
     );
 };

--- a/content/updates/2026-02-10-trip-info-modal-unification.md
+++ b/content/updates/2026-02-10-trip-info-modal-unification.md
@@ -1,0 +1,18 @@
+---
+id: rel-2026-02-10-trip-info-modal-unification
+version: v0.43.0
+title: "Unified trip information modal across desktop and mobile"
+date: 2026-02-10
+published_at: 2026-02-10T18:16:28Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "Desktop and mobile now share one trip information modal, with destination details and trip-source context centralized in a clearer view."
+---
+
+## Changes
+- [x] [Improved] ℹ️ Added the trip info icon and popup to desktop so desktop and mobile now use the same information modal entry point.
+- [x] [Improved] 🗂️ Moved destination info out of the trip content column and into the trip information modal for a cleaner main layout.
+- [x] [Improved] 🧾 Redesigned copied-trip source context inside the information modal so fork/source details are easier to read, including a direct source link when available.
+- [x] [Fixed] ⌨️ Ensured the trip information modal closes reliably via `ESC` and outside-click behavior across breakpoints.
+- [ ] [Internal] 🧹 Removed legacy destination-info open/close persistence from view state and localStorage.

--- a/data/exampleTripTemplates/index.ts
+++ b/data/exampleTripTemplates/index.ts
@@ -103,7 +103,6 @@ const buildDefaultView = (config: ExampleTripTemplateConfig) => ({
     mapStyle: config.mapStyle,
     routeMode: config.routeMode,
     showCityNames: true,
-    destinationInfoExpanded: true,
     zoomLevel: 1,
 });
 

--- a/types.ts
+++ b/types.ts
@@ -107,7 +107,6 @@ export interface IViewSettings {
     showCityNames?: boolean;
     sidebarWidth?: number;
     timelineHeight?: number;
-    destinationInfoExpanded?: boolean;
 }
 
 export interface ISharedState {


### PR DESCRIPTION
## Summary
- add the trip info icon + modal entry to desktop so desktop and mobile use the same modal pattern
- remove inline destination info from the desktop content area and show destination info only in the info modal
- move copied-trip source context out of the header byline into a clearer modal section
- remove legacy destination-info expand/collapse persistence from view settings/localStorage
- add release note: v0.43.0 (`content/updates/2026-02-10-trip-info-modal-unification.md`)

## Validation
- npm run build
