### PR TITLE
Persist debugger toggle settings across reloads

### DIFF
--- a/content/updates/2026-02-10-on-page-debug-toolbar.md
+++ b/content/updates/2026-02-10-on-page-debug-toolbar.md
@@ -2,12 +2,12 @@
 id: rel-2026-02-10-on-page-debug-toolbar
 version: v0.45.0
 title: "On-page debugger toolbar"
-date: 2026-02-10
-published_at: 2026-02-10T19:05:00Z
-status: draft
+date: 2026-02-11
+published_at: 2026-02-11T11:29:38Z
+status: published
 notify_in_app: false
 in_app_hours: 24
-summary: "Internal QA and debugging tooling update for development workflows."
+summary: "Internal QA toolbar now persists debugger toggles across reloads for faster testing."
 ---
 
 ## Changes
@@ -16,6 +16,7 @@ summary: "Internal QA and debugging tooling update for development workflows."
 - [ ] [Internal] 🧭 Expanded internal page diagnostics and validation shortcuts.
 - [ ] [Internal] 🔒 Added route-scoped debug controls for trip-state QA scenarios.
 - [ ] [Internal] 👤 Added a simulated-login debug toggle (`window.toggleSimulatedLogin`) for paywall and auth-gated flow testing.
+- [ ] [Internal] 💾 Persisted debugger toggle states (tracking boxes, panel expand/collapse, H1 marker, auto-open, simulated login) in localStorage across reloads.
 - [ ] [Internal] 🛡️ Hardened debug hook calls with optional-chaining guards so stripped production builds do not throw.
 - [ ] [Internal] 🩹 Removed destination-info collapse state and kept modal content always expanded.
 - [ ] [Internal] 🧼 Added compatibility cleanup for legacy destination-info localStorage/view payload data.

--- a/docs/ON_PAGE_DEBUGGER.md
+++ b/docs/ON_PAGE_DEBUGGER.md
@@ -65,6 +65,15 @@ Behavior:
 - Disables editing in `TripView` while expired is `true`
 - Emits event `tf:trip-expired-debug`
 
+## Debugger toggle persistence
+
+The toolbar now saves toggle state in `localStorage` and restores it after reload:
+- `tf_debug_auto_open` (`Enable auto-open`)
+- `tf_debug_tracking_enabled` (`Show/Hide Tracking Boxes`)
+- `tf_debug_panel_expanded` (`Expand/Collapse`)
+- `tf_debug_h1_highlight` (`Mark/Unmark H1`)
+- `tf_debug_simulated_login` (`Enable/Disable Sim Login`)
+
 ## Route-aware behavior
 
 ### On `/trip/:tripId`


### PR DESCRIPTION
## Summary
- persist debugger toggle preferences in localStorage for tracking boxes, panel expand/collapse, H1 highlight, auto-open, and simulated login
- restore persisted toggle defaults on component init so state survives reloads
- document persisted debugger keys and finalize the existing on-page debugger release note entry

## Testing
- npm run updates:validate
- npm run blog:validate
- npm run edge:validate
- npx vite build

## Notes
- The full npm run build script now calls image optimization tasks that require the sharp package. sharp is not installed in this environment, so I validated with the targeted checks above plus npx vite build.
