### PR TITLE
Replace emoji flags with Flagpack and move language checkmarks right

### DIFF
--- a/components/CountrySelect.tsx
+++ b/components/CountrySelect.tsx
@@ -5,6 +5,7 @@ import { MapPin, Search, Plus } from 'lucide-react';
 import { CountryTag } from './CountryTag';
 import { IdealTravelTimeline } from './IdealTravelTimeline';
 import { getCountrySeasonByName } from '../data/countryTravelData';
+import { FlagIcon } from './flags/FlagIcon';
 
 interface CountrySelectProps {
     value: string;
@@ -155,7 +156,7 @@ export const CountrySelect: React.FC<CountrySelectProps> = ({ value, onChange, d
                             onClick={() => addCountry(country.name)}
                         >
                             <div className="flex items-start gap-3 min-w-0">
-                                <span className="text-2xl">{country.flag}</span>
+                                <FlagIcon value={country.flag} size="xl" />
                                 <div className="min-w-0">
                                     <div className="font-medium text-gray-700 truncate">{country.name}</div>
                                     {country.kind === 'island' && country.parentCountryName && (

--- a/components/CountryTag.tsx
+++ b/components/CountryTag.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { X } from 'lucide-react';
+import { FlagIcon } from './flags/FlagIcon';
 
 interface CountryTagProps {
     countryName: string;
@@ -30,7 +31,7 @@ export const CountryTag: React.FC<CountryTagProps> = ({
                 className,
             ].join(' ').trim()}
         >
-            <span>{flag}</span>
+            <FlagIcon value={flag} size={isSmall ? 'sm' : 'md'} />
             <span className={metaLabel && !isSmall ? 'flex flex-col leading-tight' : ''}>
                 <span>{countryName}</span>
                 {metaLabel && !isSmall && <span className="text-[10px] font-medium text-gray-500">{metaLabel}</span>}

--- a/components/CreateTripForm.tsx
+++ b/components/CreateTripForm.tsx
@@ -61,6 +61,7 @@ import { TripGenerationSkeleton } from './TripGenerationSkeleton';
 import { HeroWebGLBackground } from './HeroWebGLBackground';
 import { SiteFooter } from './marketing/SiteFooter';
 import { SiteHeader } from './navigation/SiteHeader';
+import { FlagIcon } from './flags/FlagIcon';
 import {
     CountrySeasonEntry,
     getCommonBestMonths,
@@ -1222,24 +1223,27 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                             <div className="mt-5 flex flex-wrap gap-2 text-xs text-gray-500">
                                 <button
                                     type="button"
-                                    className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
+                                    className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
                                     onClick={() => fillExample('Italy', 14, 'Rome, Florence, Venice. Art & Food.')}
                                 >
-                                    🇮🇹 2 Weeks in Italy
+                                    <FlagIcon code="IT" />
+                                    2 Weeks in Italy
                                 </button>
                                 <button
                                     type="button"
-                                    className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
+                                    className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
                                     onClick={() => fillExample('Japan', 7, 'Anime, Tech, and Sushi.')}
                                 >
-                                    🇯🇵 7 Days in Japan
+                                    <FlagIcon code="JP" />
+                                    7 Days in Japan
                                 </button>
                                 <button
                                     type="button"
-                                    className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
+                                    className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
                                     onClick={() => onTripGenerated(createThailandTrip(new Date().toISOString()))}
                                 >
-                                    🇹🇭 Thailand (Test Plan)
+                                    <FlagIcon code="TH" />
+                                    Thailand (Test Plan)
                                 </button>
                             </div>
                         </div>
@@ -1339,7 +1343,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                                         >
                                                             <div className="min-w-0">
                                                                 <div className="text-sm font-medium text-gray-800 flex items-center gap-2">
-                                                                    <span>{country.flag}</span>
+                                                                    <FlagIcon value={country.flag} />
                                                                     <span>{country.name}</span>
                                                                 </div>
                                                                 {country.kind === 'island' && country.parentCountryName && (
@@ -1650,7 +1654,7 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
                                             >
                                                 <div className="flex items-center justify-between gap-3">
                                                     <div className="text-sm font-semibold text-gray-900 flex items-center gap-2">
-                                                        <span>{entry.flag}</span>
+                                                        <FlagIcon value={entry.flag} />
                                                         <span>{entry.countryName}</span>
                                                     </div>
                                                     <div className="text-[11px] text-gray-500">Score {ranked?.score || 0}</div>
@@ -1664,7 +1668,10 @@ export const CreateTripForm: React.FC<CreateTripFormProps> = ({ onTripGenerated,
 
                             {selectedSurpriseOption && (
                                 <div className="rounded-xl border border-gray-200 bg-white p-3 space-y-1.5">
-                                    <div className="text-sm font-semibold text-gray-900">{selectedSurpriseOption.flag} {selectedSurpriseOption.countryName}</div>
+                                    <div className="text-sm font-semibold text-gray-900 inline-flex items-center gap-2">
+                                        <FlagIcon value={selectedSurpriseOption.flag} />
+                                        {selectedSurpriseOption.countryName}
+                                    </div>
                                     <div className="text-xs text-gray-600">Suggested trip length: {selectedSurpriseOption.suggestedTripDays.recommended} days</div>
                                     <div className="text-xs text-gray-600">
                                         Seasonal highlights: {selectedSurpriseOption.events.slice(0, 2).map((event) => `${event.name} (${event.monthLabel})`).join(' • ')}

--- a/components/DetailsPanel.tsx
+++ b/components/DetailsPanel.tsx
@@ -13,6 +13,7 @@ import { ActivityTypeIcon, formatActivityTypeLabel, getActivityTypeButtonClass }
 import { TransportModeIcon } from './TransportModeIcon';
 import { useAppDialog } from './AppDialogProvider';
 import { normalizeTransportMode, TRANSPORT_MODE_UI_ORDER } from '../shared/transportModes';
+import { FlagIcon } from './flags/FlagIcon';
 
 interface DetailsPanelProps {
   item: ITimelineItem | null;
@@ -80,16 +81,6 @@ const appendNotes = (existing: string, addition: string): string => {
     if (!trimmedAddition) return existing;
     if (!trimmedExisting) return trimmedAddition;
     return `${existing.trimEnd()}\n\n${trimmedAddition}`;
-};
-
-const toFlagEmoji = (countryCode?: string): string | null => {
-    if (!countryCode) return null;
-    const upper = countryCode.trim().toUpperCase();
-    if (!/^[A-Z]{2}$/.test(upper)) return null;
-    return upper
-        .split('')
-        .map(char => String.fromCodePoint(127397 + char.charCodeAt(0)))
-        .join('');
 };
 
 const getCountryFromText = (text?: string): { countryName?: string; countryCode?: string } => {
@@ -965,7 +956,6 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
       displayItem.countryCode ||
       getCountryFromText(displayedCityLocation).countryCode
   );
-  const countryFlagForDisplay = toFlagEmoji(countryCodeForDisplay);
   
   const effectiveColor = isActivity ? getActivityColorByTypes(displayItem.activityType) : displayItem.color;
   const usesClassColor = (isActivity || isTransport) ? true : isTailwindCityColorValue(effectiveColor);
@@ -1214,8 +1204,8 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                         <MapPin size={18} className="mr-3 text-accent-500 mt-0.5" />
                         <div className="min-w-0">
                             <div className="flex items-center gap-2">
-                                {countryFlagForDisplay && (
-                                    <span className="text-base leading-none" aria-hidden="true">{countryFlagForDisplay}</span>
+                                {countryCodeForDisplay && (
+                                    <FlagIcon code={countryCodeForDisplay} size="sm" fallback={null} />
                                 )}
                                 <span className="font-medium">{isCity ? (cityDisplayName || 'No city selected') : displayItem.location}</span>
                                 {isCity && (

--- a/components/flags/FlagIcon.tsx
+++ b/components/flags/FlagIcon.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { normalizeFlagCode } from '../../utils/flagUtils';
+
+type FlagIconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+interface FlagIconProps {
+    code?: string | null;
+    value?: string | null;
+    size?: FlagIconSize;
+    className?: string;
+    square?: boolean;
+    rounded?: boolean;
+    fallback?: React.ReactNode;
+    label?: string;
+}
+
+const SIZE_CLASS_MAP: Record<FlagIconSize, string> = {
+    xs: 'text-[10px]',
+    sm: 'text-xs',
+    md: 'text-sm',
+    lg: 'text-base',
+    xl: 'text-xl',
+    '2xl': 'text-2xl',
+};
+
+export const FlagIcon: React.FC<FlagIconProps> = ({
+    code,
+    value,
+    size = 'md',
+    className = '',
+    square = false,
+    rounded = true,
+    fallback = '🌍',
+    label,
+}) => {
+    const normalizedCode = normalizeFlagCode(code || value);
+    const baseClassName = [SIZE_CLASS_MAP[size], 'inline-block shrink-0 align-middle leading-none', className]
+        .filter(Boolean)
+        .join(' ')
+        .trim();
+
+    if (!normalizedCode) {
+        if (!fallback) return null;
+        return (
+            <span
+                className={baseClassName}
+                role={label ? 'img' : undefined}
+                aria-label={label}
+                aria-hidden={label ? undefined : true}
+            >
+                {fallback}
+            </span>
+        );
+    }
+
+    return (
+        <span
+            className={[
+                'fp',
+                normalizedCode,
+                square ? 'fp-square' : '',
+                rounded ? 'fp-rounded' : '',
+                baseClassName,
+            ].filter(Boolean).join(' ')}
+            role={label ? 'img' : undefined}
+            aria-label={label}
+            aria-hidden={label ? undefined : true}
+        />
+    );
+};

--- a/components/marketing/ExampleTripCard.tsx
+++ b/components/marketing/ExampleTripCard.tsx
@@ -13,6 +13,7 @@ import { getDestinationDisplayName } from '../../utils';
 import { getExampleCityLaneViewTransitionName, getExampleMapViewTransitionName, getExampleTitleViewTransitionName } from '../../shared/viewTransitionNames';
 import { ProgressiveImage } from '../ProgressiveImage';
 import { buildBlurhashEndpointUrl, isImageCdnEnabled } from '../../utils/imageDelivery';
+import { FlagIcon } from '../flags/FlagIcon';
 
 interface ExampleTripCardProps {
     card: ExampleTripCardType;
@@ -172,7 +173,7 @@ export const ExampleTripCard: React.FC<ExampleTripCardProps> = ({
                 <div className="mt-1.5 flex items-center gap-1.5 text-sm text-slate-600">
                     {card.countries.map((c) => (
                         <span key={c.name} className="inline-flex items-center gap-1">
-                            <span>{c.flag}</span>
+                            <FlagIcon value={c.flag} />
                             <span>{getDestinationDisplayName(c.name, currentLocale)}</span>
                         </span>
                     ))}

--- a/components/navigation/LanguageSelect.tsx
+++ b/components/navigation/LanguageSelect.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { AppLanguage } from '../../types';
 import { LOCALE_DROPDOWN_ORDER, LOCALE_FLAGS, LOCALE_LABELS, normalizeLocale } from '../../config/locales';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '../ui/select';
+import { FlagIcon } from '../flags/FlagIcon';
 
 interface LanguageSelectProps {
     value: AppLanguage;
@@ -25,7 +26,7 @@ export const LanguageSelect: React.FC<LanguageSelectProps> = ({
         >
             <SelectTrigger aria-label={ariaLabel} className={triggerClassName}>
                 <span className="inline-flex items-center gap-2 truncate">
-                    <span aria-hidden="true">{LOCALE_FLAGS[value]}</span>
+                    <FlagIcon code={LOCALE_FLAGS[value]} size="sm" />
                     <span>{LOCALE_LABELS[value]}</span>
                 </span>
             </SelectTrigger>
@@ -36,9 +37,9 @@ export const LanguageSelect: React.FC<LanguageSelectProps> = ({
                 className="rounded-xl border-slate-200 bg-white p-1 shadow-xl"
             >
                 {LOCALE_DROPDOWN_ORDER.map((locale) => (
-                    <SelectItem key={locale} value={locale} className="rounded-lg py-2.5">
+                    <SelectItem key={locale} value={locale} indicatorPosition="right" className="rounded-lg py-2.5">
                         <span className="inline-flex items-center gap-2 font-medium">
-                            <span aria-hidden="true">{LOCALE_FLAGS[locale]}</span>
+                            <FlagIcon code={LOCALE_FLAGS[locale]} size="sm" />
                             <span>{LOCALE_LABELS[locale]}</span>
                         </span>
                     </SelectItem>

--- a/components/navigation/LanguageSuggestionBanner.tsx
+++ b/components/navigation/LanguageSuggestionBanner.tsx
@@ -3,11 +3,12 @@ import { X, Translate } from '@phosphor-icons/react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { extractLocaleFromPath, getNamespacesForMarketingPath, isToolRoute } from '../../config/routes';
 import { AppLanguage } from '../../types';
-import { applyDocumentLocale, DEFAULT_LOCALE, SUPPORTED_LOCALES } from '../../config/locales';
+import { applyDocumentLocale, DEFAULT_LOCALE, LOCALE_FLAGS, SUPPORTED_LOCALES } from '../../config/locales';
 import { APP_NAME } from '../../config/appGlobals';
 import { buildLocalizedLocation } from '../../services/localeRoutingService';
 import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analyticsService';
 import i18n, { preloadLocaleNamespaces } from '../../i18n';
+import { FlagIcon } from '../flags/FlagIcon';
 
 const SESSION_DISMISS_KEY = 'tf_locale_suggestion_dismissed_session';
 const SWITCH_ACK_KEY = 'tf_locale_suggestion_switched';
@@ -16,49 +17,49 @@ const MESSAGE_BY_LOCALE: Record<AppLanguage, { message: string; action: string; 
     en: {
         message: 'This page is also available in English.',
         action: `Try ${APP_NAME} in English`,
-        actionShort: '🇬🇧 English',
+        actionShort: 'English',
         dismiss: 'Dismiss language suggestion',
     },
     es: {
         message: 'Esta página también está disponible en español.',
         action: `Probar ${APP_NAME} en español`,
-        actionShort: '🇪🇸 Español',
+        actionShort: 'Español',
         dismiss: 'Cerrar sugerencia de idioma',
     },
     de: {
         message: 'Diese Seite ist auch auf Deutsch verfügbar.',
         action: `${APP_NAME} auf Deutsch testen`,
-        actionShort: '🇩🇪 Deutsch',
+        actionShort: 'Deutsch',
         dismiss: 'Sprachhinweis schließen',
     },
     fr: {
         message: 'Cette page est également disponible en français.',
         action: `Essayer ${APP_NAME} en français`,
-        actionShort: '🇫🇷 Français',
+        actionShort: 'Français',
         dismiss: 'Fermer la suggestion de langue',
     },
     ru: {
         message: 'Эта страница также доступна на русском языке.',
         action: `Попробовать ${APP_NAME} на русском`,
-        actionShort: '🇷🇺 Русский',
+        actionShort: 'Русский',
         dismiss: 'Закрыть подсказку языка',
     },
     pt: {
         message: 'Esta página também está disponível em português.',
         action: `Experimentar ${APP_NAME} em português`,
-        actionShort: '🇵🇹 Português',
+        actionShort: 'Português',
         dismiss: 'Fechar sugestão de idioma',
     },
     it: {
         message: 'Questa pagina è disponibile anche in italiano.',
         action: `Prova ${APP_NAME} in italiano`,
-        actionShort: '🇮🇹 Italiano',
+        actionShort: 'Italiano',
         dismiss: 'Chiudi suggerimento lingua',
     },
     pl: {
         message: 'Ta strona jest również dostępna po polsku.',
         action: `Wypróbuj ${APP_NAME} po polsku`,
-        actionShort: '🇵🇱 Polski',
+        actionShort: 'Polski',
         dismiss: 'Zamknij podpowiedź języka',
     },
 };
@@ -182,7 +183,10 @@ export const LanguageSuggestionBanner: React.FC = () => {
                         source: 'language_banner',
                     })}
                 >
-                    <span className="sm:hidden">{copy.actionShort}</span>
+                    <span className="inline-flex items-center gap-1 sm:hidden">
+                        <FlagIcon code={LOCALE_FLAGS[suggestedLocale]} size="sm" />
+                        {copy.actionShort}
+                    </span>
                     <span className="hidden sm:inline">{copy.action}</span>
                 </button>
                 <button

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -112,20 +112,30 @@ const SelectLabel = React.forwardRef<
 ));
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
+interface SelectItemProps extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> {
+  indicatorPosition?: 'left' | 'right';
+}
+
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+  SelectItemProps
+>(({ className, children, indicatorPosition = 'left', ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
     className={[
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-2 pl-8 pr-2 text-sm text-slate-800 outline-none',
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-2 text-sm text-slate-800 outline-none',
+      indicatorPosition === 'right' ? 'pl-2 pr-8' : 'pl-8 pr-2',
       'data-[highlighted]:bg-accent-50 data-[highlighted]:text-accent-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className || '',
     ].join(' ')}
     {...props}
   >
-    <span className="absolute left-2 top-1/2 flex h-3.5 w-3.5 -translate-y-1/2 items-center justify-center">
+    <span
+      className={[
+        'absolute top-1/2 flex h-3.5 w-3.5 -translate-y-1/2 items-center justify-center',
+        indicatorPosition === 'right' ? 'right-2' : 'left-2',
+      ].join(' ')}
+    >
       <SelectPrimitive.ItemIndicator>
         <Check className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>

--- a/config/locales.ts
+++ b/config/locales.ts
@@ -64,18 +64,18 @@ export const LOCALE_LABELS: Record<AppLanguage, string> = {
 };
 
 export const LOCALE_FLAGS: Record<AppLanguage, string> = {
-    en: '🇬🇧',
-    es: '🇪🇸',
-    de: '🇩🇪',
-    fr: '🇫🇷',
-    pt: '🇵🇹',
-    ru: '🇷🇺',
-    it: '🇮🇹',
-    pl: '🇵🇱',
+    en: 'GB',
+    es: 'ES',
+    de: 'DE',
+    fr: 'FR',
+    pt: 'PT',
+    ru: 'RU',
+    it: 'IT',
+    pl: 'PL',
 };
 
 export const formatLocaleOptionLabel = (locale: AppLanguage): string => {
-    return `${LOCALE_FLAGS[locale]} ${LOCALE_LABELS[locale]}`;
+    return LOCALE_LABELS[locale];
 };
 
 export const applyDocumentLocale = (locale: AppLanguage): void => {

--- a/content/updates/2026-02-16-flagpack-real-flags.md
+++ b/content/updates/2026-02-16-flagpack-real-flags.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-02-16-flagpack-real-flags
+version: v0.41.0
+title: "Flagpack rollout for consistent real flags"
+date: 2026-02-16
+published_at: 2026-02-16T06:51:35Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Replaced emoji flag rendering with a shared Flagpack-based flag component across planner, inspiration, blog, and language UI."
+---
+
+## Changes
+- [x] [Improved] 🏳️ Replaced emoji-flag rendering with real SVG flags in planner destination chips, pickers, labs, and country context cards.
+- [x] [Improved] 🌐 Updated language selectors, language suggestions, and English-article notices to use the new shared flag system.
+- [x] [Improved] 🧭 Updated inspirations cards, country pills, and trip-list row flags to render through `FlagIcon` for consistent display.
+- [ ] [Internal] 📘 Added destination-system guidance to use `FlagIcon` + `flagpack` for all future flag-related UI work.

--- a/docs/DESTINATION_SYSTEM.md
+++ b/docs/DESTINATION_SYSTEM.md
@@ -24,6 +24,15 @@ All lookup maps live in `utils.ts` and are built once at module load time.
 
 ---
 
+## Flag Rendering Standard
+
+- Do not render emoji flags directly in UI components.
+- Use `components/flags/FlagIcon.tsx` for any flag display.
+- `FlagIcon` is backed by `flagpack` and accepts ISO codes or legacy emoji values.
+- For new work, prefer ISO flag codes (`US`, `DE`, `GB-SCT`) over hardcoded emoji strings.
+
+---
+
 ## Data Sources
 
 ### 1. `COUNTRIES` array — `utils.ts:782`
@@ -31,7 +40,7 @@ All lookup maps live in `utils.ts` and are built once at module load time.
 Static array of ~195 sovereign countries. Each entry:
 
 ```ts
-{ name: "Japan", code: "JP", flag: "🇯🇵" }
+{ name: "Japan", code: "JP", flag: "JP" } // or legacy emoji, rendered via FlagIcon
 ```
 
 - `code` = **ISO 3166-1 alpha-2** (uppercase, 2 chars)

--- a/index.css
+++ b/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "flagpack/dist/flagpack.css";
 
 @font-face {
   font-family: "Bricolage Grotesque";

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@supabase/supabase-js": "^2.49.1",
         "@types/google.maps": "^3.58.1",
         "blurhash": "^2.0.5",
+        "flagpack": "^1.0.5",
         "i18next": "^25.6.0",
         "i18next-browser-languagedetector": "^8.2.0",
         "i18next-icu": "^2.4.1",
@@ -3619,6 +3620,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/flagpack": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/flagpack/-/flagpack-1.0.5.tgz",
+      "integrity": "sha512-jrb3OEoVXPBXjmhwZq6C9DTH6Axarh+rfnT3kA5T4xQ2FD9MogwCasqNJnMvhHHkaEVryXwQf1MQvqVv8UsK3g==",
+      "license": "MIT"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@supabase/supabase-js": "^2.49.1",
     "@types/google.maps": "^3.58.1",
     "blurhash": "^2.0.5",
+    "flagpack": "^1.0.5",
     "i18next": "^25.6.0",
     "i18next-browser-languagedetector": "^8.2.0",
     "i18next-icu": "^2.4.1",

--- a/pages/BlogPage.tsx
+++ b/pages/BlogPage.tsx
@@ -5,6 +5,7 @@ import { Article, Clock, Tag, ArrowRight, MagnifyingGlass, GlobeHemisphereWest }
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
 import { getPublishedBlogPostsForLocales } from '../services/blogService';
 import { ProgressiveImage } from '../components/ProgressiveImage';
+import { FlagIcon } from '../components/flags/FlagIcon';
 import type { BlogPost } from '../services/blogService';
 import { buildLocalizedMarketingPath, extractLocaleFromPath } from '../config/routes';
 import { DEFAULT_LOCALE, localeToIntlLocale } from '../config/locales';
@@ -65,7 +66,7 @@ const BlogCard: React.FC<{ post: BlogPost; locale: AppLanguage }> = ({ post, loc
                 </h3>
                 {showEnglishBadge && (
                     <p className="mt-2 inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-800">
-                        <span aria-hidden="true">🇬🇧</span>
+                        <FlagIcon code="GB" size="sm" />
                         {t('index.englishArticleNotice')}
                     </p>
                 )}

--- a/pages/BlogPostPage.tsx
+++ b/pages/BlogPostPage.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
 import { ProgressiveImage } from '../components/ProgressiveImage';
+import { FlagIcon } from '../components/flags/FlagIcon';
 import { getBlogPostBySlugWithFallback, getPublishedBlogPostsForLocales } from '../services/blogService';
 import { buildLocalizedMarketingPath, buildPath, extractLocaleFromPath } from '../config/routes';
 import { DEFAULT_LOCALE, localeToIntlLocale } from '../config/locales';
@@ -220,7 +221,7 @@ export const BlogPostPage: React.FC = () => {
                 {showEnglishContentNotice && (
                     <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900">
                         <span className="inline-flex items-center gap-1.5">
-                            <span aria-hidden="true">🇬🇧</span>
+                            <FlagIcon code="GB" size="sm" />
                             {t('index.englishArticleNotice')}
                         </span>
                     </div>

--- a/pages/CreateTripClassicLabPage.tsx
+++ b/pages/CreateTripClassicLabPage.tsx
@@ -41,6 +41,7 @@ import { SiteHeader } from '../components/navigation/SiteHeader';
 import { SiteFooter } from '../components/marketing/SiteFooter';
 import { DateRangePicker } from '../components/DateRangePicker';
 import { IdealTravelTimeline } from '../components/IdealTravelTimeline';
+import { FlagIcon } from '../components/flags/FlagIcon';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/dialog';
 import { Drawer, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle } from '../components/ui/drawer';
 import { Switch } from '../components/ui/switch';
@@ -1492,7 +1493,10 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
                                                         <div className="flex items-start justify-between gap-3">
                                                             <div className="min-w-0">
                                                                 <div className="truncate text-sm font-medium text-slate-800">
-                                                                    {option.flag} {optionLabel}
+                                                                    <span className="inline-flex items-center gap-1.5">
+                                                                        <FlagIcon value={option.flag} />
+                                                                        {optionLabel}
+                                                                    </span>
                                                                 </div>
                                                                 {islandMeta && (
                                                                     <div className="mt-0.5 text-xs text-slate-500">
@@ -1544,7 +1548,7 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
                                                                 <DotsSixVertical size={12} weight="duotone" />
                                                             </span>
                                                         )}
-                                                        <span>{option?.flag || '🌍'}</span>
+                                                        <FlagIcon value={option?.flag || '🌍'} />
                                                         <span>{destinationLabel}</span>
                                                         <button
                                                             type="button"
@@ -2027,7 +2031,7 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
                                                             ref={(node) => setSnapshotNodeRef(index, node)}
                                                             className="relative z-10 flex h-8 w-8 items-center justify-center rounded-full border border-white/30 bg-[#0f173b] text-sm shadow-lg shadow-black/20"
                                                         >
-                                                            {option?.flag || '🌍'}
+                                                            <FlagIcon value={option?.flag || '🌍'} size="xs" />
                                                         </div>
                                                         <div className="min-w-0 pt-0.5">
                                                             <div className="text-sm font-semibold text-indigo-50">{getLocalizedDestinationLabel(destination)}</div>

--- a/pages/CreateTripJourneyArchitectLabPage.tsx
+++ b/pages/CreateTripJourneyArchitectLabPage.tsx
@@ -15,6 +15,7 @@ import {
 } from '@phosphor-icons/react';
 import { SiteHeader } from '../components/navigation/SiteHeader';
 import { SiteFooter } from '../components/marketing/SiteFooter';
+import { FlagIcon } from '../components/flags/FlagIcon';
 import { useDbSync } from '../hooks/useDbSync';
 import { AppLanguage } from '../types';
 import { buildCreateTripUrl, getDestinationOptionByName, resolveDestinationName, searchDestinationOptions } from '../utils';
@@ -292,7 +293,7 @@ export const CreateTripJourneyArchitectLabPage: React.FC<CreateTripJourneyArchit
                                                             key={destination}
                                                             className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-sm text-slate-700"
                                                         >
-                                                            {option?.flag || '🌍'} {destination}
+                                                            <FlagIcon value={option?.flag || '🌍'} /> {destination}
                                                             <button
                                                                 type="button"
                                                                 onClick={() => removeDestination(destination)}
@@ -334,7 +335,10 @@ export const CreateTripJourneyArchitectLabPage: React.FC<CreateTripJourneyArchit
                                                             }}
                                                             className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-left text-sm text-slate-700 transition-colors hover:border-amber-300"
                                                         >
-                                                            {option.flag} {option.name}
+                                                            <span className="inline-flex items-center gap-1.5">
+                                                                <FlagIcon value={option.flag} />
+                                                                {option.name}
+                                                            </span>
                                                         </button>
                                                     ))}
                                                     {suggestions.length === 0 && (

--- a/pages/CreateTripSplitWorkspaceLabPage.tsx
+++ b/pages/CreateTripSplitWorkspaceLabPage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@phosphor-icons/react';
 import { SiteHeader } from '../components/navigation/SiteHeader';
 import { SiteFooter } from '../components/marketing/SiteFooter';
+import { FlagIcon } from '../components/flags/FlagIcon';
 import { useDbSync } from '../hooks/useDbSync';
 import { AppLanguage } from '../types';
 import { buildCreateTripUrl, getDestinationOptionByName, resolveDestinationName, searchDestinationOptions } from '../utils';
@@ -188,7 +189,7 @@ export const CreateTripSplitWorkspaceLabPage: React.FC<CreateTripSplitWorkspaceL
                                                         key={destination}
                                                         className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-3 py-1 text-sm"
                                                     >
-                                                        {option?.flag || '🌍'} {destination}
+                                                        <FlagIcon value={option?.flag || '🌍'} /> {destination}
                                                         <button
                                                             type="button"
                                                             onClick={() => removeDestination(destination)}
@@ -230,7 +231,10 @@ export const CreateTripSplitWorkspaceLabPage: React.FC<CreateTripSplitWorkspaceL
                                                         }}
                                                         className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-slate-200 transition-colors hover:border-cyan-300/60"
                                                     >
-                                                        <span>{option.flag} {option.name}</span>
+                                                        <span className="inline-flex items-center gap-1.5">
+                                                            <FlagIcon value={option.flag} />
+                                                            {option.name}
+                                                        </span>
                                                         <Plus size={14} className="text-cyan-200" />
                                                     </button>
                                                 ))}
@@ -433,7 +437,10 @@ export const CreateTripSplitWorkspaceLabPage: React.FC<CreateTripSplitWorkspaceL
                                         return (
                                             <div key={destination} className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">
                                                 <div className="flex items-center justify-between text-sm">
-                                                    <span className="font-medium text-slate-100">{option?.flag || '🌍'} {destination}</span>
+                                                    <span className="font-medium text-slate-100 inline-flex items-center gap-1.5">
+                                                        <FlagIcon value={option?.flag || '🌍'} />
+                                                        {destination}
+                                                    </span>
                                                     <span className="text-cyan-200">{nights} night{nights === 1 ? '' : 's'}</span>
                                                 </div>
                                                 <div className="mt-1 text-xs text-slate-400">Stop {index + 1} of {destinations.length}</div>

--- a/pages/CreateTripV1Page.tsx
+++ b/pages/CreateTripV1Page.tsx
@@ -44,6 +44,7 @@ import { TripGenerationSkeleton } from '../components/TripGenerationSkeleton';
 import { HeroWebGLBackground } from '../components/HeroWebGLBackground';
 import { SiteFooter } from '../components/marketing/SiteFooter';
 import { SiteHeader } from '../components/navigation/SiteHeader';
+import { FlagIcon } from '../components/flags/FlagIcon';
 import {
     getCommonBestMonths,
     getCountrySeasonByName,
@@ -744,24 +745,27 @@ export const CreateTripV1Page: React.FC<CreateTripV1PageProps> = ({ onTripGenera
                         <div className="flex flex-wrap gap-2 text-xs text-gray-500">
                             <button
                                 type="button"
-                                className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
                                 onClick={() => fillExample('Italy', 14, 'Rome, Florence, Venice. Art & Food.')}
                             >
-                                🇮🇹 2 Weeks in Italy
+                                <FlagIcon code="IT" />
+                                2 Weeks in Italy
                             </button>
                             <button
                                 type="button"
-                                className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
                                 onClick={() => fillExample('Japan', 7, 'Anime, Tech, and Sushi.')}
                             >
-                                🇯🇵 7 Days in Japan
+                                <FlagIcon code="JP" />
+                                7 Days in Japan
                             </button>
                             <button
                                 type="button"
-                                className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm"
                                 onClick={() => onTripGenerated(createThailandTrip(new Date().toISOString()))}
                             >
-                                🇹🇭 Thailand (Test Plan)
+                                <FlagIcon code="TH" />
+                                Thailand (Test Plan)
                             </button>
                         </div>
                     </div>

--- a/pages/CreateTripV2Page.tsx
+++ b/pages/CreateTripV2Page.tsx
@@ -45,6 +45,7 @@ import { TripView } from '../components/TripView';
 import { TripGenerationSkeleton } from '../components/TripGenerationSkeleton';
 import { SiteFooter } from '../components/marketing/SiteFooter';
 import { SiteHeader } from '../components/navigation/SiteHeader';
+import { FlagIcon } from '../components/flags/FlagIcon';
 import {
     getCommonBestMonths,
     getCountrySeasonByName,
@@ -131,7 +132,7 @@ const CountryContextCard: React.FC<{ countryName: string }> = ({ countryName }) 
     return (
         <div className="rounded-2xl border border-gray-100 bg-white/80 backdrop-blur-sm p-4 shadow-sm">
             <div className="flex items-center gap-2.5 mb-3">
-                <span className="text-2xl">{flag}</span>
+                <FlagIcon value={flag} size="xl" />
                 <div>
                     <div className="text-sm font-semibold text-gray-900">{countryName}</div>
                     {season?.climate && <div className="text-xs text-gray-500">{season.climate}</div>}
@@ -684,14 +685,17 @@ export const CreateTripV2Page: React.FC<CreateTripV2PageProps> = ({ onTripGenera
 
                         {/* Quick examples */}
                         <div className="flex flex-wrap gap-2 text-xs text-gray-500">
-                            <button type="button" className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm" onClick={() => fillExample('Italy', 14, 'Rome, Florence, Venice. Art & Food.')}>
-                                🇮🇹 2 Weeks in Italy
+                            <button type="button" className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm" onClick={() => fillExample('Italy', 14, 'Rome, Florence, Venice. Art & Food.')}>
+                                <FlagIcon code="IT" />
+                                2 Weeks in Italy
                             </button>
-                            <button type="button" className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm" onClick={() => fillExample('Japan', 7, 'Anime, Tech, and Sushi.')}>
-                                🇯🇵 7 Days in Japan
+                            <button type="button" className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm" onClick={() => fillExample('Japan', 7, 'Anime, Tech, and Sushi.')}>
+                                <FlagIcon code="JP" />
+                                7 Days in Japan
                             </button>
-                            <button type="button" className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm" onClick={() => onTripGenerated(createThailandTrip(new Date().toISOString()))}>
-                                🇹🇭 Thailand (Test Plan)
+                            <button type="button" className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm" onClick={() => onTripGenerated(createThailandTrip(new Date().toISOString()))}>
+                                <FlagIcon code="TH" />
+                                Thailand (Test Plan)
                             </button>
                         </div>
                     </form>

--- a/pages/CreateTripV3Page.tsx
+++ b/pages/CreateTripV3Page.tsx
@@ -41,6 +41,7 @@ import { TripGenerationSkeleton } from '../components/TripGenerationSkeleton';
 import { HeroWebGLBackground } from '../components/HeroWebGLBackground';
 import { SiteFooter } from '../components/marketing/SiteFooter';
 import { SiteHeader } from '../components/navigation/SiteHeader';
+import { FlagIcon } from '../components/flags/FlagIcon';
 import {
     getCommonBestMonths,
     getCountrySeasonByName,
@@ -115,19 +116,19 @@ const VIBE_CARDS: SelectionCardConfig[] = [
 // Popular picks for step 1
 interface PopularPick {
     name: string;
-    flag: string;
+    flagCode: string;
     bestMonths: string;
 }
 
 const POPULAR_PICKS: PopularPick[] = [
-    { name: 'Japan', flag: '🇯🇵', bestMonths: 'Mar-May, Sep-Nov' },
-    { name: 'Italy', flag: '🇮🇹', bestMonths: 'Apr-Jun, Sep-Oct' },
-    { name: 'Thailand', flag: '🇹🇭', bestMonths: 'Nov-Feb' },
-    { name: 'Portugal', flag: '🇵🇹', bestMonths: 'Apr-Oct' },
-    { name: 'Greece', flag: '🇬🇷', bestMonths: 'May-Oct' },
-    { name: 'New Zealand', flag: '🇳🇿', bestMonths: 'Dec-Mar' },
-    { name: 'Morocco', flag: '🇲🇦', bestMonths: 'Mar-May, Sep-Nov' },
-    { name: 'South Korea', flag: '🇰🇷', bestMonths: 'Apr-Jun, Sep-Nov' },
+    { name: 'Japan', flagCode: 'JP', bestMonths: 'Mar-May, Sep-Nov' },
+    { name: 'Italy', flagCode: 'IT', bestMonths: 'Apr-Jun, Sep-Oct' },
+    { name: 'Thailand', flagCode: 'TH', bestMonths: 'Nov-Feb' },
+    { name: 'Portugal', flagCode: 'PT', bestMonths: 'Apr-Oct' },
+    { name: 'Greece', flagCode: 'GR', bestMonths: 'May-Oct' },
+    { name: 'New Zealand', flagCode: 'NZ', bestMonths: 'Dec-Mar' },
+    { name: 'Morocco', flagCode: 'MA', bestMonths: 'Mar-May, Sep-Nov' },
+    { name: 'South Korea', flagCode: 'KR', bestMonths: 'Apr-Jun, Sep-Nov' },
 ];
 
 const BUDGET_OPTIONS = ['Budget', 'Medium', 'Premium', 'Luxury'] as const;
@@ -512,7 +513,7 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
                                             onClick={() => removeCountry(c)}
                                             className="flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3 py-1.5 text-xs font-medium text-accent-700 hover:bg-accent-100 transition-colors"
                                         >
-                                            <span>{dest?.flag || season?.flag || fb?.flag || '🌍'}</span>
+                                            <FlagIcon value={dest?.flag || season?.flag || fb?.flag || '🌍'} />
                                             <span>{c}</span>
                                             <span className="text-accent-400">×</span>
                                         </button>
@@ -538,7 +539,7 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
                                                     : 'border-gray-200 bg-white hover:border-accent-300 hover:bg-accent-50/40',
                                             ].join(' ')}
                                         >
-                                            <span className="text-3xl mb-1">{pick.flag}</span>
+                                            <FlagIcon code={pick.flagCode} size="2xl" className="mb-1" />
                                             <span className="text-sm font-semibold text-gray-900">{pick.name}</span>
                                             <span className="text-[10px] text-gray-500 mt-0.5">{pick.bestMonths}</span>
                                             {isSelected && (
@@ -913,8 +914,9 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
 
                         {/* Quick examples */}
                         <div className="mt-5 flex flex-wrap justify-center gap-2 text-xs text-gray-500">
-                            <button type="button" className="px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm" onClick={() => onTripGenerated(createThailandTrip(new Date().toISOString()))}>
-                                🇹🇭 Thailand (Test Plan)
+                            <button type="button" className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-gray-200 rounded-full hover:border-accent-300 hover:text-accent-600 transition-all shadow-sm" onClick={() => onTripGenerated(createThailandTrip(new Date().toISOString()))}>
+                                <FlagIcon code="TH" />
+                                Thailand (Test Plan)
                             </button>
                         </div>
                     </div>

--- a/pages/InspirationsPage.tsx
+++ b/pages/InspirationsPage.tsx
@@ -17,6 +17,7 @@ import {
 } from '@phosphor-icons/react';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
 import { ProgressiveImage } from '../components/ProgressiveImage';
+import { FlagIcon } from '../components/flags/FlagIcon';
 import { getAnalyticsDebugAttributes, trackEvent } from '../services/analyticsService';
 import {
     categories,
@@ -30,6 +31,7 @@ import {
 import type { Destination, FestivalEvent as FestivalEventType, WeekendGetaway as WeekendGetawayType, CountryGroup, QuickIdea } from '../data/inspirationsData';
 import { getBlogPostsBySlugs } from '../services/blogService';
 import { buildCreateTripUrl, resolveDestinationCodes } from '../utils';
+import { stripLeadingFlagEmoji } from '../utils/flagUtils';
 import { destinationCardMedia, festivalCardMedia } from '../data/inspirationCardMedia';
 import { buildLocalizedMarketingPath, extractLocaleFromPath } from '../config/routes';
 import { DEFAULT_LOCALE } from '../config/locales';
@@ -176,7 +178,8 @@ const DestinationCard: React.FC<{ destination: Destination }> = ({ destination }
                 <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 text-xs">
                     <span className="inline-flex items-center gap-1 font-semibold text-slate-600">
                         <MapPin size={13} weight="duotone" className="text-accent-400" />
-                        {destination.flag} {destination.country}
+                        <FlagIcon value={destination.flag} />
+                        {destination.country}
                     </span>
                     <div className="flex items-center gap-3 text-slate-400">
                         <span className="inline-flex items-center gap-1"><Clock size={13} weight="duotone" className="text-accent-400" />{destination.durationDays} days</span>
@@ -246,7 +249,10 @@ const FestivalCard: React.FC<{ event: FestivalEventType; nextDate: Date }> = ({ 
         </div>
         <div className="flex flex-1 flex-col p-4">
             <h3 className="text-base font-bold text-slate-900 group-hover:text-accent-700 transition-colors">{event.name}</h3>
-            <p className="mt-1 line-clamp-1 text-xs font-medium text-slate-400">{event.flag} {locationLabel}</p>
+            <p className="mt-1 line-clamp-1 text-xs font-medium text-slate-400 inline-flex items-center gap-1.5">
+                <FlagIcon value={event.flag} />
+                {locationLabel}
+            </p>
             <p className="mt-0.5 text-xs font-semibold text-fuchsia-600">Next: {formatFestivalDate(nextDate)}</p>
             <p className="mt-1.5 flex-1 text-sm leading-relaxed text-slate-500 line-clamp-2">{event.description}</p>
             <div className="mt-3 flex items-center gap-1 text-xs text-slate-400">
@@ -290,7 +296,10 @@ const GetawayCard: React.FC<{ getaway: WeekendGetawayType }> = ({ getaway }) => 
         </div>
         <div className="min-w-0 flex-1">
             <h3 className="text-base font-bold text-slate-900 group-hover:text-accent-700 transition-colors">{getaway.title}</h3>
-            <p className="mt-0.5 text-xs font-medium text-slate-400">{getaway.flag} {getaway.to} · {getaway.durationDays} days</p>
+            <p className="mt-0.5 text-xs font-medium text-slate-400 inline-flex items-center gap-1.5">
+                <FlagIcon value={getaway.flag} />
+                {getaway.to} · {getaway.durationDays} days
+            </p>
             <p className="mt-1.5 text-sm leading-relaxed text-slate-500 line-clamp-2">{getaway.description}</p>
             {getaway.blogSlugs && getaway.blogSlugs.length > 0 && (
                 <div className="mt-2">
@@ -312,7 +321,7 @@ const CountryPill: React.FC<{ group: CountryGroup }> = ({ group }) => (
         className={`group flex items-center gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm ${CARD_HOVER_TRANSITION} hover:-translate-y-0.5 hover:shadow-lg`}
         {...getAnalyticsDebugAttributes('inspirations__country_pill', { country: group.country })}
     >
-        <span className="text-3xl">{group.flag}</span>
+        <FlagIcon value={group.flag} size="2xl" />
         <div className="min-w-0 flex-1">
             <h3 className="text-sm font-bold text-slate-900 group-hover:text-accent-700 transition-colors">{group.country}</h3>
             <p className="text-xs text-slate-400">{group.bestMonths}</p>
@@ -498,18 +507,22 @@ export const InspirationsPage: React.FC = () => {
                         <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">{t('inspirations.quickStart')}</h2>
                         <div className="flex flex-wrap gap-2">
                             {quickIdeas.map((idea) => {
+                                const ideaLabel = stripLeadingFlagEmoji(idea.label);
                                 const start = suggestedStartForDays(idea.days);
                                 const end = addDaysLocal(start, idea.days - 1);
                                 const countries = resolveDestinationCodes([idea.destinationCode]);
                                 return (
                                     <Link
                                         key={idea.label}
-                                        to={buildCreateTripUrl({ countries, startDate: toIso(start), endDate: toIso(end), meta: { source: 'inspirations', label: idea.label } })}
-                                        onClick={() => trackEvent('inspirations__quick_pill', { label: idea.label })}
+                                        to={buildCreateTripUrl({ countries, startDate: toIso(start), endDate: toIso(end), meta: { source: 'inspirations', label: ideaLabel } })}
+                                        onClick={() => trackEvent('inspirations__quick_pill', { label: ideaLabel })}
                                         className="rounded-full border border-slate-200 bg-white px-3.5 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition-all hover:border-accent-300 hover:text-accent-700 hover:shadow-md hover:scale-[1.03] active:scale-[0.98]"
-                                        {...getAnalyticsDebugAttributes('inspirations__quick_pill', { label: idea.label })}
+                                        {...getAnalyticsDebugAttributes('inspirations__quick_pill', { label: ideaLabel })}
                                     >
-                                        {idea.label}
+                                        <span className="inline-flex items-center gap-1.5">
+                                            <FlagIcon code={idea.destinationCode} />
+                                            {ideaLabel}
+                                        </span>
                                     </Link>
                                 );
                             })}

--- a/pages/inspirations/CountryDetailPage.tsx
+++ b/pages/inspirations/CountryDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, Link, useLocation } from 'react-router-dom';
 import { ArrowLeft, Globe, ArrowRight } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import { MarketingLayout } from '../../components/marketing/MarketingLayout';
+import { FlagIcon } from '../../components/flags/FlagIcon';
 import { countryGroups } from '../../data/inspirationsData';
 import { buildLocalizedMarketingPath, extractLocaleFromPath } from '../../config/routes';
 import { DEFAULT_LOCALE } from '../../config/locales';
@@ -63,7 +64,10 @@ export const CountryDetailPage: React.FC = () => {
                     className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl"
                     style={{ fontFamily: "var(--tf-font-heading)" }}
                 >
-                    {country.flag} {t('inspirations.subpages.country.title', { country: country.country })}
+                    <span className="inline-flex items-center gap-2">
+                        <FlagIcon value={country.flag} size="2xl" />
+                        {t('inspirations.subpages.country.title', { country: country.country })}
+                    </span>
                 </h1>
                 <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
                     {t('inspirations.subpages.country.description', { country: country.country })}

--- a/utils/flagUtils.ts
+++ b/utils/flagUtils.ts
@@ -1,0 +1,53 @@
+const REGIONAL_INDICATOR_START = 0x1f1e6;
+const REGIONAL_INDICATOR_END = 0x1f1ff;
+const ASCII_A = 65;
+
+const REGIONAL_FLAG_EMOJI_REGEX = /[\u{1F1E6}-\u{1F1FF}]{2}/u;
+const LEADING_FLAG_EMOJI_REGEX = /^\s*(?:🏴|[\u{1F1E6}-\u{1F1FF}]{2})\s*/u;
+const FLAG_CODE_REGEX = /^[a-z]{2}(?:-[a-z]{2,4})?$/;
+
+export const SCOTLAND_FLAG_CODE = 'gb-sct';
+
+const isRegionalIndicator = (codePoint: number): boolean =>
+    codePoint >= REGIONAL_INDICATOR_START && codePoint <= REGIONAL_INDICATOR_END;
+
+const regionalPairToCode = (flagEmoji: string): string | null => {
+    const chars = Array.from(flagEmoji);
+    if (chars.length !== 2) return null;
+
+    const codePoints = chars.map((char) => char.codePointAt(0));
+    if (codePoints.some((codePoint) => typeof codePoint !== 'number')) return null;
+
+    const [first, second] = codePoints as number[];
+    if (!isRegionalIndicator(first) || !isRegionalIndicator(second)) return null;
+
+    const firstChar = String.fromCharCode(ASCII_A + (first - REGIONAL_INDICATOR_START));
+    const secondChar = String.fromCharCode(ASCII_A + (second - REGIONAL_INDICATOR_START));
+    return `${firstChar}${secondChar}`.toLowerCase();
+};
+
+export const normalizeFlagCode = (value?: string | null): string | null => {
+    if (!value) return null;
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === '🌍') return null;
+
+    const normalizedCodeCandidate = trimmed
+        .replace(/_/g, '-')
+        .replace(/\s+/g, '')
+        .toLowerCase();
+    if (FLAG_CODE_REGEX.test(normalizedCodeCandidate)) {
+        return normalizedCodeCandidate;
+    }
+
+    if (trimmed.includes('🏴')) {
+        return SCOTLAND_FLAG_CODE;
+    }
+
+    const regionalMatch = trimmed.match(REGIONAL_FLAG_EMOJI_REGEX);
+    if (!regionalMatch) return null;
+    return regionalPairToCode(regionalMatch[0]);
+};
+
+export const stripLeadingFlagEmoji = (value: string): string => {
+    return value.replace(LEADING_FLAG_EMOJI_REGEX, '').trim();
+};


### PR DESCRIPTION
## Summary
- replace emoji-based flag rendering with shared Flagpack-powered `FlagIcon`
- update planner, inspirations, blog notices, language controls, trip manager, and details panel to use real flags
- add flag usage guidance in destination docs and release note entry
- move language dropdown selected checkmark indicator to the right side

## Validation
- npm run build
- npm run updates:validate