### PR TITLE
fix: avoid benchmark generation edge timeouts with direct provider runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ VITE_GEMINI_API_KEY=your_gemini_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 OPENROUTER_API_KEY=your_openrouter_api_key_here
+# Optional provider request timeout tuning (ms)
+# /api/ai/generate default: 35000 (kept below typical edge response timeout window)
+AI_GENERATE_PROVIDER_TIMEOUT_MS=35000
+# /api/internal/ai/benchmark worker default: 90000
+AI_BENCHMARK_PROVIDER_TIMEOUT_MS=90000
 # Temporary internal API guard (admin benchmark endpoints)
 TF_ADMIN_API_KEY=replace_with_a_long_random_secret
 ```

--- a/content/updates/2026-02-11-ai-backend-target-architecture.md
+++ b/content/updates/2026-02-11-ai-backend-target-architecture.md
@@ -53,3 +53,5 @@ summary: "Implemented the first operational benchmark stack with persisted sessi
 - [ ] [Internal] 🔄 Added benchmark-page startup bootstrap to auto-load the latest persisted benchmark session when no `session` URL param is present, so refresh does not appear to lose prior runs.
 - [ ] [Internal] 🛑 Added benchmark cancellation support (`POST /api/internal/ai/benchmark/cancel`) with per-run and per-session abort actions in `/admin/ai-benchmark`.
 - [ ] [Internal] 📡 Kept benchmark polling/live-latency updates active after reloading an in-progress session so running rows continue updating until completion or manual abort.
+- [ ] [Internal] ⏳ Switched benchmark execution off nested `/api/ai/generate` calls to direct provider runtime execution with a dedicated benchmark timeout budget (`AI_BENCHMARK_PROVIDER_TIMEOUT_MS`, default 90s) to reduce edge timeout failures.
+- [ ] [Internal] 🧰 Added provider timeout environment controls for runtime and benchmark paths (`AI_GENERATE_PROVIDER_TIMEOUT_MS`, `AI_BENCHMARK_PROVIDER_TIMEOUT_MS`) and documented expected defaults.

--- a/docs/AI_BACKEND_TARGET_ARCHITECTURE.md
+++ b/docs/AI_BACKEND_TARGET_ARCHITECTURE.md
@@ -19,6 +19,7 @@ Current implementation status:
 12. Benchmark execution now starts asynchronously in edge background (`waitUntil`) and `/admin/ai-benchmark` polls session status until runs settle, reducing deployed timeout failures.
 13. `/api/internal/ai/benchmark/cancel` is implemented for manual cancellation of active benchmark runs (single run or entire session).
 14. `/admin/ai-benchmark` keeps polling and live latency updates when a persisted session reloads with active runs, and exposes abort actions in the run table/session toolbar.
+15. Benchmark workers now call provider APIs directly (shared edge runtime) with a dedicated provider timeout budget (default 90s), avoiding nested `/api/ai/generate` edge timeout failures.
 
 ## 1) Confirmed decisions (2026-02-11)
 
@@ -248,6 +249,11 @@ Response includes:
 2. run rows with status/latency/validation/usage/cost/trip URL
 3. summary counts
 4. persisted session token for URL reload/share
+
+Execution notes:
+1. Benchmark run workers call providers directly via shared edge runtime helpers (instead of nested `/api/ai/generate` calls).
+2. Provider timeout budget is configurable with `AI_BENCHMARK_PROVIDER_TIMEOUT_MS` (default `90000`).
+3. `/api/ai/generate` uses a separate timeout (`AI_GENERATE_PROVIDER_TIMEOUT_MS`, default `35000`) to stay inside synchronous edge response limits.
 
 ## 8.3 Benchmark read endpoint
 

--- a/netlify/edge-functions/ai-generate.ts
+++ b/netlify/edge-functions/ai-generate.ts
@@ -1,3 +1,9 @@
+import {
+  GEMINI_DEFAULT_MODEL,
+  generateProviderItinerary,
+  resolveTimeoutMs,
+} from "../edge-lib/ai-provider-runtime.ts";
+
 interface GenerateTarget {
   provider?: string;
   model?: string;
@@ -8,413 +14,18 @@ interface GenerateRequestBody {
   target?: GenerateTarget;
 }
 
-interface ProviderUsage {
-  promptTokens?: number;
-  completionTokens?: number;
-  totalTokens?: number;
-  estimatedCostUsd?: number;
-}
-
 const JSON_HEADERS = {
   "Content-Type": "application/json; charset=utf-8",
   "Cache-Control": "no-store",
 };
 
-const PROVIDER_ALLOWLIST: Record<string, Set<string>> = {
-  gemini: new Set([
-    "gemini-2.5-flash",
-    "gemini-2.5-pro",
-    "gemini-3-flash-preview",
-    "gemini-3-pro-preview",
-  ]),
-  openai: new Set([
-    "gpt-5-mini",
-    "gpt-5.2",
-  ]),
-  anthropic: new Set([
-    "claude-sonnet-4.5",
-    "claude-opus-4.6",
-  ]),
-  openrouter: new Set(),
-};
-
-const GEMINI_DEFAULT_MODEL = "gemini-3-pro-preview";
-const ANTHROPIC_MODEL_MAP: Record<string, string> = {
-  "claude-sonnet-4.5": "claude-sonnet-4-0",
-  "claude-opus-4.6": "claude-opus-4-0",
-  "claude-sonnet-4-0": "claude-sonnet-4-0",
-  "claude-opus-4-0": "claude-opus-4-0",
-};
-
-const GEMINI_PRICING_PER_MILLION: Record<string, { input: number; output: number }> = {
-  "gemini-2.5-flash": { input: 0.35, output: 1.05 },
-  "gemini-2.5-pro": { input: 3.5, output: 10.5 },
-  "gemini-3-flash-preview": { input: 0.35, output: 1.05 },
-  "gemini-3-pro-preview": { input: 3.5, output: 10.5 },
-};
-
-const readEnv = (name: string): string => {
-  try {
-    return (globalThis as { Deno?: { env?: { get: (key: string) => string | undefined } } }).Deno?.env?.get(name) || "";
-  } catch {
-    return "";
-  }
-};
+const EDGE_REQUEST_PROVIDER_TIMEOUT_MS = resolveTimeoutMs("AI_GENERATE_PROVIDER_TIMEOUT_MS", 35_000, 5_000, 60_000);
 
 const json = (status: number, payload: unknown): Response =>
   new Response(JSON.stringify(payload), {
     status,
     headers: JSON_HEADERS,
   });
-
-const extractJsonObject = (raw: string): Record<string, unknown> => {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    throw new Error("Provider returned empty content.");
-  }
-
-  const fenceMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-  const withoutFence = fenceMatch ? fenceMatch[1] : trimmed;
-
-  try {
-    const parsed = JSON.parse(withoutFence);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new Error("Response JSON was not an object.");
-    }
-    return parsed as Record<string, unknown>;
-  } catch {
-    const firstBrace = withoutFence.indexOf("{");
-    const lastBrace = withoutFence.lastIndexOf("}");
-    if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
-      throw new Error("Provider response did not contain valid JSON object boundaries.");
-    }
-
-    const candidate = withoutFence.slice(firstBrace, lastBrace + 1);
-    const reparsed = JSON.parse(candidate);
-    if (!reparsed || typeof reparsed !== "object" || Array.isArray(reparsed)) {
-      throw new Error("Response JSON candidate was not an object.");
-    }
-    return reparsed as Record<string, unknown>;
-  }
-};
-
-const extractOpenAiText = (content: unknown): string => {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-
-  return content
-    .map((entry) => {
-      if (typeof entry === "string") return entry;
-      if (!entry || typeof entry !== "object") return "";
-      const text = (entry as { text?: string }).text;
-      return typeof text === "string" ? text : "";
-    })
-    .filter(Boolean)
-    .join("\n");
-};
-
-const extractAnthropicText = (content: unknown): string => {
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((entry) => {
-      if (!entry || typeof entry !== "object") return "";
-      const typed = entry as { type?: string; text?: string };
-      if (typed.type !== "text") return "";
-      return typeof typed.text === "string" ? typed.text : "";
-    })
-    .filter(Boolean)
-    .join("\n");
-};
-
-const estimateGeminiCost = (
-  model: string,
-  promptTokens: number | undefined,
-  completionTokens: number | undefined,
-): number | undefined => {
-  const pricing = GEMINI_PRICING_PER_MILLION[model];
-  if (!pricing) return undefined;
-
-  const input = Number.isFinite(promptTokens) ? (promptTokens as number) : 0;
-  const output = Number.isFinite(completionTokens) ? (completionTokens as number) : 0;
-
-  const estimated = (input / 1_000_000) * pricing.input + (output / 1_000_000) * pricing.output;
-  return Number.isFinite(estimated) ? Number(estimated.toFixed(6)) : undefined;
-};
-
-const ensureModelAllowed = (provider: string, model: string): Response | null => {
-  const allowlist = PROVIDER_ALLOWLIST[provider];
-  if (!allowlist) {
-    return json(400, {
-      error: `Unsupported provider '${provider}'.`,
-      code: "PROVIDER_NOT_SUPPORTED",
-    });
-  }
-
-  if (!allowlist.has(model)) {
-    return json(400, {
-      error: `Model '${model}' is not enabled for provider '${provider}'.`,
-      code: "MODEL_NOT_ALLOWED",
-    });
-  }
-
-  return null;
-};
-
-const generateWithGemini = async (prompt: string, model: string) => {
-  const apiKey = readEnv("GEMINI_API_KEY") || readEnv("VITE_GEMINI_API_KEY");
-  if (!apiKey) {
-    return json(500, {
-      error: "Gemini API key missing. Configure GEMINI_API_KEY (preferred) or VITE_GEMINI_API_KEY on Netlify.",
-      code: "GEMINI_KEY_MISSING",
-    });
-  }
-
-  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
-
-  const response = await fetch(endpoint, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      contents: [{ role: "user", parts: [{ text: prompt }] }],
-      generationConfig: {
-        responseMimeType: "application/json",
-        temperature: 0.2,
-      },
-    }),
-  });
-
-  if (!response.ok) {
-    const details = await response.text();
-    return json(502, {
-      error: "Gemini generation request failed.",
-      code: "GEMINI_REQUEST_FAILED",
-      details: details.slice(0, 1200),
-    });
-  }
-
-  const payload = await response.json();
-  const rawText = (payload?.candidates?.[0]?.content?.parts || [])
-    .map((part: { text?: string }) => part?.text || "")
-    .join("\n");
-
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = extractJsonObject(rawText);
-  } catch (error) {
-    return json(502, {
-      error: "Gemini response could not be parsed as JSON itinerary payload.",
-      code: "GEMINI_PARSE_FAILED",
-      details: error instanceof Error ? error.message : "Unknown parsing error",
-      sample: rawText.slice(0, 800),
-    });
-  }
-
-  const usageMeta = payload?.usageMetadata || {};
-  const promptTokens = Number(usageMeta.promptTokenCount);
-  const completionTokens = Number(usageMeta.candidatesTokenCount);
-  const totalTokens = Number(usageMeta.totalTokenCount);
-
-  const usage: ProviderUsage = {
-    promptTokens: Number.isFinite(promptTokens) ? promptTokens : undefined,
-    completionTokens: Number.isFinite(completionTokens) ? completionTokens : undefined,
-    totalTokens: Number.isFinite(totalTokens) ? totalTokens : undefined,
-    estimatedCostUsd: estimateGeminiCost(
-      model,
-      Number.isFinite(promptTokens) ? promptTokens : undefined,
-      Number.isFinite(completionTokens) ? completionTokens : undefined,
-    ),
-  };
-
-  return json(200, {
-    data: parsed,
-    meta: {
-      provider: "gemini",
-      model,
-      usage,
-    },
-  });
-};
-
-const generateWithOpenAi = async (prompt: string, model: string) => {
-  const apiKey = readEnv("OPENAI_API_KEY");
-  if (!apiKey) {
-    return json(500, {
-      error: "OpenAI API key missing. Configure OPENAI_API_KEY on Netlify.",
-      code: "OPENAI_KEY_MISSING",
-    });
-  }
-
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model,
-      temperature: 0.2,
-      response_format: { type: "json_object" },
-      messages: [
-        {
-          role: "system",
-          content: "Return only a valid JSON object. Do not include markdown fences.",
-        },
-        {
-          role: "user",
-          content: prompt,
-        },
-      ],
-    }),
-  });
-
-  if (!response.ok) {
-    const details = await response.text();
-    return json(502, {
-      error: "OpenAI generation request failed.",
-      code: "OPENAI_REQUEST_FAILED",
-      details: details.slice(0, 1200),
-    });
-  }
-
-  const payload = await response.json();
-  const rawText = extractOpenAiText(payload?.choices?.[0]?.message?.content);
-
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = extractJsonObject(rawText);
-  } catch (error) {
-    return json(502, {
-      error: "OpenAI response could not be parsed as JSON itinerary payload.",
-      code: "OPENAI_PARSE_FAILED",
-      details: error instanceof Error ? error.message : "Unknown parsing error",
-      sample: rawText.slice(0, 800),
-    });
-  }
-
-  const usageMeta = payload?.usage || {};
-  const promptTokens = Number(usageMeta.prompt_tokens);
-  const completionTokens = Number(usageMeta.completion_tokens);
-  const totalTokens = Number(usageMeta.total_tokens);
-
-  const usage: ProviderUsage = {
-    promptTokens: Number.isFinite(promptTokens) ? promptTokens : undefined,
-    completionTokens: Number.isFinite(completionTokens) ? completionTokens : undefined,
-    totalTokens: Number.isFinite(totalTokens) ? totalTokens : undefined,
-  };
-
-  return json(200, {
-    data: parsed,
-    meta: {
-      provider: "openai",
-      model,
-      usage,
-    },
-  });
-};
-
-const resolveAnthropicModel = (model: string): string => {
-  return ANTHROPIC_MODEL_MAP[model] || model;
-};
-
-const generateWithAnthropic = async (prompt: string, model: string) => {
-  const apiKey = readEnv("ANTHROPIC_API_KEY");
-  if (!apiKey) {
-    return json(500, {
-      error: "Anthropic API key missing. Configure ANTHROPIC_API_KEY on Netlify.",
-      code: "ANTHROPIC_KEY_MISSING",
-    });
-  }
-
-  const providerModel = resolveAnthropicModel(model);
-
-  const response = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: providerModel,
-      max_tokens: 8192,
-      temperature: 0.2,
-      system: "Return only a valid JSON object. Do not include markdown fences.",
-      messages: [
-        {
-          role: "user",
-          content: prompt,
-        },
-      ],
-    }),
-  });
-
-  if (!response.ok) {
-    const details = await response.text();
-    return json(502, {
-      error: "Anthropic generation request failed.",
-      code: "ANTHROPIC_REQUEST_FAILED",
-      model,
-      providerModel,
-      details: details.slice(0, 1200),
-    });
-  }
-
-  const payload = await response.json();
-  const rawText = extractAnthropicText(payload?.content);
-
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = extractJsonObject(rawText);
-  } catch (error) {
-    return json(502, {
-      error: "Anthropic response could not be parsed as JSON itinerary payload.",
-      code: "ANTHROPIC_PARSE_FAILED",
-      details: error instanceof Error ? error.message : "Unknown parsing error",
-      sample: rawText.slice(0, 800),
-    });
-  }
-
-  const usageMeta = payload?.usage || {};
-  const promptTokens = Number(usageMeta.input_tokens);
-  const completionTokens = Number(usageMeta.output_tokens);
-  const totalTokens = Number.isFinite(promptTokens) && Number.isFinite(completionTokens)
-    ? promptTokens + completionTokens
-    : NaN;
-
-  const usage: ProviderUsage = {
-    promptTokens: Number.isFinite(promptTokens) ? promptTokens : undefined,
-    completionTokens: Number.isFinite(completionTokens) ? completionTokens : undefined,
-    totalTokens: Number.isFinite(totalTokens) ? totalTokens : undefined,
-  };
-
-  return json(200, {
-    data: parsed,
-    meta: {
-      provider: "anthropic",
-      model,
-      providerModel,
-      usage,
-    },
-  });
-};
-
-const generateWithOpenRouter = async (prompt: string, model: string) => {
-  const apiKey = readEnv("OPENROUTER_API_KEY");
-  if (!apiKey) {
-    return json(500, {
-      error: "OpenRouter API key missing. Configure OPENROUTER_API_KEY on Netlify.",
-      code: "OPENROUTER_KEY_MISSING",
-    });
-  }
-
-  return json(501, {
-    error: "OpenRouter backend adapter is not enabled yet in this runtime.",
-    code: "OPENROUTER_NOT_ENABLED",
-    model,
-  });
-};
 
 export default async (request: Request) => {
   if (request.method !== "POST") {
@@ -441,20 +52,22 @@ export default async (request: Request) => {
     ? body.target.model.trim()
     : GEMINI_DEFAULT_MODEL;
 
-  const allowlistError = ensureModelAllowed(provider, model);
-  if (allowlistError) return allowlistError;
-
   try {
-    if (provider === "gemini") {
-      return await generateWithGemini(prompt, model);
+    const result = await generateProviderItinerary({
+      prompt,
+      provider,
+      model,
+      timeoutMs: EDGE_REQUEST_PROVIDER_TIMEOUT_MS,
+    });
+
+    if (!result.ok) {
+      return json(result.status, result.value);
     }
-    if (provider === "openai") {
-      return await generateWithOpenAi(prompt, model);
-    }
-    if (provider === "anthropic") {
-      return await generateWithAnthropic(prompt, model);
-    }
-    return await generateWithOpenRouter(prompt, model);
+
+    return json(200, {
+      data: result.value.data,
+      meta: result.value.meta,
+    });
   } catch (error) {
     return json(500, {
       error: "Unexpected server error during AI generation.",

--- a/netlify/edge-lib/ai-provider-runtime.ts
+++ b/netlify/edge-lib/ai-provider-runtime.ts
@@ -1,0 +1,614 @@
+export interface ProviderUsage {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  estimatedCostUsd?: number;
+}
+
+export interface ProviderGenerationMeta {
+  provider: string;
+  model: string;
+  providerModel?: string;
+  usage?: ProviderUsage;
+}
+
+export interface ProviderGenerationSuccess {
+  data: Record<string, unknown>;
+  meta: ProviderGenerationMeta;
+}
+
+export interface ProviderGenerationFailurePayload {
+  error: string;
+  code: string;
+  details?: string;
+  sample?: string;
+  model?: string;
+  providerModel?: string;
+}
+
+export type ProviderGenerationResult =
+  | { ok: true; value: ProviderGenerationSuccess }
+  | { ok: false; status: number; value: ProviderGenerationFailurePayload };
+
+export interface ProviderGenerationOptions {
+  prompt: string;
+  provider: string;
+  model: string;
+  timeoutMs: number;
+}
+
+export const PROVIDER_ALLOWLIST: Record<string, Set<string>> = {
+  gemini: new Set([
+    "gemini-2.5-flash",
+    "gemini-2.5-pro",
+    "gemini-3-flash-preview",
+    "gemini-3-pro-preview",
+  ]),
+  openai: new Set([
+    "gpt-5-mini",
+    "gpt-5.2",
+  ]),
+  anthropic: new Set([
+    "claude-sonnet-4.5",
+    "claude-opus-4.6",
+  ]),
+  openrouter: new Set(),
+};
+
+export const GEMINI_DEFAULT_MODEL = "gemini-3-pro-preview";
+
+const ANTHROPIC_MODEL_MAP: Record<string, string> = {
+  "claude-sonnet-4.5": "claude-sonnet-4-0",
+  "claude-opus-4.6": "claude-opus-4-0",
+  "claude-sonnet-4-0": "claude-sonnet-4-0",
+  "claude-opus-4-0": "claude-opus-4-0",
+};
+
+const GEMINI_PRICING_PER_MILLION: Record<string, { input: number; output: number }> = {
+  "gemini-2.5-flash": { input: 0.35, output: 1.05 },
+  "gemini-2.5-pro": { input: 3.5, output: 10.5 },
+  "gemini-3-flash-preview": { input: 0.35, output: 1.05 },
+  "gemini-3-pro-preview": { input: 3.5, output: 10.5 },
+};
+
+export const readEnv = (name: string): string => {
+  try {
+    return (globalThis as { Deno?: { env?: { get: (key: string) => string | undefined } } }).Deno?.env?.get(name) || "";
+  } catch {
+    return "";
+  }
+};
+
+export const resolveTimeoutMs = (
+  envKey: string,
+  fallbackMs: number,
+  minMs = 1_000,
+  maxMs = 180_000,
+): number => {
+  const raw = Number(readEnv(envKey));
+  if (!Number.isFinite(raw)) return fallbackMs;
+  return Math.max(minMs, Math.min(maxMs, Math.round(raw)));
+};
+
+const clipText = (value: string, max = 1_200): string => {
+  return value.length > max ? value.slice(0, max) : value;
+};
+
+const fetchWithTimeout = async (
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> => {
+  const timeout = Math.max(1_000, Math.round(timeoutMs));
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error(`Provider request timed out after ${timeout}ms.`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+const extractJsonObject = (raw: string): Record<string, unknown> => {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("Provider returned empty content.");
+  }
+
+  const fenceMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const withoutFence = fenceMatch ? fenceMatch[1] : trimmed;
+
+  try {
+    const parsed = JSON.parse(withoutFence);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Response JSON was not an object.");
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    const firstBrace = withoutFence.indexOf("{");
+    const lastBrace = withoutFence.lastIndexOf("}");
+    if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+      throw new Error("Provider response did not contain valid JSON object boundaries.");
+    }
+
+    const candidate = withoutFence.slice(firstBrace, lastBrace + 1);
+    const reparsed = JSON.parse(candidate);
+    if (!reparsed || typeof reparsed !== "object" || Array.isArray(reparsed)) {
+      throw new Error("Response JSON candidate was not an object.");
+    }
+    return reparsed as Record<string, unknown>;
+  }
+};
+
+const extractOpenAiText = (content: unknown): string => {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  return content
+    .map((entry) => {
+      if (typeof entry === "string") return entry;
+      if (!entry || typeof entry !== "object") return "";
+      const text = (entry as { text?: string }).text;
+      return typeof text === "string" ? text : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+};
+
+const extractAnthropicText = (content: unknown): string => {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return "";
+      const typed = entry as { type?: string; text?: string };
+      if (typed.type !== "text") return "";
+      return typeof typed.text === "string" ? typed.text : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+};
+
+const estimateGeminiCost = (
+  model: string,
+  promptTokens: number | undefined,
+  completionTokens: number | undefined,
+): number | undefined => {
+  const pricing = GEMINI_PRICING_PER_MILLION[model];
+  if (!pricing) return undefined;
+
+  const input = Number.isFinite(promptTokens) ? (promptTokens as number) : 0;
+  const output = Number.isFinite(completionTokens) ? (completionTokens as number) : 0;
+
+  const estimated = (input / 1_000_000) * pricing.input + (output / 1_000_000) * pricing.output;
+  return Number.isFinite(estimated) ? Number(estimated.toFixed(6)) : undefined;
+};
+
+const resolveAnthropicModel = (model: string): string => {
+  return ANTHROPIC_MODEL_MAP[model] || model;
+};
+
+export const ensureModelAllowed = (
+  provider: string,
+  model: string,
+): ProviderGenerationFailurePayload | null => {
+  const allowlist = PROVIDER_ALLOWLIST[provider];
+  if (!allowlist) {
+    return {
+      error: `Unsupported provider '${provider}'.`,
+      code: "PROVIDER_NOT_SUPPORTED",
+    };
+  }
+
+  if (!allowlist.has(model)) {
+    return {
+      error: `Model '${model}' is not enabled for provider '${provider}'.`,
+      code: "MODEL_NOT_ALLOWED",
+    };
+  }
+
+  return null;
+};
+
+const generateWithGemini = async (
+  prompt: string,
+  model: string,
+  timeoutMs: number,
+): Promise<ProviderGenerationResult> => {
+  const apiKey = readEnv("GEMINI_API_KEY") || readEnv("VITE_GEMINI_API_KEY");
+  if (!apiKey) {
+    return {
+      ok: false,
+      status: 500,
+      value: {
+        error: "Gemini API key missing. Configure GEMINI_API_KEY (preferred) or VITE_GEMINI_API_KEY on Netlify.",
+        code: "GEMINI_KEY_MISSING",
+      },
+    };
+  }
+
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(
+      endpoint,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          contents: [{ role: "user", parts: [{ text: prompt }] }],
+          generationConfig: {
+            responseMimeType: "application/json",
+            temperature: 0.2,
+          },
+        }),
+      },
+      timeoutMs,
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      status: 504,
+      value: {
+        error: "Gemini generation request timed out.",
+        code: "GEMINI_REQUEST_TIMEOUT",
+        details: error instanceof Error ? error.message : "Unknown timeout error",
+      },
+    };
+  }
+
+  if (!response.ok) {
+    const details = await response.text();
+    return {
+      ok: false,
+      status: 502,
+      value: {
+        error: "Gemini generation request failed.",
+        code: "GEMINI_REQUEST_FAILED",
+        details: clipText(details),
+      },
+    };
+  }
+
+  const payload = await response.json();
+  const rawText = (payload?.candidates?.[0]?.content?.parts || [])
+    .map((part: { text?: string }) => part?.text || "")
+    .join("\n");
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = extractJsonObject(rawText);
+  } catch (error) {
+    return {
+      ok: false,
+      status: 502,
+      value: {
+        error: "Gemini response could not be parsed as JSON itinerary payload.",
+        code: "GEMINI_PARSE_FAILED",
+        details: error instanceof Error ? error.message : "Unknown parsing error",
+        sample: rawText.slice(0, 800),
+      },
+    };
+  }
+
+  const usageMeta = payload?.usageMetadata || {};
+  const promptTokens = Number(usageMeta.promptTokenCount);
+  const completionTokens = Number(usageMeta.candidatesTokenCount);
+  const totalTokens = Number(usageMeta.totalTokenCount);
+
+  const usage: ProviderUsage = {
+    promptTokens: Number.isFinite(promptTokens) ? promptTokens : undefined,
+    completionTokens: Number.isFinite(completionTokens) ? completionTokens : undefined,
+    totalTokens: Number.isFinite(totalTokens) ? totalTokens : undefined,
+    estimatedCostUsd: estimateGeminiCost(
+      model,
+      Number.isFinite(promptTokens) ? promptTokens : undefined,
+      Number.isFinite(completionTokens) ? completionTokens : undefined,
+    ),
+  };
+
+  return {
+    ok: true,
+    value: {
+      data: parsed,
+      meta: {
+        provider: "gemini",
+        model,
+        usage,
+      },
+    },
+  };
+};
+
+const generateWithOpenAi = async (
+  prompt: string,
+  model: string,
+  timeoutMs: number,
+): Promise<ProviderGenerationResult> => {
+  const apiKey = readEnv("OPENAI_API_KEY");
+  if (!apiKey) {
+    return {
+      ok: false,
+      status: 500,
+      value: {
+        error: "OpenAI API key missing. Configure OPENAI_API_KEY on Netlify.",
+        code: "OPENAI_KEY_MISSING",
+      },
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(
+      "https://api.openai.com/v1/chat/completions",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          temperature: 0.2,
+          response_format: { type: "json_object" },
+          messages: [
+            {
+              role: "system",
+              content: "Return only a valid JSON object. Do not include markdown fences.",
+            },
+            {
+              role: "user",
+              content: prompt,
+            },
+          ],
+        }),
+      },
+      timeoutMs,
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      status: 504,
+      value: {
+        error: "OpenAI generation request timed out.",
+        code: "OPENAI_REQUEST_TIMEOUT",
+        details: error instanceof Error ? error.message : "Unknown timeout error",
+      },
+    };
+  }
+
+  if (!response.ok) {
+    const details = await response.text();
+    return {
+      ok: false,
+      status: 502,
+      value: {
+        error: "OpenAI generation request failed.",
+        code: "OPENAI_REQUEST_FAILED",
+        details: clipText(details),
+      },
+    };
+  }
+
+  const payload = await response.json();
+  const rawText = extractOpenAiText(payload?.choices?.[0]?.message?.content);
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = extractJsonObject(rawText);
+  } catch (error) {
+    return {
+      ok: false,
+      status: 502,
+      value: {
+        error: "OpenAI response could not be parsed as JSON itinerary payload.",
+        code: "OPENAI_PARSE_FAILED",
+        details: error instanceof Error ? error.message : "Unknown parsing error",
+        sample: rawText.slice(0, 800),
+      },
+    };
+  }
+
+  const usageMeta = payload?.usage || {};
+  const promptTokens = Number(usageMeta.prompt_tokens);
+  const completionTokens = Number(usageMeta.completion_tokens);
+  const totalTokens = Number(usageMeta.total_tokens);
+
+  const usage: ProviderUsage = {
+    promptTokens: Number.isFinite(promptTokens) ? promptTokens : undefined,
+    completionTokens: Number.isFinite(completionTokens) ? completionTokens : undefined,
+    totalTokens: Number.isFinite(totalTokens) ? totalTokens : undefined,
+  };
+
+  return {
+    ok: true,
+    value: {
+      data: parsed,
+      meta: {
+        provider: "openai",
+        model,
+        usage,
+      },
+    },
+  };
+};
+
+const generateWithAnthropic = async (
+  prompt: string,
+  model: string,
+  timeoutMs: number,
+): Promise<ProviderGenerationResult> => {
+  const apiKey = readEnv("ANTHROPIC_API_KEY");
+  if (!apiKey) {
+    return {
+      ok: false,
+      status: 500,
+      value: {
+        error: "Anthropic API key missing. Configure ANTHROPIC_API_KEY on Netlify.",
+        code: "ANTHROPIC_KEY_MISSING",
+      },
+    };
+  }
+
+  const providerModel = resolveAnthropicModel(model);
+
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(
+      "https://api.anthropic.com/v1/messages",
+      {
+        method: "POST",
+        headers: {
+          "x-api-key": apiKey,
+          "anthropic-version": "2023-06-01",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: providerModel,
+          max_tokens: 8192,
+          temperature: 0.2,
+          system: "Return only a valid JSON object. Do not include markdown fences.",
+          messages: [
+            {
+              role: "user",
+              content: prompt,
+            },
+          ],
+        }),
+      },
+      timeoutMs,
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      status: 504,
+      value: {
+        error: "Anthropic generation request timed out.",
+        code: "ANTHROPIC_REQUEST_TIMEOUT",
+        details: error instanceof Error ? error.message : "Unknown timeout error",
+      },
+    };
+  }
+
+  if (!response.ok) {
+    const details = await response.text();
+    return {
+      ok: false,
+      status: 502,
+      value: {
+        error: "Anthropic generation request failed.",
+        code: "ANTHROPIC_REQUEST_FAILED",
+        model,
+        providerModel,
+        details: clipText(details),
+      },
+    };
+  }
+
+  const payload = await response.json();
+  const rawText = extractAnthropicText(payload?.content);
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = extractJsonObject(rawText);
+  } catch (error) {
+    return {
+      ok: false,
+      status: 502,
+      value: {
+        error: "Anthropic response could not be parsed as JSON itinerary payload.",
+        code: "ANTHROPIC_PARSE_FAILED",
+        details: error instanceof Error ? error.message : "Unknown parsing error",
+        sample: rawText.slice(0, 800),
+      },
+    };
+  }
+
+  const usageMeta = payload?.usage || {};
+  const promptTokens = Number(usageMeta.input_tokens);
+  const completionTokens = Number(usageMeta.output_tokens);
+  const totalTokens = Number.isFinite(promptTokens) && Number.isFinite(completionTokens)
+    ? promptTokens + completionTokens
+    : NaN;
+
+  const usage: ProviderUsage = {
+    promptTokens: Number.isFinite(promptTokens) ? promptTokens : undefined,
+    completionTokens: Number.isFinite(completionTokens) ? completionTokens : undefined,
+    totalTokens: Number.isFinite(totalTokens) ? totalTokens : undefined,
+  };
+
+  return {
+    ok: true,
+    value: {
+      data: parsed,
+      meta: {
+        provider: "anthropic",
+        model,
+        providerModel,
+        usage,
+      },
+    },
+  };
+};
+
+const generateWithOpenRouter = async (model: string): Promise<ProviderGenerationResult> => {
+  const apiKey = readEnv("OPENROUTER_API_KEY");
+  if (!apiKey) {
+    return {
+      ok: false,
+      status: 500,
+      value: {
+        error: "OpenRouter API key missing. Configure OPENROUTER_API_KEY on Netlify.",
+        code: "OPENROUTER_KEY_MISSING",
+      },
+    };
+  }
+
+  return {
+    ok: false,
+    status: 501,
+    value: {
+      error: "OpenRouter backend adapter is not enabled yet in this runtime.",
+      code: "OPENROUTER_NOT_ENABLED",
+      model,
+    },
+  };
+};
+
+export const generateProviderItinerary = async (
+  options: ProviderGenerationOptions,
+): Promise<ProviderGenerationResult> => {
+  const provider = options.provider.trim().toLowerCase();
+  const model = options.model.trim();
+
+  const allowlistError = ensureModelAllowed(provider, model);
+  if (allowlistError) {
+    return {
+      ok: false,
+      status: 400,
+      value: allowlistError,
+    };
+  }
+
+  if (provider === "gemini") {
+    return await generateWithGemini(options.prompt, model, options.timeoutMs);
+  }
+  if (provider === "openai") {
+    return await generateWithOpenAi(options.prompt, model, options.timeoutMs);
+  }
+  if (provider === "anthropic") {
+    return await generateWithAnthropic(options.prompt, model, options.timeoutMs);
+  }
+  return await generateWithOpenRouter(model);
+};


### PR DESCRIPTION
## Summary
- move benchmark run execution off nested `/api/ai/generate` edge calls to direct provider runtime calls inside benchmark workers
- add shared edge provider runtime module used by both benchmark and `/api/ai/generate`
- set benchmark provider timeout budget to 90s by default (`AI_BENCHMARK_PROVIDER_TIMEOUT_MS`)
- keep `/api/ai/generate` timeout budget separate (`AI_GENERATE_PROVIDER_TIMEOUT_MS`, default 35s) to avoid generic platform edge timeouts
- document new timeout controls and runtime behavior in README + architecture + update note

## Validation
- npm run build
