### PR TITLE
Publish Seollal spotlight release note for auth + Korean launch

### DIFF
--- a/content/updates/2026-02-17-seollal-auth-korean-launch.md
+++ b/content/updates/2026-02-17-seollal-auth-korean-launch.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-02-17-seollal-auth-korean-launch
+version: v0.42.0
+title: "Seollal spotlight: Korean launch + production auth"
+date: 2026-02-17
+published_at: 2026-02-17T19:58:29Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "Shipped Korean localization, Kakao sign-in, and production account flows so more travelers can start and continue trip planning with real login."
+---
+
+## Changes
+- [x] [New feature] 🇰🇷 Added Korean language support across auth, pricing, planner, and core marketing pages.
+- [x] [New feature] 🧧 Added Kakao social login so Korean travelers can sign in with a familiar local provider.
+- [x] [New feature] 🔐 Launched production authentication with email/password plus social sign-in and account recovery flows.
+- [x] [Improved] ⏳ Added guest queue handoff so anonymous create-trip requests resume after login instead of being lost.


### PR DESCRIPTION
## Summary
- add a new published release entry (`v0.42.0`) so the `/updates` page surfaces the latest auth + Korean launch milestone
- highlight Korean localization and Kakao login with explicit Seollal-focused visual copy
- keep this PR release-note-only to avoid shipping unrelated code changes

## Test plan
- [ ] run `npm run updates:validate`
- [ ] open `/updates` in Deploy Preview and confirm `v0.42.0` appears as the newest card
- [ ] verify Korean/Kakao highlights render in the new entry

Made with [Cursor](https://cursor.com)