### PR TITLE
Fix blog fallback locale semantics + canonicalize release version timeline

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -11,6 +11,7 @@
 - Any completed feature/fix must be reflected in `content/updates/*.md`.
 - For new components, check whether logical CSS properties should be used for direction safety; if unclear, ask for clarification.
 - For user-facing copy edits, ask the user for EN/DE style sign-off unless they explicitly opt out.
+- Release notes in `content/updates/*.md` are always written in English and do not require EN/DE style sign-off.
 - For clickable marketing/planner UI updates, add `trackEvent(...)` + `getAnalyticsDebugAttributes(...)` in the standard format unless explicitly excluded.
 
 ## Update entry policy

--- a/content/updates/2026-02-09-bem-analytics-events.md
+++ b/content/updates/2026-02-09-bem-analytics-events.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-09-bem-analytics-events
-version: v0.29.0
+version: v0.26.0
 title: "Comprehensive analytics tracking"
 date: 2026-02-09
 published_at: 2026-02-09T22:25:00Z

--- a/content/updates/2026-02-09-edge-function-fix-and-safeguards.md
+++ b/content/updates/2026-02-09-edge-function-fix-and-safeguards.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-09-edge-function-fix-and-safeguards
-version: v0.31.0
+version: v0.28.0
 title: "Edge function stability fix"
 date: 2026-02-09
 published_at: 2026-02-09T22:35:00Z

--- a/content/updates/2026-02-09-homepage-redesign.md
+++ b/content/updates/2026-02-09-homepage-redesign.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-09-homepage-redesign
-version: v0.23.0
+version: v0.21.0
 title: "View transitions, country pages, and blog & homepage redesign"
 date: 2026-02-09
 published_at: 2026-02-09T12:00:00Z

--- a/content/updates/2026-02-09-inspiration-prefill-links.md
+++ b/content/updates/2026-02-09-inspiration-prefill-links.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-09-inspiration-prefill-links
-version: v0.25.0
+version: v0.23.0
 title: "Inspiration links now pre-fill the trip form"
 date: 2026-02-09
 published_at: 2026-02-09T22:00:00Z

--- a/content/updates/2026-02-09-mobile-nav-pricing.md
+++ b/content/updates/2026-02-09-mobile-nav-pricing.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-09-mobile-nav-pricing
-version: v0.24.0
+version: v0.22.0
 title: "Unified navigation, mobile menu, pricing page & My Trips"
 date: 2026-02-09
 published_at: 2026-02-09T18:00:00Z

--- a/content/updates/2026-02-09-nav-breakpoints-lazy-db.md
+++ b/content/updates/2026-02-09-nav-breakpoints-lazy-db.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-09-nav-breakpoints-lazy-db
-version: v0.26.0
+version: v0.24.0
 title: "Navigation spacing fix & faster marketing page loads"
 date: 2026-02-09
 published_at: 2026-02-09T22:10:00Z

--- a/content/updates/2026-02-09-og-meta-all-pages.md
+++ b/content/updates/2026-02-09-og-meta-all-pages.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-09-og-meta-all-pages
-version: v0.30.0
+version: v0.27.0
 title: "Better social previews for every page"
 date: 2026-02-09
 published_at: 2026-02-09T22:30:00Z

--- a/content/updates/2026-02-09-plane-window-hero.md
+++ b/content/updates/2026-02-09-plane-window-hero.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-09-plane-window-hero
-version: v0.32.0
+version: v0.29.0
 title: "Plane window hero animation"
 date: 2026-02-09
 published_at: 2026-02-09T22:40:00Z

--- a/content/updates/2026-02-09-trip-preview-maps.md
+++ b/content/updates/2026-02-09-trip-preview-maps.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-09-trip-preview-maps
-version: v0.28.0
+version: v0.25.0
 title: "Real trip routes on homepage cards"
 date: 2026-02-09
 published_at: 2026-02-09T22:20:00Z

--- a/content/updates/2026-02-10-create-trip-visual-overhaul-labs.md
+++ b/content/updates/2026-02-10-create-trip-visual-overhaul-labs.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-10-create-trip-visual-overhaul-labs
-version: v0.38.0
+version: v0.30.0
 title: "Create trip visual overhaul labs"
 date: 2026-02-10
 published_at: 2026-02-10T08:09:29Z

--- a/content/updates/2026-02-10-example-trip-playground-and-anonymous-limits.md
+++ b/content/updates/2026-02-10-example-trip-playground-and-anonymous-limits.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-10-example-trip-playground-and-anonymous-limits
-version: v0.44.0
+version: v0.34.0
 title: "Example trip playground improvements"
 date: 2026-02-10
 published_at: 2026-02-10T18:50:00Z

--- a/content/updates/2026-02-10-inspirations-photo-cards.md
+++ b/content/updates/2026-02-10-inspirations-photo-cards.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-10-inspirations-photo-cards
-version: v0.41.0
+version: v0.31.0
 title: "Travel photography now powers inspiration and blog previews"
 date: 2026-02-10
 published_at: 2026-02-10T10:24:25Z

--- a/content/updates/2026-02-10-on-page-debug-toolbar.md
+++ b/content/updates/2026-02-10-on-page-debug-toolbar.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-10-on-page-debug-toolbar
-version: v0.45.0
+version: v0.35.0
 title: "On-page debugger toolbar"
 date: 2026-02-11
 published_at: 2026-02-11T11:29:38Z

--- a/content/updates/2026-02-10-trip-info-modal-unification.md
+++ b/content/updates/2026-02-10-trip-info-modal-unification.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-10-trip-info-modal-unification
-version: v0.43.0
+version: v0.33.0
 title: "Unified trip information modal across desktop and mobile"
 date: 2026-02-10
 published_at: 2026-02-10T18:16:28Z

--- a/content/updates/2026-02-10-trip-palettes-and-map-color-modes.md
+++ b/content/updates/2026-02-10-trip-palettes-and-map-color-modes.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-10-trip-palettes-map-color-modes
-version: v0.42.0
+version: v0.32.0
 title: "Trip palettes and map color modes"
 date: 2026-02-10
 published_at: 2026-02-10T13:50:00Z

--- a/content/updates/2026-02-11-page-speed-continuous-optimization.md
+++ b/content/updates/2026-02-11-page-speed-continuous-optimization.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-11-page-speed-continuous-optimization
-version: v0.46.0
+version: v0.36.0
 title: "Page speed baseline and continuous optimization"
 date: 2026-02-12
 published_at: 2026-02-12T15:18:56Z

--- a/content/updates/2026-02-12-global-404-plane-window.md
+++ b/content/updates/2026-02-12-global-404-plane-window.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-12-global-404-plane-window
-version: v0.50.0
+version: v0.38.0
 title: "Global 404 page with animated plane-window motif"
 date: 2026-02-13
 published_at: 2026-02-13T06:34:45Z

--- a/content/updates/2026-02-12-i18n-locale-seo-rollout.md
+++ b/content/updates/2026-02-12-i18n-locale-seo-rollout.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-12-i18n-locale-seo-rollout
-version: v0.49.0
+version: v0.37.0
 title: "I18n foundation and locale-aware SEO rollout"
 date: 2026-02-12
 published_at: 2026-02-12T20:35:58Z

--- a/content/updates/2026-02-13-blog-locale-path-retention.md
+++ b/content/updates/2026-02-13-blog-locale-path-retention.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-02-13-blog-locale-path-retention
+version: v0.40.0
+title: "Blog locale path retention for English fallback articles"
+date: 2026-02-13
+published_at: 2026-02-13T15:42:10Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Non-English blog browsing now keeps locale URL context when opening English-only posts, with clearer article-language messaging."
+---
+
+## Changes
+- [x] [Fixed] 🌍 Opening an English-only blog post from a non-English blog view now keeps the active locale path and UI language context.
+- [x] [Improved] 🧭 "Back to blog" and related article links now route to the active locale's blog paths.
+- [x] [Improved] 🇬🇧 Blog post pages now show a localized English-content notice and scope `lang` attributes to article content.
+- [x] [Improved] 🔗 Locale fallback article URLs now set a canonical link to the original English source page to prevent duplicate indexing.

--- a/content/updates/2026-02-13-og-font-compat-and-share-sync-guards.md
+++ b/content/updates/2026-02-13-og-font-compat-and-share-sync-guards.md
@@ -1,6 +1,6 @@
 ---
 id: rel-2026-02-13-og-font-compat-and-share-sync-guards
-version: v0.51.0
+version: v0.39.0
 title: "OG image rendering restored and share-sync guard tightened"
 date: 2026-02-13
 published_at: 2026-02-13T15:36:57Z

--- a/docs/UPDATE_FORMAT.md
+++ b/docs/UPDATE_FORMAT.md
@@ -83,6 +83,7 @@ Write visible items from the user's perspective — focus on the benefit, not th
 ## Versioning policy
 - Every new published release must use a new version.
 - Versions must be strictly increasing over publish time.
+- Published versions must be gapless and canonical by `published_at` order (`v0.1.0`, `v0.2.0`, `v0.3.0`, ...).
 - Reusing a previous version is not allowed and should fail validation.
 - Draft versions are provisional and do not reserve a published version number.
 

--- a/netlify/edge-functions/site-og-meta.ts
+++ b/netlify/edge-functions/site-og-meta.ts
@@ -776,9 +776,10 @@ const buildMetadata = (url: URL): Metadata => {
     );
 
     if (missingLocalizedBlogVariant) {
-      basePathForMeta = "/";
-      canonicalPath = buildLocalizedPath(basePathForMeta, effectiveLocale);
-      alternateLinks = buildAlternateLinks(url.origin, basePathForMeta, SUPPORTED_LOCALES.slice());
+      // Keep locale-specific UI on the current path, but canonicalize
+      // to the source article locale to avoid duplicate-indexing fallback URLs.
+      canonicalPath = buildLocalizedPath(pathInfo.basePath, DEFAULT_LOCALE);
+      alternateLinks = buildAlternateLinks(url.origin, pathInfo.basePath, blogLocales ?? [DEFAULT_LOCALE]);
     } else {
       canonicalPath = buildLocalizedPath(pathInfo.basePath, effectiveLocale);
       alternateLinks = buildAlternateLinks(

--- a/pages/BlogPage.tsx
+++ b/pages/BlogPage.tsx
@@ -21,7 +21,6 @@ const BlogCard: React.FC<{ post: BlogPost; locale: AppLanguage }> = ({ post, loc
     const { t } = useTranslation('blog');
     const [hasImageError, setHasImageError] = useState(false);
     const showImage = !hasImageError;
-    const postLocale = post.language === DEFAULT_LOCALE ? DEFAULT_LOCALE : post.language;
     const showEnglishBadge = locale !== DEFAULT_LOCALE && post.language === DEFAULT_LOCALE;
     const formattedDate = new Date(post.publishedAt).toLocaleDateString(localeToIntlLocale(locale), {
         month: 'short',
@@ -32,7 +31,7 @@ const BlogCard: React.FC<{ post: BlogPost; locale: AppLanguage }> = ({ post, loc
 
     return (
         <Link
-            to={buildLocalizedMarketingPath('blogPost', postLocale, { slug: post.slug })}
+            to={buildLocalizedMarketingPath('blogPost', locale, { slug: post.slug })}
             lang={cardLang}
             data-blog-card-lang={cardLang}
             className={`group flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm ${BLOG_CARD_TRANSITION} hover:-translate-y-0.5 hover:shadow-lg`}

--- a/scripts/validate-updates.mjs
+++ b/scripts/validate-updates.mjs
@@ -71,6 +71,8 @@ const compareVersionCore = (a, b) => {
   return a.patch - b.patch;
 };
 
+const canonicalPublishedVersionForIndex = (index) => `v0.${index}.0`;
+
 const validateFile = async (filePath) => {
   const raw = await fs.readFile(filePath, 'utf8');
   const parsed = parseFrontmatter(raw);
@@ -224,6 +226,18 @@ const main = async () => {
       console.error(`  - Older: ${path.relative(process.cwd(), prev.file)} (${prev.version} @ ${prev.publishedAt})`);
       console.error(`  - Newer: ${path.relative(process.cwd(), curr.file)} (${curr.version} @ ${curr.publishedAt})`);
     }
+  }
+
+  for (let i = 0; i < publishedReleases.length; i += 1) {
+    const release = publishedReleases[i];
+    const expectedVersion = canonicalPublishedVersionForIndex(i + 1);
+    if (release.version === expectedVersion) continue;
+
+    hasErrors = true;
+    console.error('\n[updates:validate] published versions must be canonical and gapless by published_at timestamp');
+    console.error(`  - File: ${path.relative(process.cwd(), release.file)} (${release.publishedAt})`);
+    console.error(`  - Found: ${release.version}`);
+    console.error(`  - Expected: ${expectedVersion}`);
   }
 
   if (hasErrors) {

--- a/services/blogService.ts
+++ b/services/blogService.ts
@@ -183,6 +183,18 @@ export const getBlogPostBySlug = (slug: string, locale: AppLanguage = DEFAULT_LO
     return allBlogPosts.find((post) => post.slug === slug && post.language === locale);
 };
 
+export const getBlogPostBySlugWithFallback = (
+    slug: string,
+    locale: AppLanguage = DEFAULT_LOCALE,
+    fallbackLocale: AppLanguage = DEFAULT_LOCALE
+): BlogPost | undefined => {
+    const localizedPost = getBlogPostBySlug(slug, locale);
+    if (localizedPost) return localizedPost;
+
+    if (locale === fallbackLocale) return undefined;
+    return getBlogPostBySlug(slug, fallbackLocale);
+};
+
 export const getBlogPostTranslations = (translationGroup: string): BlogPost[] => {
     return allBlogPosts
         .filter((post) => post.translationGroup === translationGroup && post.status === 'published')

--- a/services/localeRoutingService.ts
+++ b/services/localeRoutingService.ts
@@ -1,6 +1,6 @@
 import { buildLocalizedMarketingPath, getBlogSlugFromPath, isLocalizedMarketingPath, isToolRoute, localizeMarketingPath } from '../config/routes';
 import { AppLanguage } from '../types';
-import { getBlogPostBySlug } from './blogService';
+import { getBlogPostBySlugWithFallback } from './blogService';
 
 interface BuildLocalizedLocationInput {
     pathname: string;
@@ -20,7 +20,7 @@ export const buildLocalizedLocation = ({ pathname, search = '', hash = '', targe
 
     const blogSlug = getBlogSlugFromPath(pathname);
     if (blogSlug) {
-        const blogPost = getBlogPostBySlug(blogSlug, targetLocale);
+        const blogPost = getBlogPostBySlugWithFallback(blogSlug, targetLocale);
         if (!blogPost) {
             return `${buildLocalizedMarketingPath('home', targetLocale)}${hash}`;
         }


### PR DESCRIPTION
## Summary
- keep non-English locale path when opening English fallback blog posts
- scope content language semantics to the article content block (`lang` + `translate="no"` on fallback) while keeping document locale from route
- add canonical handling for fallback blog URLs so they point to the original English source article
- update locale routing/blog resolution to support English fallback without redirecting to home
- normalize published release-note versions to a gapless canonical sequence by `published_at`
- enforce canonical gapless published versioning in `scripts/validate-updates.mjs`
- document the no-skip canonical versioning rule in `docs/UPDATE_FORMAT.md`
- update `LLM.md` so release-note copy is English-only and does not require EN/DE style sign-off

## Validation
- npm run updates:validate
- npm run build

## Notes
- branch rebased on latest `origin/main` before commit
