### PR TITLE
Fix auth-hydration trip expiry fallback and highlight KR launch

### DIFF
--- a/content/updates/2026-02-13-auth-roles-pricing-guest-queue.md
+++ b/content/updates/2026-02-13-auth-roles-pricing-guest-queue.md
@@ -7,10 +7,12 @@ published_at: 2026-02-13T14:06:09Z
 status: published
 notify_in_app: true
 in_app_hours: 24
-summary: "Added production auth with tier-based access, synced pricing tiers, and queued guest trip handoff."
+summary: "Launched production auth and plan tiers, plus Korean localization and Kakao sign-in during the Seollal release window."
 ---
 
 ## Changes
+- [x] [New feature] 🇰🇷 Added full Korean language support across auth, pricing, planner, and core marketing pages for the Seollal launch.
+- [x] [New feature] 🧧 Added Kakao social login so Korean travelers can sign in with a familiar local provider.
 - [x] [New feature] 🔐 Added production login and registration with email/password plus Google, Apple, and Facebook sign-in.
 - [x] [New feature] 🎒 Introduced Backpacker, Explorer, and Globetrotter tiers with entitlement-driven limits in app and database.
 - [x] [Improved] 💳 Updated pricing page to render tier limits from the shared plan catalog without runtime database calls.

--- a/content/updates/2026-02-17-auth-hydration-trip-expiry.md
+++ b/content/updates/2026-02-17-auth-hydration-trip-expiry.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-02-17-auth-hydration-trip-expiry
+version: v0.56.0
+title: "Trip expiry respects signed-in access during hydration"
+date: 2026-02-17
+published_at: 2026-02-17T19:11:21Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Trip creation now avoids applying guest expiry windows before signed-in access state is ready."
+---
+
+## Changes
+- [x] [Fixed] 🔐 New trips created right after sign-in no longer get guest-style expiry limits while account access is still loading.
+- [ ] [Internal] 🧠 Added session-aware trip-expiry resolution so authenticated/unknown sessions defer to server entitlement rules instead of forcing the anonymous fallback.

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -153,6 +153,22 @@ export const dbGetAccessToken = async (): Promise<string | null> => {
     return data?.session?.access_token ?? null;
 };
 
+export type DbSessionKind = 'authenticated' | 'anonymous' | 'unknown';
+
+export const dbGetSessionKind = async (): Promise<DbSessionKind> => {
+    if (!DB_ENABLED) return 'unknown';
+    const client = requireSupabase();
+    const { data, error } = await client.auth.getSession();
+    if (error) {
+        console.error('Failed to determine Supabase session kind', error);
+        return 'unknown';
+    }
+    const user = data?.session?.user;
+    if (!user) return 'unknown';
+    const isAnonymous = Boolean((user as { is_anonymous?: unknown }).is_anonymous);
+    return isAnonymous ? 'anonymous' : 'authenticated';
+};
+
 const isRlsViolation = (error: { code?: string; message?: string } | null) => {
     if (!error) return false;
     if (error.code === '42501') return true;


### PR DESCRIPTION
## Summary
- prevent anonymous expiry fallback from being persisted while auth/access hydration is still unresolved by deferring expiry to server entitlement logic
- sync locally saved trips with persisted DB rows after create/copy flows so `tripExpiresAt` reflects authoritative entitlements
- update the PR #68 release entry with explicit Korean + Kakao Seollal launch highlights and add a dedicated draft note for the hydration expiry fix

## Test plan
- [ ] create/copy a trip immediately after sign-in while auth is still hydrating and verify `trip_expires_at` in DB reflects user entitlements (not anonymous fallback)
- [ ] create/copy as anonymous and verify expiry still applies according to anonymous/free plan limits
- [ ] open `/updates` and confirm the auth release now surfaces Korean launch and Kakao login highlights
- [ ] verify `npm run updates:validate` passes

Made with [Cursor](https://cursor.com)