### PR TITLE
i18n banners: persistent acknowledgement + session dismiss + event-based tracking

### DIFF
--- a/components/navigation/LanguageSuggestionBanner.tsx
+++ b/components/navigation/LanguageSuggestionBanner.tsx
@@ -10,6 +10,7 @@ import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analytic
 import i18n, { preloadLocaleNamespaces } from '../../i18n';
 
 const SESSION_DISMISS_KEY = 'tf_locale_suggestion_dismissed_session';
+const SWITCH_ACK_KEY = 'tf_locale_suggestion_switched';
 
 const MESSAGE_BY_LOCALE: Record<AppLanguage, { message: string; action: string; actionShort: string; dismiss: string }> = {
     en: {
@@ -56,20 +57,6 @@ const MESSAGE_BY_LOCALE: Record<AppLanguage, { message: string; action: string; 
     },
 };
 
-const appendLanguageBannerTrackingParams = (target: string, from: AppLanguage, to: AppLanguage): string => {
-    if (typeof window === 'undefined') return target;
-    try {
-        const url = new URL(target, window.location.origin);
-        url.searchParams.set('utm_source', 'language_banner');
-        url.searchParams.set('utm_medium', 'locale_switch');
-        url.searchParams.set('utm_campaign', 'language_suggestion');
-        url.searchParams.set('utm_content', `${from}_to_${to}`);
-        return `${url.pathname}${url.search}${url.hash}`;
-    } catch {
-        return target;
-    }
-};
-
 const getBrowserPreferredLocale = (currentLocale: AppLanguage): AppLanguage | null => {
     if (typeof navigator === 'undefined') return null;
 
@@ -99,6 +86,15 @@ const isDismissedForSession = (): boolean => {
     }
 };
 
+const isSwitchAcknowledged = (): boolean => {
+    if (typeof window === 'undefined') return false;
+    try {
+        return window.localStorage.getItem(SWITCH_ACK_KEY) === '1';
+    } catch {
+        return false;
+    }
+};
+
 export const LanguageSuggestionBanner: React.FC = () => {
     const location = useLocation();
     const navigate = useNavigate();
@@ -112,7 +108,9 @@ export const LanguageSuggestionBanner: React.FC = () => {
         return getBrowserPreferredLocale(activeLocale);
     }, [activeLocale, location.pathname]);
 
-    const [dismissed, setDismissed] = useState<boolean>(() => isDismissedForSession());
+    const [dismissed, setDismissed] = useState<boolean>(() => (
+        isDismissedForSession() || isSwitchAcknowledged()
+    ));
 
     if (!suggestedLocale || dismissed) return null;
 
@@ -133,20 +131,30 @@ export const LanguageSuggestionBanner: React.FC = () => {
     };
 
     const handleSwitch = () => {
+        setDismissed(true);
+        if (typeof window !== 'undefined') {
+            try {
+                window.sessionStorage.setItem(SESSION_DISMISS_KEY, '1');
+                window.localStorage.setItem(SWITCH_ACK_KEY, '1');
+            } catch {
+                // ignore
+            }
+        }
+
         void preloadLocaleNamespaces(suggestedLocale, getNamespacesForMarketingPath(location.pathname));
         applyDocumentLocale(suggestedLocale);
         void i18n.changeLanguage(suggestedLocale);
 
-        const baseTarget = buildLocalizedLocation({
+        const target = buildLocalizedLocation({
             pathname: location.pathname,
             search: location.search,
             hash: location.hash,
             targetLocale: suggestedLocale,
         });
-        const target = appendLanguageBannerTrackingParams(baseTarget, activeLocale, suggestedLocale);
         trackEvent('navigation__language_suggestion--switch', {
             from: activeLocale,
             to: suggestedLocale,
+            source: 'language_banner',
             target,
         });
         navigate(target);
@@ -165,7 +173,7 @@ export const LanguageSuggestionBanner: React.FC = () => {
                     className="shrink-0 rounded-lg border border-cyan-300 bg-white px-2 py-1 text-xs font-semibold text-cyan-800 transition-colors hover:bg-cyan-100 sm:px-2.5"
                     {...getAnalyticsDebugAttributes('navigation__language_suggestion--switch', {
                         to: suggestedLocale,
-                        utm_source: 'language_banner',
+                        source: 'language_banner',
                     })}
                 >
                     <span className="sm:hidden">{copy.actionShort}</span>

--- a/content/updates/2026-02-12-i18n-locale-seo-rollout.md
+++ b/content/updates/2026-02-12-i18n-locale-seo-rollout.md
@@ -21,6 +21,8 @@ summary: "Improved multilingual UX with faster switching and persistent locale-b
 - [x] [Fixed] 🙈 Global hover tooltips are now disabled on touch/mobile devices to prevent sticky floating labels.
 - [x] [Improved] 🔕 Dismissing the locale suggestion banner now hides it for the rest of the current session.
 - [x] [Fixed] ✅ Locale suggestion dismissal now remains persistent while switching between languages in the same session.
+- [x] [Fixed] 🚫 After switching via the language suggestion CTA, the suggestion banner is now acknowledged and no longer shown again.
+- [x] [Improved] ⚠️ Translation quality notice banner can now be dismissed for the current session.
 - [x] [Improved] 📰 Non-English blog pages can show native + English articles with a locale-aware language filter and clear English-content notice.
 - [x] [Fixed] 🔗 English blog entries opened from non-English views now route to the correct article language variant.
 - [x] [Improved] ✍️ Blog pages now feature a creator-focused community CTA for bloggers and storytellers to submit ideas via contact.
@@ -30,3 +32,4 @@ summary: "Improved multilingual UX with faster switching and persistent locale-b
 - [x] [Fixed] 🧩 Placeholder interpolation now resolves correctly in translated strings (for example `{year}`, `{appName}`, counts, and query values).
 - [ ] [Internal] 🗺️ Expanded sitemap/blog validation/edge metadata locale support to include Spanish and Portuguese.
 - [ ] [Internal] 📘 Updated i18n and LLM docs so new localized pages follow consistent routing, SEO, copywriting, and analytics conventions.
+- [ ] [Internal] 📊 Locale-switch attribution now uses Umami event payload fields instead of URL query tracking params.

--- a/docs/ANALYTICS_CONVENTION.md
+++ b/docs/ANALYTICS_CONVENTION.md
@@ -29,6 +29,16 @@ All analytics events use a **BEM-inspired** naming format enforced by a TypeScri
 4. **Use `snake_case`** within each segment, separated by `__` and `--`.
 5. **Prefix grouping** — all events from a page share the same prefix (`inspirations__*`), making dashboard filtering trivial.
 6. **Do not use URL query parameters as analytics tracking** when Umami event tracking is available. Track intent with `trackEvent(...)` and payload properties instead.
+7. **`getAnalyticsDebugAttributes(...)` is for QA/debug overlays only.** It does not replace `trackEvent(...)`.
+
+## Locale switch tracking guidance
+
+- For locale switches (`header select`, `mobile select`, `language suggestion banner`), prefer `trackEvent(...)` payload properties such as:
+  - `source` (for example `language_banner`, `header_select`, `mobile_menu`)
+  - `from`, `to`
+  - `target` (localized path)
+- Avoid appending UTM-style query params to internal route switches solely for analytics attribution.
+- Keep attribution in Umami events and payload fields so URLs stay clean/canonical-safe.
 
 ## When to use payload vs `--detail`
 

--- a/docs/I18N_PAGE_WORKFLOW.md
+++ b/docs/I18N_PAGE_WORKFLOW.md
@@ -51,6 +51,12 @@ This document defines how to add or change localized pages in TravelFlow.
 - Localized marketing pages show translation disclaimer banner via `components/marketing/TranslationNoticeBanner.tsx`.
 - Banner is injected by `components/marketing/MarketingLayout.tsx`.
 - Banner links to localized `/contact` route for reporting translation issues.
+- Banner can be dismissed for the current browser session (session storage).
+
+## Language Suggestion Banner Behavior
+- Banner is shown only on marketing pages when browser-preferred locale differs from current locale.
+- Dismissing the banner hides it for the current browser session.
+- Switching via banner CTA permanently acknowledges the hint (stored locally), so it is not shown again on future visits unless storage is cleared.
 
 ## Logical Properties Requirement (Direction Safety)
 - For every new or updated component, evaluate if CSS logical properties should be used for direction safety:


### PR DESCRIPTION
## Summary
- stop using URL query params for locale-banner attribution and keep tracking in Umami events/payload
- when users switch via the locale suggestion banner, store a persistent acknowledgement so it does not show again
- add close/dismiss support to the translation quality notice banner with session persistence
- update existing docs (`docs/ANALYTICS_CONVENTION.md`, `docs/I18N_PAGE_WORKFLOW.md`) to codify the behavior and tracking pattern
- update the existing release note file without changing the release version number

## Validation
- npm run build
