### PR TITLE
fix: restore benchmark live polling and add run cancellation

### DIFF
--- a/content/updates/2026-02-11-ai-backend-target-architecture.md
+++ b/content/updates/2026-02-11-ai-backend-target-architecture.md
@@ -51,3 +51,5 @@ summary: "Implemented the first operational benchmark stack with persisted sessi
 - [ ] [Internal] 🚨 Split benchmark validation outcomes into blocking errors vs non-blocking warnings, persisted warning details in run validation payloads, and added warning visibility/filtering in `/admin/ai-benchmark`.
 - [ ] [Internal] ⏱️ Switched benchmark execution to async edge background processing (`waitUntil`) with admin-page polling so deployed benchmark runs no longer time out when model generations are slow.
 - [ ] [Internal] 🔄 Added benchmark-page startup bootstrap to auto-load the latest persisted benchmark session when no `session` URL param is present, so refresh does not appear to lose prior runs.
+- [ ] [Internal] 🛑 Added benchmark cancellation support (`POST /api/internal/ai/benchmark/cancel`) with per-run and per-session abort actions in `/admin/ai-benchmark`.
+- [ ] [Internal] 📡 Kept benchmark polling/live-latency updates active after reloading an in-progress session so running rows continue updating until completion or manual abort.

--- a/docs/AI_BACKEND_TARGET_ARCHITECTURE.md
+++ b/docs/AI_BACKEND_TARGET_ARCHITECTURE.md
@@ -17,6 +17,8 @@ Current implementation status:
 10. Transport mode enum + normalization + prompt guidance now use a shared contract (`shared/transportModes.ts`) with update workflow documented in `docs/TRANSPORT_MODE_CONTRACT.md`.
 11. Benchmark validation now includes stricter field/format checks with blocking errors vs non-blocking warning separation and per-run validation detail modal support in `/admin/ai-benchmark`.
 12. Benchmark execution now starts asynchronously in edge background (`waitUntil`) and `/admin/ai-benchmark` polls session status until runs settle, reducing deployed timeout failures.
+13. `/api/internal/ai/benchmark/cancel` is implemented for manual cancellation of active benchmark runs (single run or entire session).
+14. `/admin/ai-benchmark` keeps polling and live latency updates when a persisted session reloads with active runs, and exposes abort actions in the run table/session toolbar.
 
 ## 1) Confirmed decisions (2026-02-11)
 
@@ -285,6 +287,24 @@ Purpose:
 Request fields:
 1. `runId` (required)
 2. `rating` (`good` | `medium` | `bad` | `null`)
+
+## 8.7 Run cancellation endpoint
+
+`POST /api/internal/ai/benchmark/cancel`
+
+Purpose:
+1. Manually stop active benchmark runs from admin UI.
+2. Support cancel by single run (`runId`) or bulk cancel by session (`sessionId`).
+3. Keep cancelled rows visible in benchmark history as `failed` with explicit cancellation message.
+
+Request fields:
+1. `runId` optional (UUID)
+2. `sessionId` optional (UUID)
+
+Response includes:
+1. `cancelled` count
+2. refreshed session row (if available)
+3. full refreshed run list and summary for immediate table sync
 
 ## 9) Persistence model (Supabase)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -38,6 +38,10 @@
   function = "ai-benchmark"
 
 [[edge_functions]]
+  path = "/api/internal/ai/benchmark/cancel"
+  function = "ai-benchmark"
+
+[[edge_functions]]
   path = "/api/trip-map-preview"
   function = "trip-map-preview"
 


### PR DESCRIPTION
## Summary
- add `/api/internal/ai/benchmark/cancel` endpoint wiring + Netlify route
- support per-run and per-session abort actions in `/admin/ai-benchmark`
- keep benchmark polling and live latency updates active after reloading sessions that still have queued/running rows
- keep cancelled runs visible in table with explicit cancelled status
- update architecture doc + release note entry

## Validation
- npm run build
