### PR TITLE
Fix updates version collision blocking Netlify build + refine 404 layout

### DIFF
--- a/content/updates/2026-02-12-global-404-plane-window.md
+++ b/content/updates/2026-02-12-global-404-plane-window.md
@@ -1,9 +1,9 @@
 ---
 id: rel-2026-02-12-global-404-plane-window
-version: v0.49.0
+version: v0.50.0
 title: "Global 404 page with animated plane-window motif"
-date: 2026-02-12
-published_at: 2026-02-12T20:36:15Z
+date: 2026-02-13
+published_at: 2026-02-13T06:34:45Z
 status: published
 notify_in_app: false
 in_app_hours: 24
@@ -15,4 +15,5 @@ summary: "Added a playful multilingual global 404 page with an animated plane-wi
 - [x] [Improved] 😄 Added playful transcreated 404 messaging across all supported locales (EN, ES, DE, FR, PT, RU, IT).
 - [x] [Improved] 🧭 Added a direct "Plan yours" CTA from the 404 page to jump straight into trip creation.
 - [x] [Improved] 📬 Added a "Contact us" fallback link for missing pages users think should exist.
+- [x] [Improved] 🎨 Polished the 404 visual rhythm with clearer vertical spacing, larger center window framing, and muted non-selectable side numerals for a cleaner modern look.
 - [ ] [Internal] 📈 Added dedicated Umami events for 404 page views and 404 CTA/link interactions.

--- a/pages/NotFoundPage.tsx
+++ b/pages/NotFoundPage.tsx
@@ -26,28 +26,28 @@ export const NotFoundPage: React.FC = () => {
 
     return (
         <MarketingLayout>
-            <section className="flex min-h-[72vh] flex-col items-center justify-center py-4 md:py-8">
-                <div className="flex items-center justify-center gap-2 sm:gap-4 md:gap-8">
+            <section className="flex min-h-[76vh] flex-col items-center justify-center py-8 md:py-12">
+                <div className="flex select-none items-center justify-center gap-[clamp(0.35rem,1.6vw,1.4rem)]">
                     <span
-                        className="text-[clamp(4.5rem,19vw,13rem)] font-black leading-none text-slate-900"
+                        className="pointer-events-none select-none text-[clamp(6.8rem,24vw,17rem)] font-black leading-[0.84] tracking-[-0.04em] text-slate-400/95"
                         style={{ fontFamily: 'var(--tf-font-heading)' }}
                     >
                         4
                     </span>
-                    <div className="w-[clamp(5.25rem,18vw,11rem)] shrink-0">
+                    <div className="w-[clamp(8.25rem,24vw,15.5rem)] shrink-0">
                         <PlaneWindowAnimation />
                     </div>
                     <span
-                        className="text-[clamp(4.5rem,19vw,13rem)] font-black leading-none text-slate-900"
+                        className="pointer-events-none select-none text-[clamp(6.8rem,24vw,17rem)] font-black leading-[0.84] tracking-[-0.04em] text-slate-400/95"
                         style={{ fontFamily: 'var(--tf-font-heading)' }}
                     >
                         4
                     </span>
                 </div>
 
-                <div className="mt-8 max-w-2xl text-center md:mt-10">
+                <div className="mt-10 flex w-full max-w-3xl flex-col items-center text-center md:mt-14">
                     <h1
-                        className="text-2xl font-black tracking-tight text-slate-900 md:text-4xl"
+                        className="max-w-[18ch] text-2xl font-black leading-tight tracking-tight text-slate-900 md:text-5xl"
                         style={{ fontFamily: 'var(--tf-font-heading)' }}
                     >
                         {t('notFound.headline')}
@@ -56,13 +56,15 @@ export const NotFoundPage: React.FC = () => {
                     <Link
                         to={createTripPath}
                         onClick={() => trackEvent(PLAN_CTA_EVENT, { locale })}
-                        className="mt-6 inline-flex items-center rounded-2xl bg-accent-600 px-7 py-3 text-base font-bold text-white shadow-lg shadow-accent-200 transition-all hover:bg-accent-700 hover:shadow-xl hover:shadow-accent-300 hover:scale-[1.02] active:scale-[0.98]"
+                        className="mt-7 inline-flex items-center rounded-2xl bg-accent-600 px-7 py-3 text-base font-bold text-white shadow-lg shadow-accent-200 transition-all hover:bg-accent-700 hover:shadow-xl hover:shadow-accent-300 hover:scale-[1.02] active:scale-[0.98] md:mt-8"
                         {...getAnalyticsDebugAttributes(PLAN_CTA_EVENT, { locale })}
                     >
                         {t('notFound.planCta')}
                     </Link>
 
-                    <p className="mt-10 text-sm text-slate-600 md:text-base">
+                    <div className="mt-9 h-px w-24 bg-slate-300/80 md:mt-10" aria-hidden="true" />
+
+                    <p className="mt-7 max-w-[44ch] text-sm text-slate-600 md:mt-8 md:text-base">
                         {t('notFound.missingPrompt')}{' '}
                         <Link
                             to={contactPath}


### PR DESCRIPTION
## Summary
- Fix Netlify build failure from duplicate published release version in updates validation.
- Bump `/content/updates/2026-02-12-global-404-plane-window.md` from `v0.49.0` to `v0.50.0`.
- Set release `date` and `published_at` to a newer timestamp (`2026-02-13T06:34:45Z`) so ordering is strictly increasing.
- Refine 404 visual spacing and hierarchy: larger center window, larger closer gray side 4s, and clearer vertical rhythm.

## Why Build Was Failing
`/scripts/validate-updates.mjs` detected duplicate published version `v0.49.0` across two update files and exited non-zero, which failed `npm run build` on Netlify.

## Validation
- `npm run updates:validate`
- `npm run build`
