### PR TITLE
Fix mobile endless carousel behavior and release versioning

### DIFF
--- a/components/GoogleMapsLoader.tsx
+++ b/components/GoogleMapsLoader.tsx
@@ -22,8 +22,16 @@ export const GoogleMapsLoader: React.FC<GoogleMapsLoaderProps> = ({ children, la
     const requestedLanguage = normalizeAppLanguage(language ?? getStoredAppLanguage());
 
     useEffect(() => {
-        if (window.google?.maps) {
+        const isGoogleMapsReady = () => Boolean(window.google?.maps?.Map && typeof window.google.maps.Map === 'function');
+        const settleLoaded = () => {
             setIsLoaded(true);
+            setLoadError(null);
+        };
+        let readyCheckLoop: number | null = null;
+        let readyCheckTimeout: number | null = null;
+
+        if (isGoogleMapsReady()) {
+            settleLoaded();
             return;
         }
 
@@ -36,14 +44,16 @@ export const GoogleMapsLoader: React.FC<GoogleMapsLoaderProps> = ({ children, la
         const scriptId = 'google-maps-script';
         const existingScript = document.getElementById(scriptId);
         if (existingScript) {
-             // Script already exists, wait for it
-             const checkLoop = setInterval(() => {
-                 if (window.google?.maps) {
-                     clearInterval(checkLoop);
-                     setIsLoaded(true);
-                 }
-             }, 100);
-             return;
+            // Script already exists; poll until constructors are ready.
+            const checkLoop = window.setInterval(() => {
+                if (isGoogleMapsReady()) {
+                    window.clearInterval(checkLoop);
+                    settleLoaded();
+                }
+            }, 50);
+            return () => {
+                window.clearInterval(checkLoop);
+            };
         }
 
         const script = document.createElement('script');
@@ -53,13 +63,51 @@ export const GoogleMapsLoader: React.FC<GoogleMapsLoaderProps> = ({ children, la
         script.async = true;
         script.defer = true;
         
-        script.onload = () => setIsLoaded(true);
-        script.onerror = (e) => setLoadError(new Error("Failed to load Google Maps script"));
+        script.onload = () => {
+            if (isGoogleMapsReady()) {
+                settleLoaded();
+                return;
+            }
+
+            // Some environments expose `google.maps` before constructors are fully ready.
+            readyCheckLoop = window.setInterval(() => {
+                if (isGoogleMapsReady()) {
+                    if (readyCheckLoop !== null) {
+                        window.clearInterval(readyCheckLoop);
+                        readyCheckLoop = null;
+                    }
+                    if (readyCheckTimeout !== null) {
+                        window.clearTimeout(readyCheckTimeout);
+                        readyCheckTimeout = null;
+                    }
+                    settleLoaded();
+                }
+            }, 50);
+
+            readyCheckTimeout = window.setTimeout(() => {
+                if (readyCheckLoop !== null) {
+                    window.clearInterval(readyCheckLoop);
+                    readyCheckLoop = null;
+                }
+                readyCheckTimeout = null;
+                if (!isGoogleMapsReady()) {
+                    setLoadError(new Error('Google Maps constructors did not initialize in time'));
+                }
+            }, 10000);
+        };
+        script.onerror = () => setLoadError(new Error("Failed to load Google Maps script"));
 
         document.head.appendChild(script);
 
         return () => {
-            // Optional cleanup if needed
+            if (readyCheckLoop !== null) {
+                window.clearInterval(readyCheckLoop);
+                readyCheckLoop = null;
+            }
+            if (readyCheckTimeout !== null) {
+                window.clearTimeout(readyCheckTimeout);
+                readyCheckTimeout = null;
+            }
         };
     }, [requestedLanguage]);
 

--- a/components/ItineraryMap.tsx
+++ b/components/ItineraryMap.tsx
@@ -265,7 +265,7 @@ export const ItineraryMap: React.FC<ItineraryMapProps> = ({
 
     // Initial Map Setup
     useEffect(() => {
-        if (!isLoaded || !mapRef.current || googleMapRef.current) return;
+        if (!isLoaded || !mapRef.current || googleMapRef.current || !window.google?.maps?.Map) return;
 
         try {
             googleMapRef.current = new window.google.maps.Map(mapRef.current, {

--- a/components/ProgressiveImage.tsx
+++ b/components/ProgressiveImage.tsx
@@ -58,6 +58,7 @@ export interface ProgressiveImageProps {
     className?: string;
     placeholderBlurhash?: string;
     onError?: () => void;
+    disableCdn?: boolean;
 }
 
 export const ProgressiveImage: React.FC<ProgressiveImageProps> = ({
@@ -73,6 +74,7 @@ export const ProgressiveImage: React.FC<ProgressiveImageProps> = ({
     className,
     placeholderBlurhash,
     onError,
+    disableCdn = false,
 }) => {
     const [isLoaded, setIsLoaded] = useState(false);
     const [hasError, setHasError] = useState(false);
@@ -92,20 +94,20 @@ export const ProgressiveImage: React.FC<ProgressiveImageProps> = ({
     }, [blurhashValue, placeholderMeta?.height, placeholderMeta?.width, width, height]);
 
     const avifSrcSet = useMemo(
-        () => (isImageCdnEnabled() ? buildImageSrcSet(src, srcSetWidths, { format: 'avif', quality: 52 }) : ''),
-        [src, srcSetWidths]
+        () => (isImageCdnEnabled() && !disableCdn ? buildImageSrcSet(src, srcSetWidths, { format: 'avif', quality: 52 }) : ''),
+        [disableCdn, src, srcSetWidths]
     );
     const webpSrcSet = useMemo(
-        () => (isImageCdnEnabled() ? buildImageSrcSet(src, srcSetWidths, { format: 'webp', quality: 60 }) : ''),
-        [src, srcSetWidths]
+        () => (isImageCdnEnabled() && !disableCdn ? buildImageSrcSet(src, srcSetWidths, { format: 'webp', quality: 60 }) : ''),
+        [disableCdn, src, srcSetWidths]
     );
     const imgSrcSet = useMemo(
-        () => buildImageSrcSet(src, srcSetWidths, { quality: 66 }),
-        [src, srcSetWidths]
+        () => (disableCdn ? '' : buildImageSrcSet(src, srcSetWidths, { quality: 66 })),
+        [disableCdn, src, srcSetWidths]
     );
 
     const fallbackWidth = srcSetWidths[srcSetWidths.length - 1] || width;
-    const resolvedSrc = buildImageCdnUrl(src, { width: fallbackWidth, quality: 66 });
+    const resolvedSrc = disableCdn ? src : buildImageCdnUrl(src, { width: fallbackWidth, quality: 66 });
     const fetchPriorityAttr = fetchPriority
         ? ({ fetchpriority: fetchPriority } as { fetchpriority: 'high' | 'low' | 'auto' })
         : undefined;

--- a/components/marketing/ExampleTripCard.tsx
+++ b/components/marketing/ExampleTripCard.tsx
@@ -122,6 +122,7 @@ export const ExampleTripCard: React.FC<ExampleTripCardProps> = ({
                         className="h-full w-full object-cover"
                         loading="lazy"
                         fetchPriority="low"
+                        disableCdn={Boolean(card.mapImagePath && mapImageSrc?.includes(card.mapImagePath))}
                         onError={handleMapImageError}
                     />
                 ) : (

--- a/components/marketing/ExampleTripsCarousel.tsx
+++ b/components/marketing/ExampleTripsCarousel.tsx
@@ -1,15 +1,23 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { ArrowRight } from '@phosphor-icons/react';
 import { ITrip, IViewSettings } from '../../types';
 import { exampleTripCards } from '../../data/exampleTripCards';
-import { buildExampleTemplateMapPreviewUrl, getExampleTemplateMiniCalendar, TRIP_FACTORIES } from '../../data/exampleTripTemplates';
+import { getExampleTemplateMiniCalendar, TRIP_FACTORIES } from '../../data/exampleTripTemplates';
 import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analyticsService';
 import { ExampleTripCard } from './ExampleTripCard';
 
-const ROTATIONS = [-2, 1.5, -1, 2, -1.5, 1, -2.5, 1.8];
 const INSPIRATIONS_LINK = '/inspirations';
 const VIEW_TRANSITION_DEBUG_EVENT = 'tf:view-transition-debug';
+const DESKTOP_AUTO_SCROLL_PX_PER_SECOND = 52;
+const DRAG_CLICK_THRESHOLD_PX = 8;
+const MOBILE_QUERY = '(max-width: 767px)';
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+const DESKTOP_RIGHT_SCALE_START = 0.82;
+const DESKTOP_RIGHT_SCALE_MIN = 0.94;
+const MOBILE_CARD_WIDTH_PX = 300;
+const MOBILE_LOOP_NORMALIZE_IDLE_MS = 90;
+const SUPPORTS_SCROLLEND = typeof window !== 'undefined' && 'onscrollend' in window;
 
 interface ViewTransitionDebugDetail {
     phase: string;
@@ -26,10 +34,50 @@ const emitViewTransitionDebug = (detail: ViewTransitionDebugDetail): void => {
     window.dispatchEvent(new CustomEvent<ViewTransitionDebugDetail>(VIEW_TRANSITION_DEBUG_EVENT, { detail }));
 };
 
+const clamp = (value: number, min: number, max: number): number => {
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+};
+
+const normalizeLoopOffset = (offset: number, loopWidth: number): number => {
+    if (loopWidth <= 0) return 0;
+    return ((offset % loopWidth) + loopWidth) % loopWidth;
+};
+
 export const ExampleTripsCarousel: React.FC = () => {
     const navigate = useNavigate();
     const tripViewPrefetchRef = useRef<Promise<unknown> | null>(null);
-    const doubledCards = [...exampleTripCards, ...exampleTripCards];
+    const [isMobileViewport, setIsMobileViewport] = useState(() => (
+        typeof window !== 'undefined' ? window.matchMedia(MOBILE_QUERY).matches : false
+    ));
+
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const trackRef = useRef<HTMLDivElement | null>(null);
+    const motionCardRefs = useRef<Array<HTMLDivElement | null>>([]);
+    const mobileScrollerRef = useRef<HTMLDivElement | null>(null);
+
+    const loopWidthRef = useRef(0);
+    const cardStrideRef = useRef(364);
+    const cardWidthRef = useRef(340);
+    const viewportWidthRef = useRef(0);
+    const offsetRef = useRef(0);
+
+    const isHoveredRef = useRef(false);
+    const isMobileViewportRef = useRef(isMobileViewport);
+    const prefersReducedMotionRef = useRef(false);
+
+    const mobilePointerXRef = useRef<number | null>(null);
+    const mobileDragDistanceRef = useRef(0);
+    const suppressClickUntilRef = useRef(0);
+    const mobileSetWidthRef = useRef(0);
+    const mobileRecenteringRef = useRef(false);
+    const mobileRecenteringRafRef = useRef<number | null>(null);
+    const mobileNormalizeTimeoutRef = useRef<number | null>(null);
+    const mobilePointerActiveRef = useRef(false);
+
+    const doubledCards = useMemo(() => [...exampleTripCards, ...exampleTripCards], []);
+    const mobileLoopCards = useMemo(() => [...exampleTripCards, ...exampleTripCards, ...exampleTripCards], []);
 
     const prewarmTripView = useCallback(() => {
         if (!tripViewPrefetchRef.current) {
@@ -101,8 +149,290 @@ export const ExampleTripsCarousel: React.FC = () => {
             transitionKey,
             targetPath: target,
         });
+
         navigation();
     }, [navigate, prewarmTripView]);
+
+    const applyDesktopTransforms = useCallback(() => {
+        const track = trackRef.current;
+        if (!track || isMobileViewportRef.current) return;
+
+        const loopWidth = loopWidthRef.current;
+        if (loopWidth <= 0) return;
+
+        const normalizedOffset = normalizeLoopOffset(offsetRef.current, loopWidth);
+        offsetRef.current = normalizedOffset;
+        track.style.transform = `translate3d(${-normalizedOffset}px, 0, 0)`;
+
+        const viewportWidth = Math.max(1, viewportWidthRef.current);
+        const cardStride = cardStrideRef.current;
+        const cardWidth = cardWidthRef.current;
+
+        motionCardRefs.current.forEach((cardNode, index) => {
+            if (!cardNode) return;
+
+            const baseX = (index * cardStride) - normalizedOffset;
+            const wrappedX = ((baseX % loopWidth) + loopWidth) % loopWidth;
+            const displayX = wrappedX > viewportWidth + cardStride ? wrappedX - loopWidth : wrappedX;
+            const centerX = displayX + (cardWidth / 2);
+            const progress = clamp(centerX / viewportWidth, 0, 1);
+            const rightRamp = clamp((progress - DESKTOP_RIGHT_SCALE_START) / (1 - DESKTOP_RIGHT_SCALE_START), 0, 1);
+            const scale = 1 - (rightRamp * (1 - DESKTOP_RIGHT_SCALE_MIN));
+
+            cardNode.style.transform = `translate3d(0, 0, 0) scale(${scale.toFixed(3)})`;
+            cardNode.style.zIndex = '1';
+        });
+    }, []);
+
+    const measureDesktopTrack = useCallback(() => {
+        const track = trackRef.current;
+        const container = containerRef.current;
+        if (!track || !container) return;
+
+        const firstCard = motionCardRefs.current[0];
+        const computedStyle = window.getComputedStyle(track);
+        const gapPx = Number.parseFloat(computedStyle.columnGap || computedStyle.gap || '24') || 24;
+
+        if (firstCard) {
+            cardWidthRef.current = firstCard.offsetWidth;
+            cardStrideRef.current = firstCard.offsetWidth + gapPx;
+            loopWidthRef.current = cardStrideRef.current * exampleTripCards.length;
+        } else {
+            loopWidthRef.current = track.scrollWidth / 2;
+        }
+
+        viewportWidthRef.current = container.clientWidth;
+        offsetRef.current = normalizeLoopOffset(offsetRef.current, loopWidthRef.current);
+        applyDesktopTransforms();
+    }, [applyDesktopTransforms]);
+
+    const measureMobileSetWidth = useCallback(() => {
+        const scroller = mobileScrollerRef.current;
+        if (!scroller || !isMobileViewportRef.current) return;
+        const measuredSetWidth = scroller.scrollWidth / 3;
+        if (Number.isFinite(measuredSetWidth) && measuredSetWidth > 0) {
+            mobileSetWidthRef.current = measuredSetWidth;
+        }
+    }, []);
+
+    const normalizeMobileLoopPosition = useCallback((mode: 'initial' | 'preserve' = 'preserve') => {
+        const scroller = mobileScrollerRef.current;
+        if (!scroller || !isMobileViewportRef.current) return;
+        if (mobileRecenteringRef.current) return;
+        if (mode === 'preserve' && mobilePointerActiveRef.current) return;
+
+        measureMobileSetWidth();
+        const setWidth = mobileSetWidthRef.current;
+        if (!Number.isFinite(setWidth) || setWidth <= 0) return;
+
+        const centerOffset = (scroller.clientWidth - MOBILE_CARD_WIDTH_PX) / 2;
+        const centeredPosition = scroller.scrollLeft + centerOffset;
+        let targetScrollLeft = scroller.scrollLeft;
+
+        if (mode === 'initial') {
+            targetScrollLeft = setWidth - centerOffset;
+        } else {
+            const isOutsideCenterSet = centeredPosition < setWidth || centeredPosition >= setWidth * 2;
+            if (!isOutsideCenterSet) return;
+            const centeredRemainder = ((centeredPosition % setWidth) + setWidth) % setWidth;
+            targetScrollLeft = (setWidth + centeredRemainder) - centerOffset;
+        }
+
+        if (Math.abs(targetScrollLeft - scroller.scrollLeft) <= 0.5) return;
+
+        mobileRecenteringRef.current = true;
+        const previousInlineSnapType = scroller.style.scrollSnapType;
+        scroller.style.scrollSnapType = 'none';
+        scroller.scrollLeft = targetScrollLeft;
+        if (mobileRecenteringRafRef.current !== null) {
+            window.cancelAnimationFrame(mobileRecenteringRafRef.current);
+        }
+        mobileRecenteringRafRef.current = window.requestAnimationFrame(() => {
+            scroller.style.scrollSnapType = previousInlineSnapType;
+            mobileRecenteringRef.current = false;
+            mobileRecenteringRafRef.current = null;
+        });
+    }, [measureMobileSetWidth]);
+
+    const scheduleMobileLoopNormalization = useCallback((delayMs = MOBILE_LOOP_NORMALIZE_IDLE_MS) => {
+        if (!isMobileViewportRef.current) return;
+        if (mobileNormalizeTimeoutRef.current !== null) {
+            window.clearTimeout(mobileNormalizeTimeoutRef.current);
+        }
+        mobileNormalizeTimeoutRef.current = window.setTimeout(() => {
+            mobileNormalizeTimeoutRef.current = null;
+            normalizeMobileLoopPosition('preserve');
+        }, delayMs);
+    }, [normalizeMobileLoopPosition]);
+
+    useEffect(() => {
+        isMobileViewportRef.current = isMobileViewport;
+        if (!isMobileViewport) {
+            measureDesktopTrack();
+            return;
+        }
+
+        const scroller = mobileScrollerRef.current;
+        if (!scroller) return;
+
+        const rafId = window.requestAnimationFrame(() => {
+            normalizeMobileLoopPosition('initial');
+            scheduleMobileLoopNormalization(0);
+        });
+
+        return () => {
+            window.cancelAnimationFrame(rafId);
+        };
+    }, [isMobileViewport, measureDesktopTrack, normalizeMobileLoopPosition, scheduleMobileLoopNormalization]);
+
+    useEffect(() => {
+        const mobileMediaQuery = window.matchMedia(MOBILE_QUERY);
+        const handleMediaChange = (event: MediaQueryListEvent) => {
+            setIsMobileViewport(event.matches);
+        };
+
+        setIsMobileViewport(mobileMediaQuery.matches);
+        mobileMediaQuery.addEventListener('change', handleMediaChange);
+        return () => {
+            mobileMediaQuery.removeEventListener('change', handleMediaChange);
+        };
+    }, []);
+
+    useEffect(() => {
+        const reducedMotionQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+        prefersReducedMotionRef.current = reducedMotionQuery.matches;
+
+        const handleReducedMotionChange = (event: MediaQueryListEvent) => {
+            prefersReducedMotionRef.current = event.matches;
+        };
+
+        reducedMotionQuery.addEventListener('change', handleReducedMotionChange);
+        return () => {
+            reducedMotionQuery.removeEventListener('change', handleReducedMotionChange);
+        };
+    }, []);
+
+    useEffect(() => {
+        const scroller = mobileScrollerRef.current;
+        if (!scroller || !isMobileViewport || !SUPPORTS_SCROLLEND) return;
+
+        const handleScrollEnd = () => {
+            normalizeMobileLoopPosition('preserve');
+            scheduleMobileLoopNormalization(0);
+        };
+
+        scroller.addEventListener('scrollend', handleScrollEnd as EventListener);
+        return () => {
+            scroller.removeEventListener('scrollend', handleScrollEnd as EventListener);
+        };
+    }, [isMobileViewport, normalizeMobileLoopPosition, scheduleMobileLoopNormalization]);
+
+    useEffect(() => {
+        measureDesktopTrack();
+        measureMobileSetWidth();
+        normalizeMobileLoopPosition('preserve');
+        scheduleMobileLoopNormalization(0);
+
+        const handleWindowResize = () => {
+            measureDesktopTrack();
+            measureMobileSetWidth();
+            normalizeMobileLoopPosition('preserve');
+            scheduleMobileLoopNormalization(0);
+        };
+
+        const resizeObserver = new ResizeObserver(() => {
+            measureDesktopTrack();
+            measureMobileSetWidth();
+            normalizeMobileLoopPosition('preserve');
+            scheduleMobileLoopNormalization(0);
+        });
+
+        if (containerRef.current) resizeObserver.observe(containerRef.current);
+        if (trackRef.current) resizeObserver.observe(trackRef.current);
+        if (mobileScrollerRef.current) resizeObserver.observe(mobileScrollerRef.current);
+
+        window.addEventListener('resize', handleWindowResize);
+        return () => {
+            resizeObserver.disconnect();
+            window.removeEventListener('resize', handleWindowResize);
+            if (mobileNormalizeTimeoutRef.current !== null) {
+                window.clearTimeout(mobileNormalizeTimeoutRef.current);
+                mobileNormalizeTimeoutRef.current = null;
+            }
+            if (mobileRecenteringRafRef.current !== null) {
+                window.cancelAnimationFrame(mobileRecenteringRafRef.current);
+                mobileRecenteringRafRef.current = null;
+            }
+            mobilePointerActiveRef.current = false;
+            mobileRecenteringRef.current = false;
+        };
+    }, [measureDesktopTrack, measureMobileSetWidth, normalizeMobileLoopPosition, scheduleMobileLoopNormalization]);
+
+    useEffect(() => {
+        let rafId = 0;
+        let lastFrameTime = performance.now();
+
+        const tick = (timeMs: number) => {
+            const deltaSeconds = Math.min(0.05, (timeMs - lastFrameTime) / 1000);
+            lastFrameTime = timeMs;
+
+            if (!isMobileViewportRef.current && loopWidthRef.current > 0) {
+                if (!isHoveredRef.current && !prefersReducedMotionRef.current) {
+                    offsetRef.current += DESKTOP_AUTO_SCROLL_PX_PER_SECOND * deltaSeconds;
+                }
+                offsetRef.current = normalizeLoopOffset(offsetRef.current, loopWidthRef.current);
+                applyDesktopTransforms();
+            }
+
+            rafId = window.requestAnimationFrame(tick);
+        };
+
+        rafId = window.requestAnimationFrame(tick);
+        return () => {
+            window.cancelAnimationFrame(rafId);
+        };
+    }, [applyDesktopTransforms]);
+
+    const handleMobilePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+        if (!isMobileViewportRef.current) return;
+        if (event.button !== 0 || !event.isPrimary) return;
+        mobilePointerActiveRef.current = true;
+        if (mobileNormalizeTimeoutRef.current !== null) {
+            window.clearTimeout(mobileNormalizeTimeoutRef.current);
+            mobileNormalizeTimeoutRef.current = null;
+        }
+        mobilePointerXRef.current = event.clientX;
+        mobileDragDistanceRef.current = 0;
+    }, []);
+
+    const handleMobilePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+        if (mobilePointerXRef.current === null) return;
+        mobileDragDistanceRef.current += Math.abs(event.clientX - mobilePointerXRef.current);
+        mobilePointerXRef.current = event.clientX;
+    }, []);
+
+    const finishMobilePointer = useCallback(() => {
+        if (mobilePointerXRef.current === null) return;
+        if (mobileDragDistanceRef.current > DRAG_CLICK_THRESHOLD_PX) {
+            suppressClickUntilRef.current = performance.now() + 250;
+        }
+        mobilePointerActiveRef.current = false;
+        mobilePointerXRef.current = null;
+        mobileDragDistanceRef.current = 0;
+        if (!SUPPORTS_SCROLLEND) {
+            scheduleMobileLoopNormalization(70);
+        }
+    }, [scheduleMobileLoopNormalization]);
+
+    const handleCardButtonClick = useCallback((event: React.MouseEvent<HTMLButtonElement>, templateId?: string, transitionKey?: string) => {
+        if (performance.now() < suppressClickUntilRef.current) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+        }
+        if (!templateId || !transitionKey) return;
+        handleCardClick(templateId, transitionKey);
+    }, [handleCardClick]);
 
     return (
         <section id="examples" className="py-16 md:py-24 overflow-x-hidden md:overflow-x-visible">
@@ -115,45 +445,103 @@ export const ExampleTripsCarousel: React.FC = () => {
                 </p>
             </div>
 
-            <div className="relative mt-12 -mx-5 md:-mx-8 lg:mx-[calc(-50vw+50%)] overflow-hidden pb-3">
-                <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-16 bg-gradient-to-r from-slate-50 to-transparent md:w-24" />
-                <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-16 bg-gradient-to-l from-slate-50 to-transparent md:w-24" />
+            <div className="relative mt-12 -mx-5 md:-mx-8 lg:mx-[calc(-50vw+50%)] overflow-hidden">
+                <div className="pointer-events-none absolute inset-y-0 left-0 z-20 w-10 bg-gradient-to-r from-slate-50 via-slate-50/85 to-transparent sm:w-14 md:w-24" />
+                <div className="pointer-events-none absolute inset-y-0 right-0 z-20 w-10 bg-gradient-to-l from-slate-50 via-slate-50/85 to-transparent sm:w-14 md:w-24" />
 
-                <div className="group py-6 overflow-x-hidden md:overflow-visible">
-                    <div
-                        className="flex w-max gap-6 animate-marquee group-hover:[animation-play-state:paused]"
-                        style={{ '--marquee-duration': '60s' } as React.CSSProperties}
-                    >
+                <div
+                    ref={containerRef}
+                    className="group relative hidden md:block py-8"
+                    onMouseEnter={() => {
+                        isHoveredRef.current = true;
+                    }}
+                    onMouseLeave={() => {
+                        isHoveredRef.current = false;
+                    }}
+                >
+                    <div ref={trackRef} className="flex w-max gap-6 will-change-transform">
                         {doubledCards.map((card, index) => {
-                            const rotation = ROTATIONS[index % ROTATIONS.length];
-                            const mapPreviewUrl = card.templateId
-                                ? buildExampleTemplateMapPreviewUrl(card.templateId)
-                                : null;
                             const miniCalendar = card.templateId
                                 ? getExampleTemplateMiniCalendar(card.templateId)
                                 : null;
-                            const transitionKey = `${card.templateId || card.id}-${index}`;
+                            const transitionKey = `desktop-${card.templateId || card.id}-${index}`;
 
                             return (
-                                <button
-                                    key={`${card.id}-${index}`}
-                                    type="button"
-                                    onClick={() => card.templateId && handleCardClick(card.templateId, transitionKey)}
-                                    onMouseEnter={prewarmTripView}
-                                    onFocus={prewarmTripView}
-                                    onTouchStart={prewarmTripView}
-                                    className="block w-[300px] md:w-[340px] flex-shrink-0 transform-gpu will-change-transform transition-transform duration-300 hover:!rotate-0 hover:scale-105 text-left cursor-pointer"
-                                    style={{ transform: `rotate(${rotation}deg)` }}
-                                    {...(card.templateId
-                                        ? getAnalyticsDebugAttributes('home__carousel_card', { template: card.templateId })
-                                        : {})}
+                                <div
+                                    key={`desktop-${card.id}-${index}`}
+                                    ref={(node) => {
+                                        motionCardRefs.current[index] = node;
+                                    }}
+                                    className="w-[340px] flex-shrink-0 transform-gpu will-change-transform origin-center"
+                                    style={{ transform: 'translate3d(0, 0, 0) scale(1)' }}
                                 >
-                                    <ExampleTripCard
-                                        card={card}
-                                        mapPreviewUrl={mapPreviewUrl}
-                                        miniCalendar={miniCalendar}
-                                    />
-                                </button>
+                                    <button
+                                        type="button"
+                                        onClick={(event) => handleCardButtonClick(event, card.templateId, transitionKey)}
+                                        onMouseEnter={prewarmTripView}
+                                        onFocus={prewarmTripView}
+                                        onTouchStart={prewarmTripView}
+                                        className="block w-full text-left cursor-pointer transition-transform duration-300 hover:scale-[1.02] active:scale-[0.99]"
+                                        {...(card.templateId
+                                            ? getAnalyticsDebugAttributes('home__carousel_card', { template: card.templateId })
+                                            : {})}
+                                    >
+                                        <ExampleTripCard
+                                            card={card}
+                                            miniCalendar={miniCalendar}
+                                        />
+                                    </button>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                <div
+                    ref={mobileScrollerRef}
+                    className="md:hidden overflow-x-auto snap-x snap-proximity touch-pan-x overscroll-x-none scrollbar-hide"
+                    onScroll={() => {
+                        if (mobileRecenteringRef.current) return;
+                        if (!SUPPORTS_SCROLLEND) {
+                            scheduleMobileLoopNormalization();
+                        }
+                    }}
+                    onPointerDown={handleMobilePointerDown}
+                    onPointerMove={handleMobilePointerMove}
+                    onPointerUp={finishMobilePointer}
+                    onPointerCancel={finishMobilePointer}
+                    style={{
+                        scrollPaddingInline: `calc((100% - ${MOBILE_CARD_WIDTH_PX}px) / 2)`,
+                    }}
+                >
+                    <div className="flex items-start gap-5 py-4">
+                        {mobileLoopCards.map((card, index) => {
+                            const miniCalendar = card.templateId
+                                ? getExampleTemplateMiniCalendar(card.templateId)
+                                : null;
+                            const transitionKey = `mobile-${card.templateId || card.id}-${index}`;
+
+                            return (
+                                <div
+                                    key={`mobile-${card.id}-${index}`}
+                                    className="w-[300px] flex-shrink-0 snap-center [scroll-snap-stop:always]"
+                                >
+                                    <button
+                                        type="button"
+                                        onClick={(event) => handleCardButtonClick(event, card.templateId, transitionKey)}
+                                        onTouchStart={prewarmTripView}
+                                        onFocus={prewarmTripView}
+                                        className="block w-full text-left cursor-pointer transition-transform duration-300 active:scale-[0.99]"
+                                        {...(card.templateId
+                                            ? getAnalyticsDebugAttributes('home__carousel_card', { template: card.templateId })
+                                            : {})}
+                                    >
+                                        <ExampleTripCard
+                                            card={card}
+                                            miniCalendar={miniCalendar}
+                                        />
+                                    </button>
+                                </div>
                             );
                         })}
                     </div>

--- a/content/updates/2026-02-11-page-speed-continuous-optimization.md
+++ b/content/updates/2026-02-11-page-speed-continuous-optimization.md
@@ -1,39 +1,44 @@
 ---
 id: rel-2026-02-11-page-speed-continuous-optimization
-version: v0.56.0
+version: v0.47.0
 title: "Page speed baseline and continuous optimization"
 date: 2026-02-12
-published_at: 2026-02-12T07:59:30Z
+published_at: 2026-02-12T14:34:52Z
 status: published
 notify_in_app: true
 in_app_hours: 24
-summary: "Added hybrid BlurHash + Netlify Image CDN delivery, hardened map preview reliability, and reduced first-navigation route stalls via route-module preloading."
+summary: "Homepage and content pages now load and transition faster, with smoother media previews and a more interactive example-trip carousel."
 ---
 
 ## Changes
-- [x] [Improved] 🖼️ Added progressive BlurHash placeholders with production Netlify Image CDN delivery (AVIF/WebP + responsive widths) for blog cards/headers, inspirations cards, and homepage example trip cards.
-- [x] [Improved] 🗺️ Reduced example trip map over-download by lowering default preview source dimensions/scale and serving responsive map card `srcset` variants.
-- [x] [Improved] ⚡ Home route no longer eagerly loads Supabase-heavy DB code; trip/session DB modules now lazy-load only when trip flows actually need them.
-- [x] [Improved] 🧠 Added immutable cache headers for hashed `/assets/*` files to improve repeat-visit performance.
-- [x] [Fixed] 🤖 Added a valid `robots.txt` and explicitly disallowed crawler access to `/trip/` and `/s/` while keeping all other paths crawlable.
-- [x] [Fixed] 🛠️ Resolved React runtime warnings by switching progressive image `fetchPriority` delivery to a lowercase DOM `fetchpriority` attribute and removing nested anchor markup in Inspirations cards.
+- [x] [Improved] ⚡ Homepage, blog, and marketing pages now feel much faster, especially on first visit.
+- [x] [Improved] 🖼️ Images now appear with smoother progressive loading, so cards and headers become readable sooner on slower connections.
+- [x] [Improved] 🗺️ Example trip map previews now load faster and more reliably across homepage and share surfaces.
+- [x] [Improved] 🧭 Opening routes feels smoother with fewer blank-loading flashes between pages.
+- [x] [Improved] 🔤 Typography now loads more reliably with fewer external font delays.
+- [x] [Improved] 🎢 Homepage example trips now use a clean continuous desktop scroll with subtle perspective taper on entry, and now support endless swipe with center snapping on mobile.
+- [x] [Improved] 🧲 Mobile carousel swipe now uses smoother native center snapping after release.
+- [x] [Fixed] 📱 Endless mobile scrolling now stays stable at loop boundaries without jittering or reverse snap jumps.
+- [x] [Improved] 🎯 Mobile carousel snapping now feels more natural with native browser snap behavior and no abrupt post-swipe jumps.
+- [x] [Improved] 🌫️ Mobile carousel edge fades now blend over cards smoothly instead of hard clipping at the viewport edge.
+- [x] [Fixed] 🖼️ Example trip cards now prioritize stable built-in map previews for more consistent image loading.
+- [x] [Fixed] ✅ Map-based previews and social images now fall back gracefully when map provider restrictions occur.
+- [x] [Fixed] 🤖 Private trip/share paths are now kept out of search indexing while public pages remain crawlable.
 - [ ] [Internal] 🧱 Added build-time image placeholder manifest generation (`sharp` + `blurhash`) and integrated it into the production build pipeline.
-- [ ] [Internal] 🧩 Moved simulated-login debug state helpers into a lightweight standalone service to decouple debug toggles from Supabase runtime imports.
-- [ ] [Internal] 🎨 Deferred Prism theme CSS loading to the admin benchmark route so non-admin pages avoid that render-blocking stylesheet.
-- [ ] [Internal] 🧹 Production builds now prune `console.log/info/debug` calls while retaining warnings/errors.
-- [x] [Improved] ⚡ Blog and marketing routes now load via lazy route chunks instead of shipping planner-heavy code on first paint.
-- [x] [Improved] 🗺️ Removed globally injected Leaflet CDN assets from the HTML shell so non-map pages stop paying map-library cost.
-- [x] [Improved] 🚀 On `/blog/best-time-visit-japan` (Lighthouse mobile sample), key metrics improved from roughly FCP `4.9s → 2.5s` (~`49%` faster), LCP `5.3s → 3.5s` (~`34%` faster), TBT `80ms → 3ms` (~`96%` lower), and Speed Index `5.5s → 2.5s` (~`55%` faster).
-- [x] [Improved] 🖼️ Recompressed and regenerated responsive blog image derivatives, reducing the optimized blog image set by ~`452 KB` (`45` files, ~`15.4%` less transfer).
-- [x] [Improved] 🧠 Increased blog image browser caching from 1 hour to 30 days (`s-maxage` 1 year) for faster repeat visits.
-- [x] [Improved] 🧩 Added `content-visibility` with intrinsic-size hints for below-the-fold sections on blog detail pages.
-- [x] [Improved] 📦 Added conservative Vite `manualChunks` groups so large dependency buckets can be cached independently.
-- [x] [Improved] 🛠️ Deferred loading of the on-page debugger until explicitly requested (`debug()`/`?debug=1`/persisted auto-open).
-- [x] [Fixed] 🗺️ Homepage example trip cards now use pre-generated map assets instead of runtime preview API calls, removing extra preview request chains and preventing `/.netlify/images` map-preview 403 noise.
-- [x] [Improved] 🔤 Self-hosted `Space Grotesk` with local `woff2` subsets (`latin`, `latin-ext`, `vietnamese`) and `font-display: swap` to remove Google Fonts request chains.
-- [x] [Improved] ✍️ Added a self-hosted `Bricolage Grotesque` heading option (latin/latin-ext/vietnamese subsets) for faster local typography experiments without external font CDNs.
-- [x] [Improved] 🌍 Added self-hosted global script fallbacks (Cyrillic, Greek, Devanagari, Arabic, Hebrew, Thai) so international city/country names render reliably beyond English/German/Spanish/French Latin text.
-- [x] [Fixed] ✅ Static map preview and OG map rendering now gracefully fall back when satellite static maps are unavailable for account/region policy, avoiding hard 403 map responses.
-- [x] [Improved] 🖼️ Updated OG image edge rendering to load local self-hosted fonts first, with resilient fallback if local assets are unavailable.
-- [x] [Improved] 🧭 Added route-module warmup and link-intent preloading so first navigation in local/dev no longer stalls on lazy chunk compilation with a visible blank fallback blink.
-- [ ] [Internal] 📋 Added a persistent performance backlog document to keep route-by-route Lighthouse improvements active.
+- [ ] [Internal] 🧩 Moved simulated-login debug state helpers into a standalone service to decouple debug toggles from Supabase runtime imports.
+- [ ] [Internal] 🎨 Deferred Prism theme CSS loading to the admin benchmark route to avoid render-blocking CSS on non-admin pages.
+- [ ] [Internal] 🧹 Production builds now prune `console.log/info/debug` calls while retaining warnings and errors.
+- [ ] [Internal] 🧭 Reverted homepage example card motion to linear desktop marquee transforms and limited scaling to a short right-edge taper zone.
+- [ ] [Internal] 📱 Mobile carousel now uses a repeated data strip with scroll-position recentering to keep native swipe + snap behavior effectively endless.
+- [ ] [Internal] 🧮 Mobile loop recentering now normalizes centered card positions into the middle strip via measured modular offsets.
+- [ ] [Internal] 🎯 Switched mobile to native `snap-mandatory`; loop recentering now runs after idle/`scrollend` and uses snap-neutral teleporting to prevent boundary direction reversals.
+- [ ] [Internal] 📐 Removed forced post-snap JS center correction and kept native CSS snapping, while preserving endless-loop recentering after idle/`scrollend`.
+- [ ] [Internal] 🌫️ Replaced mobile mask-based edge softening with explicit overlay gradients to avoid hard-cut clipping on some browsers/compositors.
+- [ ] [Internal] 🗺️ Removed runtime map preview URL usage from homepage cards so map images resolve from stable local card assets first.
+- [ ] [Internal] 🧭 Hardened Google Maps loader readiness checks to wait for a constructible `google.maps.Map` before initializing trip maps.
+- [ ] [Internal] 🧭 Added route-module warmup and link-intent preloading for first-navigation chunk compilation smoothness.
+- [ ] [Internal] 📦 Added conservative Vite `manualChunks` groups so heavy dependency buckets can cache independently.
+- [ ] [Internal] 🗺️ Switched homepage example trip cards to pre-generated map assets instead of runtime map preview API calls.
+- [ ] [Internal] 🔤 Self-hosted `Space Grotesk` and `Bricolage Grotesque` font subsets to remove external font request chains.
+- [ ] [Internal] 🌍 Added self-hosted global script font fallbacks (Cyrillic/Greek/Devanagari/Arabic/Hebrew/Thai) for broader locale coverage.
+- [ ] [Internal] 🛠️ Deferred on-page debugger loading behind explicit debug entry points (`debug()`, `?debug=1`, persisted auto-open).

--- a/docs/UPDATE_FORMAT.md
+++ b/docs/UPDATE_FORMAT.md
@@ -73,6 +73,7 @@ Write visible items from the user's perspective — focus on the benefit, not th
 2. Keep coding notes locally while implementing; avoid creating multiple incremental release files for one feature.
 3. Shortly before opening the PR, update/finalize that one release file with final shipped scope.
 4. When ready to publish, bump the version to the next release number and set:
+   - You can get the next merged/published version with `npm run updates:next-version`.
    - `status: published`
    - `published_at` to the publish time
    - `notify_in_app` as needed
@@ -83,6 +84,7 @@ Write visible items from the user's perspective — focus on the benefit, not th
 - Every new published release must use a new version.
 - Versions must be strictly increasing over publish time.
 - Reusing a previous version is not allowed and should fail validation.
+- Draft versions are provisional and do not reserve a published version number.
 
 ## Timezone rule
 The site displays dates in CET (UTC+1). To ensure the correct date appears on the `/updates` page:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "updates:validate": "node scripts/validate-updates.mjs",
+    "updates:next-version": "node scripts/next-release-version.mjs",
     "blog:validate": "node scripts/validate-blog.mjs",
     "edge:validate": "node scripts/validate-edge-functions.mjs",
     "inspirations:images:jobs": "tsx scripts/build-inspiration-image-batch.ts",

--- a/scripts/next-release-version.mjs
+++ b/scripts/next-release-version.mjs
@@ -1,0 +1,106 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const UPDATES_DIR = path.resolve(process.cwd(), 'content/updates');
+const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---\n?/;
+
+const stripQuotes = (value) => {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+};
+
+const parseFrontmatter = (raw) => {
+  const normalized = raw.replace(/\r\n/g, '\n');
+  const match = normalized.match(FRONTMATTER_REGEX);
+  if (!match) return null;
+
+  const meta = {};
+  for (const line of match[1].split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const separator = trimmed.indexOf(':');
+    if (separator === -1) continue;
+    const key = trimmed.slice(0, separator).trim().toLowerCase();
+    const value = stripQuotes(trimmed.slice(separator + 1));
+    meta[key] = value;
+  }
+  return meta;
+};
+
+const parseVersionCore = (version) => {
+  const normalized = String(version || '').trim().replace(/^v/i, '');
+  const core = normalized.split(/[-+]/)[0];
+  const [majorRaw, minorRaw, patchRaw] = core.split('.');
+  const major = Number(majorRaw);
+  const minor = Number(minorRaw);
+  const patch = Number(patchRaw);
+
+  if (!Number.isInteger(major) || !Number.isInteger(minor) || !Number.isInteger(patch)) {
+    return null;
+  }
+
+  return { major, minor, patch };
+};
+
+const compareVersionCore = (a, b) => {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+};
+
+const formatVersion = ({ major, minor, patch }) => `v${major}.${minor}.${patch}`;
+
+const main = async () => {
+  const entries = await fs.readdir(UPDATES_DIR, { withFileTypes: true });
+  const files = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => path.join(UPDATES_DIR, entry.name));
+
+  const published = [];
+
+  for (const file of files) {
+    const raw = await fs.readFile(file, 'utf8');
+    const meta = parseFrontmatter(raw);
+    if (!meta) continue;
+    if (String(meta.status || '').trim().toLowerCase() !== 'published') continue;
+
+    const parsedVersion = parseVersionCore(meta.version);
+    if (!parsedVersion) continue;
+
+    published.push({
+      file,
+      version: meta.version,
+      parsedVersion,
+      publishedAt: meta.published_at || '',
+    });
+  }
+
+  if (published.length === 0) {
+    console.log('v0.1.0');
+    return;
+  }
+
+  published.sort((a, b) => {
+    const byVersion = compareVersionCore(a.parsedVersion, b.parsedVersion);
+    if (byVersion !== 0) return byVersion;
+    return Date.parse(a.publishedAt || 0) - Date.parse(b.publishedAt || 0);
+  });
+
+  const latest = published[published.length - 1];
+  const next = latest.parsedVersion.patch === 0
+    ? { major: latest.parsedVersion.major, minor: latest.parsedVersion.minor + 1, patch: 0 }
+    : { major: latest.parsedVersion.major, minor: latest.parsedVersion.minor, patch: latest.parsedVersion.patch + 1 };
+
+  const nextVersion = formatVersion(next);
+  const latestFile = path.relative(process.cwd(), latest.file);
+
+  console.log(`${nextVersion}  # latest published: ${latest.version} (${latestFile})`);
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/validate-updates.mjs
+++ b/scripts/validate-updates.mjs
@@ -181,19 +181,21 @@ const main = async () => {
     }
   }
 
-  const versionToFiles = new Map();
+  const publishedVersionToFiles = new Map();
   for (const entry of parsedByFile) {
+    const status = String(entry.meta.status || '').trim().toLowerCase();
+    if (status !== 'published') continue;
     const version = String(entry.meta.version || '').trim();
     if (!version) continue;
-    const list = versionToFiles.get(version) || [];
+    const list = publishedVersionToFiles.get(version) || [];
     list.push(entry.file);
-    versionToFiles.set(version, list);
+    publishedVersionToFiles.set(version, list);
   }
 
-  for (const [version, matchingFiles] of versionToFiles.entries()) {
+  for (const [version, matchingFiles] of publishedVersionToFiles.entries()) {
     if (matchingFiles.length <= 1) continue;
     hasErrors = true;
-    console.error(`\n[updates:validate] duplicate version detected: ${version}`);
+    console.error(`\n[updates:validate] duplicate published version detected: ${version}`);
     for (const file of matchingFiles) {
       console.error(`  - ${path.relative(process.cwd(), file)}`);
     }


### PR DESCRIPTION
## Summary
- restore natural mobile swipe snapping while keeping endless carousel looping on homepage example cards
- fix loop-boundary reverse snap/jitter behavior and apply soft edge overlays on mobile without horizontal scrollbar regressions
- harden homepage example card image/map loading and Google Maps constructor readiness checks
- add release-note tooling so next versions are derived from published releases only
- finalize release note visibility split and bump release to v0.47.0 with updated publish timestamp

## Validation
- npm run build
- npm run updates:validate
- npm run updates:next-version