### PR TITLE
fix: relax country info benchmark blocking and harden exchange-rate UX

### DIFF
--- a/content/updates/2026-02-11-ai-backend-target-architecture.md
+++ b/content/updates/2026-02-11-ai-backend-target-architecture.md
@@ -59,3 +59,4 @@ summary: "Implemented the first operational benchmark stack with persisted sessi
 - [ ] [Internal] 🧭 Improved `/admin/ai-benchmark` execution UX by auto-scrolling to results on `Test all`, removing redundant “Left panel” labeling, and tightening the internal auth card layout on small screens.
 - [ ] [Internal] 🚦 Increased benchmark parallel execution cap to 5 workers (with automatic queueing for additional selected models) and surfaced this directly in the model-selection UI.
 - [ ] [Internal] 💵 Added benchmark cost-display fallback to model-catalog estimates when exact provider `cost_usd` is unavailable, plus clarifying copy in the results section.
+- [ ] [Internal] 🧪 Downgraded `countryInfo` benchmark validation failures to non-blocking warnings, tightened AI prompt/schema guidance to require numeric `exchangeRate`, and hardened destination info UI to disable currency conversion when malformed exchange data is returned.

--- a/netlify/edge-functions/ai-benchmark.ts
+++ b/netlify/edge-functions/ai-benchmark.ts
@@ -419,7 +419,7 @@ const validateModelData = (data: Record<string, unknown>): ValidationResult => {
   const activities = Array.isArray(data.activities) ? data.activities : [];
   const travelSegments = Array.isArray(data.travelSegments) ? data.travelSegments : [];
 
-  const requiredTopLevelKeys = ["tripTitle", "countryInfo", "cities", "travelSegments", "activities"];
+  const requiredTopLevelKeys = ["tripTitle", "cities", "travelSegments", "activities"];
   const topLevelContractValid = requiredTopLevelKeys.every((key) => hasOwn(data, key));
   if (!topLevelContractValid) {
     errors.push("Top-level contract missing one or more required keys");
@@ -481,6 +481,7 @@ const validateModelData = (data: Record<string, unknown>): ValidationResult => {
   }
 
   const countryInfo = isRecord(data.countryInfo) ? data.countryInfo : null;
+  const countryInfoPresent = !!countryInfo;
   const countryInfoValid = !!countryInfo && (
     (hasText(countryInfo.currency) || (hasText(countryInfo.currencyCode) && hasText(countryInfo.currencyName))) &&
     (Number.isFinite(Number(countryInfo.exchangeRate)) || Number.isFinite(Number(countryInfo.exchangeRateToEUR))) &&
@@ -490,8 +491,10 @@ const validateModelData = (data: Record<string, unknown>): ValidationResult => {
     (hasText(countryInfo.visaInfoUrl) || hasText(countryInfo.visaLink)) &&
     (hasText(countryInfo.auswaertigesAmtUrl) || hasText(countryInfo.auswaertigesAmtLink))
   );
-  if (!countryInfoValid) {
-    errors.push("countryInfo is missing required fields or has invalid formatting");
+  if (!countryInfoPresent) {
+    warnings.push("countryInfo is missing (non-blocking)");
+  } else if (!countryInfoValid) {
+    warnings.push("countryInfo is missing required fields or has invalid formatting (non-blocking)");
   }
 
   const markdownSectionsValid = cities.every((city) => {
@@ -626,6 +629,7 @@ const validateModelData = (data: Record<string, unknown>): ValidationResult => {
     cityCountValid,
     requiredFieldsValid,
     cityCoordinatesValid,
+    countryInfoPresent,
     countryInfoValid,
     activityTypesValid,
     activityTypesCanonicalValid,
@@ -647,7 +651,6 @@ const validateModelData = (data: Record<string, unknown>): ValidationResult => {
     cityCountValid,
     requiredFieldsValid,
     cityCoordinatesValid,
-    countryInfoValid,
     activityTypesValid,
     activityDurationFormatValid,
     cityIndexValid,

--- a/services/aiService.ts
+++ b/services/aiService.ts
@@ -42,7 +42,7 @@ const itinerarySchema = {
         properties: {
             currencyCode: { type: Type.STRING, description: "ISO code, e.g. JPY" },
             currencyName: { type: Type.STRING, description: "e.g. Japanese Yen" },
-            exchangeRate: { type: Type.NUMBER, description: "Approximate exchange rate: 1 EUR = X local currency" },
+            exchangeRate: { type: Type.NUMBER, description: "Number only: local currency units for exactly 1 EUR (example: 163)" },
             languages: { type: Type.ARRAY, items: { type: Type.STRING } },
             electricSockets: { type: Type.STRING, description: "Short description of socket types, e.g. 'Type A, Type B'" },
             visaInfoUrl: { type: Type.STRING, description: "Generic URL to visa policy on Wikipedia or official gov site" },
@@ -223,6 +223,10 @@ const BASE_ITINERARY_RULES_PROMPT = `
          ### Must Do (3-4 activities)
          Use - [ ] for all items to make them checkboxes.
       4. Provide Country Info (Currency, Exchange Rate to EUR, Languages, Sockets, Visa Link, Auswärtiges Amt Link).
+         - countryInfo.exchangeRate MUST be a NUMBER only (local currency units for 1 EUR).
+         - Valid example: "exchangeRate": 163
+         - Invalid example: "exchangeRateToEUR": "1 EUR ≈ 160 JPY"
+         - Do NOT include text, units, symbols, or approximation words in exchangeRate.
       5. For EVERY activity, you MUST return "activityTypes" as an array with 1-3 values ONLY from this list:
          [${ACTIVITY_TYPES_PROMPT_LIST}]
          Do not return unknown activity types and do not leave activityTypes empty.
@@ -266,6 +270,7 @@ const STRICT_JSON_OBJECT_CONTRACT_PROMPT = `
          [${TRANSPORT_MODES_PROMPT_LIST}]
       8. travelSegments.duration must be NUMBER (hours), never a string with units.
       9. activities.duration must be NUMBER (days), never a string with units.
+      10. countryInfo.exchangeRate must be NUMBER only (example valid: 163; invalid: "1 EUR ≈ 160 JPY").
     `;
 
 const buildIslandConstraintPrompt = (


### PR DESCRIPTION
## Summary
- make `countryInfo` validation non-blocking in benchmark runs (warning-only)
- keep benchmark validation diagnostics visible via warnings/checks
- tighten AI prompt/schema guidance for numeric-only `countryInfo.exchangeRate` with explicit valid/invalid examples
- harden `CountryInfo` rendering for mixed/legacy payloads and disable currency converter controls when exchange rate is missing or malformed

## Validation
- npm run build
