### PR TITLE
Show internal news on updates page for debugger/sim-login sessions

### DIFF
--- a/components/OnPageDebugger.tsx
+++ b/components/OnPageDebugger.tsx
@@ -25,6 +25,7 @@ const DEBUG_PANEL_EXPANDED_STORAGE_KEY = 'tf_debug_panel_expanded';
 const DEBUG_H1_HIGHLIGHT_STORAGE_KEY = 'tf_debug_h1_highlight';
 const TRIP_EXPIRED_DEBUG_EVENT = 'tf:trip-expired-debug';
 const SIMULATED_LOGIN_DEBUG_EVENT = 'tf:simulated-login-debug';
+const DEBUGGER_STATE_DEBUG_EVENT = 'tf:on-page-debugger-state';
 const SIMULATED_LOGIN_STORAGE_KEY = 'tf_debug_simulated_login';
 
 interface TrackingBox {
@@ -75,6 +76,11 @@ interface TripExpiredDebugDetail {
 interface SimulatedLoginDebugDetail {
     available: boolean;
     loggedIn: boolean;
+}
+
+interface DebuggerStateDebugDetail {
+    available: boolean;
+    open: boolean;
 }
 
 interface OnPageDebuggerApi {
@@ -414,6 +420,12 @@ export const OnPageDebugger: React.FC = () => {
     }, []);
 
     useEffect(() => {
+        window.dispatchEvent(new CustomEvent<DebuggerStateDebugDetail>(DEBUGGER_STATE_DEBUG_EVENT, {
+            detail: { available: true, open: isOpen },
+        }));
+    }, [isOpen]);
+
+    useEffect(() => {
         simulatedLoggedInRef.current = simulatedLoggedIn;
     }, [simulatedLoggedIn]);
 
@@ -750,6 +762,9 @@ export const OnPageDebugger: React.FC = () => {
             delete window.onPageDebugger;
             delete window.toggleSimulatedLogin;
             delete window.getSimulatedLogin;
+            window.dispatchEvent(new CustomEvent<DebuggerStateDebugDetail>(DEBUGGER_STATE_DEBUG_EVENT, {
+                detail: { available: false, open: false },
+            }));
             window.dispatchEvent(new CustomEvent<SimulatedLoginDebugDetail>(SIMULATED_LOGIN_DEBUG_EVENT, {
                 detail: { available: false, loggedIn: false },
             }));

--- a/pages/UpdatesPage.tsx
+++ b/pages/UpdatesPage.tsx
@@ -1,9 +1,30 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
 import { ReleasePill } from '../components/marketing/ReleasePill';
 import { getPublishedReleaseNotes, getWebsiteVisibleItems, groupReleaseItemsByType } from '../services/releaseNotesService';
+
+const SIMULATED_LOGIN_STORAGE_KEY = 'tf_debug_simulated_login';
+const SIMULATED_LOGIN_DEBUG_EVENT = 'tf:simulated-login-debug';
+const DEBUGGER_STATE_DEBUG_EVENT = 'tf:on-page-debugger-state';
+
+interface SimulatedLoginDebugDetail {
+    available: boolean;
+    loggedIn: boolean;
+}
+
+interface DebuggerStateDebugDetail {
+    available: boolean;
+    open: boolean;
+}
+
+type DebuggerHost = Window & {
+    onPageDebugger?: {
+        getState: () => { open: boolean; tracking: boolean };
+    };
+    getSimulatedLogin?: () => boolean;
+};
 
 const formatReleaseDate = (dateLike: string) => {
     const parsed = new Date(dateLike);
@@ -16,16 +37,86 @@ const formatReleaseDate = (dateLike: string) => {
     });
 };
 
+const readStoredBoolean = (storageKey: string, fallbackValue: boolean): boolean => {
+    if (typeof window === 'undefined') return fallbackValue;
+    try {
+        const raw = window.localStorage.getItem(storageKey);
+        if (raw === '1') return true;
+        if (raw === '0') return false;
+        return fallbackValue;
+    } catch {
+        return fallbackValue;
+    }
+};
+
+const readInitialDebuggerOpen = (): boolean => {
+    if (typeof window === 'undefined') return false;
+    const host = window as DebuggerHost;
+    return Boolean(host.onPageDebugger?.getState()?.open);
+};
+
+const readInitialSimulatedLogin = (): boolean => {
+    if (typeof window === 'undefined') return false;
+    const host = window as DebuggerHost;
+    if (typeof host.getSimulatedLogin === 'function') {
+        return Boolean(host.getSimulatedLogin());
+    }
+    return readStoredBoolean(SIMULATED_LOGIN_STORAGE_KEY, false);
+};
+
 export const UpdatesPage: React.FC = () => {
     const releases = useMemo(() => getPublishedReleaseNotes(), []);
+    const [isDebuggerOpen, setIsDebuggerOpen] = useState<boolean>(() => readInitialDebuggerOpen());
+    const [isSimulatedLoggedIn, setIsSimulatedLoggedIn] = useState<boolean>(() => readInitialSimulatedLogin());
+    const showInternalNews = isDebuggerOpen || isSimulatedLoggedIn;
+
+    useEffect(() => {
+        const syncFromHost = () => {
+            const host = window as DebuggerHost;
+            setIsDebuggerOpen(Boolean(host.onPageDebugger?.getState()?.open));
+            if (typeof host.getSimulatedLogin === 'function') {
+                setIsSimulatedLoggedIn(Boolean(host.getSimulatedLogin()));
+                return;
+            }
+            setIsSimulatedLoggedIn(readStoredBoolean(SIMULATED_LOGIN_STORAGE_KEY, false));
+        };
+
+        const handleDebuggerState = (event: Event) => {
+            const detail = (event as CustomEvent<DebuggerStateDebugDetail>).detail;
+            if (!detail?.available) {
+                setIsDebuggerOpen(false);
+                return;
+            }
+            setIsDebuggerOpen(Boolean(detail.open));
+        };
+
+        const handleSimulatedLoginState = (event: Event) => {
+            const detail = (event as CustomEvent<SimulatedLoginDebugDetail>).detail;
+            if (!detail?.available) {
+                setIsSimulatedLoggedIn(false);
+                return;
+            }
+            setIsSimulatedLoggedIn(Boolean(detail.loggedIn));
+        };
+
+        syncFromHost();
+
+        window.addEventListener(DEBUGGER_STATE_DEBUG_EVENT, handleDebuggerState as EventListener);
+        window.addEventListener(SIMULATED_LOGIN_DEBUG_EVENT, handleSimulatedLoginState as EventListener);
+        return () => {
+            window.removeEventListener(DEBUGGER_STATE_DEBUG_EVENT, handleDebuggerState as EventListener);
+            window.removeEventListener(SIMULATED_LOGIN_DEBUG_EVENT, handleSimulatedLoginState as EventListener);
+        };
+    }, []);
+
     const releaseEntries = useMemo(
         () =>
             releases.flatMap((release) => {
-                const visibleItems = getWebsiteVisibleItems(release);
+                const visibleItems = showInternalNews ? release.items : getWebsiteVisibleItems(release);
                 if (visibleItems.length === 0) return [];
                 return [{ release, groupedItems: groupReleaseItemsByType(visibleItems) }];
             }),
-        [releases]
+        [releases, showInternalNews]
     );
 
     return (
@@ -35,6 +126,12 @@ export const UpdatesPage: React.FC = () => {
             </section>
 
             <section className="mt-2 space-y-4">
+                {showInternalNews && (
+                    <article className="rounded-2xl border border-rose-200 bg-rose-50/80 p-4 shadow-sm">
+                        <p className="text-sm font-medium text-rose-800">Internal view enabled. Hidden release items are visible.</p>
+                    </article>
+                )}
+
                 {releaseEntries.length === 0 && (
                     <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
                         <p className="text-sm text-slate-600">No published updates yet.</p>
@@ -97,20 +194,29 @@ export const UpdatesPage: React.FC = () => {
                                         <ul className="mt-2 list-disc space-y-2 pl-5 text-sm leading-6 text-slate-700 marker:text-slate-400">
                                             {group.items.map((item, itemIndex) => (
                                                 <li key={`${release.id}-${group.typeKey}-${group.typeLabel}-${itemIndex}`}>
-                                                    <ReactMarkdown
-                                                        remarkPlugins={[remarkGfm]}
-                                                        components={{
-                                                            p: ({ node, ...props }) => <p {...props} className="m-0" />,
-                                                            a: ({ node, ...props }) => (
-                                                                <a {...props} className="text-accent-700 underline decoration-accent-300 underline-offset-2 hover:text-accent-800" />
-                                                            ),
-                                                            code: ({ node, ...props }) => (
-                                                                <code {...props} className="rounded bg-slate-100 px-1 py-0.5 text-[0.92em] text-slate-800" />
-                                                            ),
-                                                        }}
-                                                    >
-                                                        {item.text}
-                                                    </ReactMarkdown>
+                                                    <div className="flex flex-wrap items-start gap-2">
+                                                        {item.typeKey === 'internal' && (
+                                                            <span className="mt-0.5 inline-flex shrink-0 rounded-full border border-rose-300 bg-rose-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-rose-700">
+                                                                Internal
+                                                            </span>
+                                                        )}
+                                                        <div className="min-w-0 flex-1">
+                                                            <ReactMarkdown
+                                                                remarkPlugins={[remarkGfm]}
+                                                                components={{
+                                                                    p: ({ node, ...props }) => <p {...props} className="m-0" />,
+                                                                    a: ({ node, ...props }) => (
+                                                                        <a {...props} className="text-accent-700 underline decoration-accent-300 underline-offset-2 hover:text-accent-800" />
+                                                                    ),
+                                                                    code: ({ node, ...props }) => (
+                                                                        <code {...props} className="rounded bg-slate-100 px-1 py-0.5 text-[0.92em] text-slate-800" />
+                                                                    ),
+                                                                }}
+                                                            >
+                                                                {item.text}
+                                                            </ReactMarkdown>
+                                                        </div>
+                                                    </div>
                                                 </li>
                                             ))}
                                         </ul>


### PR DESCRIPTION
## Summary
- show all release-note items on `/updates` when the on-page debugger is open
- also show all release-note items when simulated login is enabled
- add a dedicated `Internal` badge marker on internal update entries so they are clearly identifiable
- add a small internal-view callout on the updates page when privileged visibility is active

## Validation
- `npx vite build`
- `npm run updates:validate`
- `npm run blog:validate`
- `npm run edge:validate`

## Notes
- I did not add a new release-note markdown file for this small change, per request.