### PR TITLE
fix: harden benchmark timeout floor to 90 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ OPENROUTER_API_KEY=your_openrouter_api_key_here
 # /api/ai/generate default: 35000 (kept below typical edge response timeout window)
 AI_GENERATE_PROVIDER_TIMEOUT_MS=35000
 # /api/internal/ai/benchmark worker default: 90000
+# Values below 90000 are ignored (benchmark keeps a hard 90s minimum).
 AI_BENCHMARK_PROVIDER_TIMEOUT_MS=90000
 # Temporary internal API guard (admin benchmark endpoints)
 TF_ADMIN_API_KEY=replace_with_a_long_random_secret

--- a/content/updates/2026-02-11-ai-backend-target-architecture.md
+++ b/content/updates/2026-02-11-ai-backend-target-architecture.md
@@ -55,3 +55,4 @@ summary: "Implemented the first operational benchmark stack with persisted sessi
 - [ ] [Internal] 📡 Kept benchmark polling/live-latency updates active after reloading an in-progress session so running rows continue updating until completion or manual abort.
 - [ ] [Internal] ⏳ Switched benchmark execution off nested `/api/ai/generate` calls to direct provider runtime execution with a dedicated benchmark timeout budget (`AI_BENCHMARK_PROVIDER_TIMEOUT_MS`, default 90s) to reduce edge timeout failures.
 - [ ] [Internal] 🧰 Added provider timeout environment controls for runtime and benchmark paths (`AI_GENERATE_PROVIDER_TIMEOUT_MS`, `AI_BENCHMARK_PROVIDER_TIMEOUT_MS`) and documented expected defaults.
+- [ ] [Internal] 🛡️ Enforced a hard 90s minimum benchmark provider timeout so low env overrides (for example `10000`) can no longer force premature benchmark request aborts.

--- a/docs/AI_BACKEND_TARGET_ARCHITECTURE.md
+++ b/docs/AI_BACKEND_TARGET_ARCHITECTURE.md
@@ -252,7 +252,7 @@ Response includes:
 
 Execution notes:
 1. Benchmark run workers call providers directly via shared edge runtime helpers (instead of nested `/api/ai/generate` calls).
-2. Provider timeout budget is configurable with `AI_BENCHMARK_PROVIDER_TIMEOUT_MS` (default `90000`).
+2. Provider timeout budget is configurable with `AI_BENCHMARK_PROVIDER_TIMEOUT_MS` (default `90000`, hard minimum `90000` for benchmark workers).
 3. `/api/ai/generate` uses a separate timeout (`AI_GENERATE_PROVIDER_TIMEOUT_MS`, default `35000`) to stay inside synchronous edge response limits.
 
 ## 8.3 Benchmark read endpoint

--- a/netlify/edge-functions/ai-benchmark.ts
+++ b/netlify/edge-functions/ai-benchmark.ts
@@ -96,7 +96,10 @@ const AUTH_HEADER = "authorization";
 const MAX_RUN_COUNT = 3;
 const MAX_CONCURRENCY = 4;
 const CANCELLED_BY_USER_MESSAGE = "Cancelled by user.";
-const BENCHMARK_PROVIDER_TIMEOUT_MS = resolveTimeoutMs("AI_BENCHMARK_PROVIDER_TIMEOUT_MS", 90_000, 10_000, 180_000);
+const BENCHMARK_PROVIDER_TIMEOUT_MS = Math.max(
+  90_000,
+  resolveTimeoutMs("AI_BENCHMARK_PROVIDER_TIMEOUT_MS", 90_000, 10_000, 180_000),
+);
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SATISFACTION_RATINGS = new Set(["good", "medium", "bad"]);
 const ALLOWED_MODEL_TRANSPORT_MODE_SET = new Set<string>(MODEL_TRANSPORT_MODE_VALUES);


### PR DESCRIPTION
## Summary
- enforce a hard 90s minimum benchmark provider timeout in `ai-benchmark` workers
- prevent low env overrides (for example `AI_BENCHMARK_PROVIDER_TIMEOUT_MS=10000`) from causing premature benchmark aborts
- document timeout-floor behavior in README + architecture doc + release note

## Validation
- npm run build
