### PR TITLE
Align release-note visibility and timestamps to real main chronology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,11 @@ This repository uses markdown release files as the source of truth for product u
 - Update/finalize that single release note shortly before opening the PR, once final scope is clear.
 - Use `[x]` for website-visible user-facing items.
 - Use `[ ]` for hidden internal items.
+- Keep technical identifiers out of visible items (no route paths, code symbols, endpoints, or environment keys in `[x]` lines).
 - Prefix every change line message with an emoji as defined in `docs/UPDATE_FORMAT.md`.
 - Bump the release `version` whenever a new release is published.
 - Keep versions strictly increasing; never reuse prior versions.
-- Set `published_at` to the current time but **always before 23:00 UTC** — timestamps at or after 23:00 UTC display as the next day in CET. Ensure the timestamp is strictly after the previous version's `published_at`.
+- Set `published_at` to when the change actually reached `main` (prefer production deploy timestamp; otherwise main merge timestamp), but **always before 23:00 UTC**. Timestamps at or after 23:00 UTC display as the next day in CET. Ensure the timestamp is strictly after the previous version's `published_at`.
 - Keep entries concise, prioritized, and accurate.
 - For new UI components and layout changes, explicitly check whether direction-aware styling is needed.
 - Prefer CSS logical properties (for example `margin-inline`, `padding-inline`, `inset-inline`) over left/right-specific properties when it makes sense.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,11 @@ When a user-facing feature, fix, or behavior change is completed, you must updat
 - Add internal/non-marketing items as `- [ ] [Internal] ...`.
 - Each change line must start with a **content-matching emoji** — pick an emoji that hints at what the specific change is about. Do NOT use a fixed emoji per type (no 🚀 for every feature, no ✨ for every improvement).
 - Only mark items `[x]` (visible) when they describe a **clear user benefit**. Hide technical details, dependency changes, refactors, and implementation specifics as `[ ]`.
+- Keep technical identifiers out of visible items (no route paths, code symbols, endpoints, or environment keys in `[x]` lines).
 - Write visible items from the user's perspective — focus on what changed for them, not how it was built.
 - Keep the most important user-facing items first, and fixes after primary highlights.
 - Bump the release `version` whenever publishing a new release entry.
-- Set `published_at` to the current time but **always before 23:00 UTC** — timestamps at or after 23:00 UTC display as the next day in CET. Ensure the timestamp is strictly after the previous version's `published_at`.
+- Set `published_at` to when the change actually reached `main` (prefer production deploy timestamp; otherwise main merge timestamp), but **always before 23:00 UTC**. Timestamps at or after 23:00 UTC display as the next day in CET. Ensure the timestamp is strictly after the previous version's `published_at`.
 
 ## Completion gate
 Before finalizing, ensure all applicable code changes are represented in release markdown and versioning is updated.

--- a/content/updates/2026-02-10-on-page-debug-toolbar.md
+++ b/content/updates/2026-02-10-on-page-debug-toolbar.md
@@ -3,7 +3,7 @@ id: rel-2026-02-10-on-page-debug-toolbar
 version: v0.35.0
 title: "On-page debugger toolbar"
 date: 2026-02-11
-published_at: 2026-02-11T11:29:38Z
+published_at: 2026-02-11T05:28:17Z
 status: published
 notify_in_app: false
 in_app_hours: 24

--- a/content/updates/2026-02-11-og-playground-stability-and-controls.md
+++ b/content/updates/2026-02-11-og-playground-stability-and-controls.md
@@ -1,9 +1,9 @@
 ---
 id: rel-2026-02-11-og-playground-stability-and-controls
-version: v0.43.0
+version: v0.36.0
 title: "Image delivery optimization and OG playground stability"
 date: 2026-02-11
-published_at: 2026-02-17T20:02:10Z
+published_at: 2026-02-11T10:28:13Z
 status: published
 notify_in_app: false
 in_app_hours: 24
@@ -11,8 +11,8 @@ summary: "Faster blog and inspiration image delivery plus internal OG playground
 ---
 
 ## Changes
-- [x] [Improved] ⚡ Blog cards and post headers now use build-time optimized responsive images (`480/768/1024/1536`) to reduce payload size and improve load speed.
-- [x] [Improved] 🖼️ Inspiration cards now use the same build-time responsive image pipeline (`480/768/1024/1536`) for faster loading on mobile and desktop.
+- [x] [Improved] ⚡ Blog cards and post headers now load faster with lighter responsive image delivery.
+- [x] [Improved] 🖼️ Inspiration cards now use the same optimized image delivery for faster loading on mobile and desktop.
 - [ ] [Internal] 🧠 Image build scripts are now incremental by default and skip generation when source files already exist, keeping repeated deploy builds fast.
 - [ ] [Internal] 📝 Added a full npm script reference to the README so all `npm run` commands are documented in one place.
 - [ ] [Internal] 🧯 Fixed a client-side initialization crash in `/api/og/playground` that blocked preview image rendering and sample URL output.

--- a/content/updates/2026-02-11-page-speed-continuous-optimization.md
+++ b/content/updates/2026-02-11-page-speed-continuous-optimization.md
@@ -1,9 +1,9 @@
 ---
 id: rel-2026-02-11-page-speed-continuous-optimization
-version: v0.36.0
+version: v0.37.0
 title: "Page speed baseline and continuous optimization"
 date: 2026-02-12
-published_at: 2026-02-12T15:18:56Z
+published_at: 2026-02-11T16:12:40Z
 status: published
 notify_in_app: true
 in_app_hours: 24
@@ -12,14 +12,14 @@ summary: "Improved page speed and perceived navigation with lighter initial bund
 
 ## Changes
 - [x] [Improved] ⚡ Homepage, blog, and marketing routes now load faster with less initial JS on first visit.
-- [x] [Improved] 🖼️ Progressive BlurHash placeholders and production Netlify Image CDN delivery now make content imagery appear faster and transfer fewer bytes.
+- [x] [Improved] 🖼️ Progressive image loading now makes content appear sooner while reducing data usage.
 - [x] [Improved] 🗺️ Example trip map previews now use smaller responsive sources to reduce over-download on cards.
-- [x] [Improved] 🚀 Navigation now prewarms likely next routes (hover/focus/touch/viewport/idle) and uses Speculation Rules prefetch hints for quicker follow-up page opens.
+- [x] [Improved] 🚀 Navigation now feels faster because likely next pages are warmed in advance.
 - [x] [Improved] 🎯 Example-card interactions now keep fast direct navigation while still warming trip-view assets ahead of click.
 - [x] [Fixed] 🤖 Trip/share URLs are now correctly disallowed for crawlers while public pages remain crawlable.
-- [x] [Fixed] 🛠️ React warnings were resolved for progressive image `fetchpriority` attributes and nested anchor markup.
+- [ ] [Internal] 🛠️ Resolved React warnings around progressive-image priority attributes and nested anchor markup.
 - [x] [Improved] 🔤 Typography now loads more reliably via self-hosted font subsets with reduced external dependency cost.
-- [x] [Improved] 🧠 Hashed `/assets/*` files now ship with immutable cache headers for stronger repeat-visit performance.
+- [x] [Improved] 🧠 Repeat visits are faster with stronger asset caching behavior.
 - [ ] [Internal] 🧱 Added build-time image placeholder manifest generation (`sharp` + `blurhash`) to keep placeholder rendering deterministic.
 - [ ] [Internal] 🧩 Moved simulated-login debug helpers into a lightweight standalone service to avoid pulling DB-heavy modules into unrelated routes.
 - [ ] [Internal] 🎨 Deferred Prism theme CSS loading to the admin benchmark route so non-admin pages avoid render-blocking CSS.

--- a/content/updates/2026-02-12-global-404-plane-window.md
+++ b/content/updates/2026-02-12-global-404-plane-window.md
@@ -3,7 +3,7 @@ id: rel-2026-02-12-global-404-plane-window
 version: v0.38.0
 title: "Global 404 page with animated plane-window motif"
 date: 2026-02-13
-published_at: 2026-02-13T06:34:45Z
+published_at: 2026-02-12T20:50:01Z
 status: published
 notify_in_app: false
 in_app_hours: 24

--- a/content/updates/2026-02-12-homepage-example-carousel-mobile-and-transition-lanes.md
+++ b/content/updates/2026-02-12-homepage-example-carousel-mobile-and-transition-lanes.md
@@ -3,7 +3,7 @@ id: rel-2026-02-12-homepage-example-carousel-mobile-and-transition-lanes
 version: v0.44.0
 title: "Homepage example carousel mobile fix and transition lanes"
 date: 2026-02-12
-published_at: 2026-02-17T20:02:40Z
+published_at: 2026-02-13T20:50:33Z
 status: published
 notify_in_app: false
 in_app_hours: 24
@@ -14,18 +14,18 @@ summary: "Stabilized the homepage example carousel on mobile and upgraded exampl
 - [x] [Fixed] 📱 Removed homepage horizontal body overflow on mobile around the animated example carousel.
 - [x] [Fixed] 🖼️ Restored the original desktop carousel breakout/fade behavior while keeping the mobile overflow fix.
 - [x] [Fixed] 🖐️ Disabled text selection on homepage example cards (including iOS touch callout) for smoother swipe and tap behavior.
-- [x] [Improved] 🔗 Added a harmonized “Discover more inspirations” section link below the homepage carousel and tracked clicks via Umami event analytics.
-- [x] [Fixed] ⚡ Reduced delay when opening example trips by prewarming the trip view in the background instead of blocking navigation on click.
+- [x] [Improved] 🔗 Added a clearer “Discover more inspirations” link below the homepage carousel.
+- [x] [Fixed] ⚡ Example trips now open faster with less perceived delay.
 - [x] [Improved] 🗓️ Added minimal bottom calendar lanes on every example card that mirror city stay colors and relative stay/route sizing.
 - [x] [Improved] 🏷️ Added city-lane hover tooltips on example cards with subtle offset outlines derived from each lane color.
 - [x] [Fixed] 🎯 Increased city-lane hover hit area, switched tooltips to city names only, and stabilized lane hover styling to avoid visible card jitter.
 - [x] [Fixed] 🧭 Refined city-lane hover visuals with a tighter, thicker border effect and kept pointer cursor behavior.
 - [x] [Fixed] 🪟 Added extra carousel vertical buffer so example card hover shadows are no longer clipped at the wrapper edge.
-- [x] [Improved] 🧬 Linked example card map/title/city-lane visuals to matching trip-page elements via shared View Transition names for smoother morph animations.
-- [x] [Fixed] 🎞️ Temporarily disabled homepage-to-example View Transition triggering to restore fast, direct navigation while transition reliability is investigated.
-- [x] [Fixed] ⚙️ Removed global click-based View Transition wrapping for route changes to avoid slow back navigation from trip pages.
+- [x] [Improved] 🧬 Improved visual continuity when opening example cards into full trip views.
+- [x] [Fixed] 🎞️ Adjusted transition behavior to prioritize speed and reliability when opening examples.
+- [x] [Fixed] ⚙️ Reduced back-navigation lag from trip pages by removing heavy transition wrapping.
 - [x] [Fixed] 🔤 Restored system sans-serif body text and stabilized local Space Grotesk subset loading to avoid visual jumps on resize.
-- [x] [Improved] 🪶 Applied global headline `text-wrap: pretty` for cleaner line breaks across pages.
+- [x] [Improved] 🪶 Headline line breaks are now cleaner and more readable across pages.
 - [x] [Improved] 🌏 Added a new multi-country “Backpacking South East Asia” example card with an openable 37-day roundtrip route template, richer city/activity coverage, localized card titles/city labels across all supported languages, and template defaults tuned for vertical timeline + minimal map.
 - [ ] [Internal] 🧩 Added shared transition-name helpers and example-template mini-calendar data utilities to keep card and trip visual mapping consistent.
 - [ ] [Internal] 🧪 Added View Transition diagnostics to the on-page debugger, including lifecycle events and live anchor audits.

--- a/content/updates/2026-02-12-i18n-locale-seo-rollout.md
+++ b/content/updates/2026-02-12-i18n-locale-seo-rollout.md
@@ -1,9 +1,9 @@
 ---
 id: rel-2026-02-12-i18n-locale-seo-rollout
-version: v0.37.0
+version: v0.39.0
 title: "I18n foundation and locale-aware SEO rollout"
 date: 2026-02-12
-published_at: 2026-02-12T20:35:58Z
+published_at: 2026-02-13T12:57:45Z
 status: published
 notify_in_app: false
 in_app_hours: 24
@@ -26,10 +26,10 @@ summary: "Improved multilingual UX with faster switching and persistent locale-b
 - [x] [Improved] 📰 Non-English blog pages can show native + English articles with a locale-aware language filter and clear English-content notice.
 - [x] [Fixed] 🔗 English blog entries opened from non-English views now route to the correct article language variant.
 - [x] [Improved] ✍️ Blog pages now feature a creator-focused community CTA for bloggers and storytellers to submit ideas via contact.
-- [x] [Improved] 🔤 Blog cards and article content now set explicit `lang` attributes per post language (including `lang="en"` for English content on non-English pages).
-- [x] [Improved] 🔎 Localized marketing pages now output locale-aware canonical and `hreflang` clusters, including `x-default`, plus localized title/description metadata.
+- [x] [Improved] 🔤 Blog cards and article pages now show clearer language context when mixing local and English content.
+- [ ] [Internal] 🔎 Localized marketing pages now output locale-aware canonical and `hreflang` clusters, including `x-default`, plus localized title/description metadata.
 - [x] [Improved] 🍪 Cookie consent banner and shared footer/header CTA copy are now localized for all supported locales.
-- [x] [Fixed] 🧩 Placeholder interpolation now resolves correctly in translated strings (for example `{year}`, `{appName}`, counts, and query values).
+- [x] [Fixed] 🧩 Dynamic values in translated strings now render correctly across locales.
 - [ ] [Internal] 🗺️ Expanded sitemap/blog validation/edge metadata locale support to include Spanish and Portuguese.
 - [ ] [Internal] 📘 Updated i18n and LLM docs so new localized pages follow consistent routing, SEO, copywriting, and analytics conventions.
 - [ ] [Internal] 📊 Locale-switch attribution now uses Umami event payload fields instead of URL query tracking params.

--- a/content/updates/2026-02-13-auth-roles-pricing-guest-queue.md
+++ b/content/updates/2026-02-13-auth-roles-pricing-guest-queue.md
@@ -1,9 +1,9 @@
 ---
 id: rel-2026-02-13-auth-roles-pricing-guest-queue
-version: v0.39.0
+version: v0.48.0
 title: "Auth, Tiers, and Guest Trip Queue Foundation"
 date: 2026-02-13
-published_at: 2026-02-13T14:06:09Z
+published_at: 2026-02-17T19:02:19Z
 status: published
 notify_in_app: true
 in_app_hours: 24
@@ -11,26 +11,15 @@ summary: "Established production authentication, tiered access, and guest-to-acc
 ---
 
 ## Changes
-- [x] [New feature] 🔐 Added production login and registration with email/password plus Google, Apple, and Facebook sign-in.
-- [x] [New feature] 🎒 Introduced Backpacker, Explorer, and Globetrotter tiers with entitlement-driven limits in app and database.
-- [x] [Improved] 💳 Updated pricing page to render tier limits from the shared plan catalog without runtime database calls.
-- [x] [New feature] 🧪 Added protected admin routes and admin navigation for dashboard, AI benchmark, and access control.
-- [x] [New feature] ⏳ Added guest create-trip queue handoff: fake loading, delayed auth modal, then post-login generation resume.
-- [x] [Improved] 🪟 Added login modal interception for normal login taps so users can authenticate in-context and continue on the same page.
-- [x] [Improved] 🎨 Refined auth UI with branded social provider icons and stronger visual hierarchy for sign-in actions.
-- [x] [Improved] 🧭 Added a dedicated admin navigation shell with direct links to Dashboard, AI Benchmark, Access Control, and a quick "Back to Platform" action.
-- [x] [Improved] 🔁 Hardened OAuth return flow so post-login resumes reliably redirect users to the page where authentication started.
-- [x] [Improved] 🛂 Added login/logout controls in trip and example views so auth actions are accessible directly inside the planner workspace.
-- [x] [Improved] 🏷️ Added a lightweight "Last used" social provider badge on both login page and login modal using local storage preferences.
-- [x] [Improved] ✅ Updated "Last used" provider behavior to persist only after a successful social login callback (not on click or failed attempts).
-- [x] [Improved] 🧭 Restyled the admin header to match the main site navigation language while keeping admin-only links and a top-right back-to-platform action.
-- [x] [Improved] 🔑 Added forgot-password and set-password-by-email actions on login page and auth modal, so social-login users can reliably enable password sign-in.
-- [x] [New feature] 🛠️ Added a dedicated password reset route (`/auth/reset-password`) with secure validation and post-success redirect to the intended app page.
-- [x] [Fixed] 🧯 Added a defensive login-modal fallback so example/trip flows no longer crash when context is missing and still preserve redirect intent to `/login`.
-- [x] [Fixed] 🧱 Added a second safety guard in `useLoginModal` to prevent stale-chunk context throws from breaking render during logout/navigation transitions.
-- [ ] [Internal] 🗃️ Added Supabase RPC and schema extensions for roles, tier overrides, queued generation requests, and auth flow logs.
-- [ ] [Internal] 📈 Added auth observability with structured analytics events and local redacted `tf_auth_trace_v1` debugging buffer.
-- [ ] [Internal] 🧭 Extended auth observability for password recovery (`password_reset_request`, `password_update`) with flow-level analytics and server trace logging.
-- [ ] [Internal] 🛡️ Migrated AI benchmark edge auth to admin bearer-token verification with optional emergency key fallback flag.
-- [ ] [Internal] 🌐 Added i18n guardrails and validation for ICU placeholder syntax (`{name}`), locale parity checks, and namespace placement guidance for LLM agents.
-- [ ] [Internal] 🧭 Expanded Supabase OAuth setup documentation with field-level dashboard mapping, direct auth links, and `travelflowapp.netlify.app` + `localhost:5173` examples.
+- [x] [New feature] 🔐 Launched production account authentication with email/password and major social sign-in providers.
+- [x] [New feature] 🎒 Introduced Backpacker, Explorer, and Globetrotter plans with account-based trip limits.
+- [x] [Improved] 💳 Updated pricing so plan limits are shown clearly and consistently.
+- [x] [New feature] ⏳ Guest create-trip requests now resume after sign-in instead of being lost.
+- [x] [Improved] 🛂 Added convenient sign-in and sign-out controls directly in planner and example trip views.
+- [x] [Improved] 🔑 Added password recovery and password-setup flows so users can regain account access more reliably.
+- [x] [Fixed] 🧯 Improved sign-in flow resilience so users return to the right place after authentication interruptions.
+- [ ] [Internal] 🧪 Added protected admin access sections and navigation structure for internal role and benchmark workflows.
+- [ ] [Internal] 📈 Added structured auth observability and recovery event tracing for login and password flows.
+- [ ] [Internal] 🛡️ Hardened admin benchmark authorization and fallback handling for edge runtime checks.
+- [ ] [Internal] 🌐 Added i18n guardrails and validation for ICU placeholder syntax, locale parity checks, and namespace placement guidance.
+- [ ] [Internal] 🧭 Expanded Supabase auth setup documentation with dashboard mappings and local/production callback examples.

--- a/content/updates/2026-02-13-blog-locale-path-retention.md
+++ b/content/updates/2026-02-13-blog-locale-path-retention.md
@@ -1,9 +1,9 @@
 ---
 id: rel-2026-02-13-blog-locale-path-retention
-version: v0.46.0
+version: v0.42.0
 title: "Blog locale path retention for English fallback articles"
 date: 2026-02-13
-published_at: 2026-02-17T20:03:40Z
+published_at: 2026-02-13T17:10:21Z
 status: published
 notify_in_app: false
 in_app_hours: 24
@@ -13,5 +13,5 @@ summary: "Non-English blog browsing now keeps locale URL context when opening En
 ## Changes
 - [x] [Fixed] 🌍 Opening an English-only blog post from a non-English blog view now keeps the active locale path and UI language context.
 - [x] [Improved] 🧭 "Back to blog" and related article links now route to the active locale's blog paths.
-- [x] [Improved] 🇬🇧 Blog post pages now show a localized English-content notice and scope `lang` attributes to article content.
-- [x] [Improved] 🔗 Locale fallback article URLs now set a canonical link to the original English source page to prevent duplicate indexing.
+- [x] [Improved] 🇬🇧 Blog post pages now show clearer localized notices when article content is only available in English.
+- [ ] [Internal] 🔗 Locale fallback article URLs now set a canonical link to the original English source page to prevent duplicate indexing.

--- a/content/updates/2026-02-13-create-trip-reliability-and-classic-default.md
+++ b/content/updates/2026-02-13-create-trip-reliability-and-classic-default.md
@@ -1,45 +1,24 @@
 ---
 id: rel-2026-02-13-create-trip-reliability-and-classic-default
-version: v0.41.0
+version: v0.45.0
 title: "Create-trip reliability fix and Classic Card default rollout"
 date: 2026-02-13
-published_at: 2026-02-13T15:45:00Z
+published_at: 2026-02-15T19:16:28Z
 status: published
 notify_in_app: true
 in_app_hours: 24
-summary: "Create-trip now recovers automatically from stale lazy chunks on first load, and the Classic Card experience is the new default with a cleaner, production-ready flow."
+summary: "Create Trip now recovers from first-load failures more reliably, with Classic Card as default and a smoother generation flow across mobile and localized experiences."
 ---
 
 ## Changes
-- [x] [Fixed] 🧩 Added automatic lazy-chunk recovery with a one-time reload guard, so first-load stale module failures no longer dead-end create-trip and other lazy routes.
-- [x] [Improved] 🧭 Rolled out Classic Card Overhaul as the default `/create-trip` experience while preserving the legacy form and all other lab concepts on dedicated routes.
-- [x] [Improved] ✅ Added required-state completion checks for Destination and Dates, restored blog-style destination search input, and moved selected-country chips below the input with the original button-style visual treatment.
-- [x] [Fixed] 🔁 Restored `prefill` URL handling for Classic Card so inspiration links populate destinations/dates/options on first load again.
-- [x] [Fixed] 🧭 Restored the Travel Snapshot route-path arrows/loop visualization and aligned the mobile sticky snapshot to the same visual style as desktop.
-- [x] [Fixed] 👥 Restored per-traveler settings modal controls and transport behavior (`Automatic` vs multi-select), with camper visible but disabled for now.
-- [x] [Fixed] 🏳️‍🌈 Restored same-sex couple traveler-modal rainbow mode styling and fixed traveler settings interpolation rendering in localized copy.
-- [x] [Improved] 📱 Added a mobile/tablet sticky trip snapshot footer with primary create action and expandable details, including safe bottom spacing to avoid content overlap.
-- [x] [Improved] 📅 Refined mobile snapshot readability with visible travel dates and restored +/- week steppers for flexible trip duration input.
-- [x] [Improved] 🤖 Switched the default Classic Card flow to in-page AI generation (`aiService`) and aligned admin benchmark input masking to the same UI shape without changing prompt contract semantics.
-- [x] [Improved] 🌍 Added a dedicated `createTrip` i18n namespace across all supported locales, wired tool-route language preloading, and fixed locale state sync so create-trip navigation, country names, and date labels stay in the active app language.
-- [x] [Fixed] 🌐 Fixed tool-route language state sync so changing language on create-trip persists across hard reloads, including localized URLs like `/:locale/create-trip`.
-- [x] [Improved] 🌍 Added localized create-trip route support (`/:locale/create-trip`) and locale-aware switching for planner entry links while keeping trip/share URLs unchanged.
-- [x] [Improved] 🏷️ Added localized OG/meta output for localized create-trip URLs so shared planner links use language-matching title/description.
-- [x] [Improved] 📱 Increased vertical spacing and readability in the mobile trip snapshot footer (headline, pills, and expanded details).
-- [x] [Fixed] 🌐 Completed create-trip namespace localization coverage for all supported locales (`en,de,es,fr,it,pt,ru,pl`), including a new Polish locale file and fully translated French planner strings.
-- [x] [Fixed] 🧾 Corrected create-trip interpolation placeholders from double-curly to ICU format (`{label}`), so prefill badges render translated labels correctly in every locale.
-- [x] [Fixed] 🗓️ Localized ideal-travel tooltip month initials using `Intl.DateTimeFormat`, so month letters follow the active language instead of English-only abbreviations.
-- [x] [Fixed] 🏳️‍🌈 Restored the original same-sex couple “gay mode” modal treatment with the full rainbow border gradient around traveler settings, matching the classic-overhaul behavior.
-- [x] [Improved] 🧪 Added a bottom info banner on the default create-trip form with direct links to Classic Legacy, Classic Card, Split Workspace, and Journey Architect lab routes for quick regression testing.
-- [x] [Improved] 💾 Added URL-backed create-trip draft persistence (via `prefill`) so form state survives hard reloads and remains shareable, while canonical metadata stays path-based.
-- [x] [Fixed] ⏱️ Raised create-trip AI edge timeout floor to prevent 5-second provider timeouts from aborting generation before trips can be created.
-- [x] [Improved] 🚀 Restored legacy-style generation transition on Classic Card: clicking create now opens the trip route immediately with the same trip ID and a loading itinerary shell that hydrates in place when AI generation completes.
-- [x] [Improved] 🧭 Restored legacy loading experience on `/trip/:id` with centered fake-progress modal messaging and initial map focus on selected destination(s), including grouped multi-country focus.
-- [x] [Fixed] 🧯 Fixed a trip-view runtime initialization crash (`Cannot access '<minified>' before initialization`) by correcting loader-overlay state declaration order.
-- [x] [Improved] 🧪 Added three additional create-trip design-variant experiments as dedicated routes (`/create-trip/labs/design-v1`, `/create-trip/labs/design-v2`, `/create-trip/labs/design-v3`) with compatibility aliases (`/create-trip/v1..v3`) and linked them from the default labs banner.
-- [x] [Fixed] 🗓️ Corrected weekday-label alignment in the date-range picker by formatting weekday headers in UTC, preventing day-column shifts for negative UTC offsets.
-- [x] [Fixed] 🇷🇺 Replaced Russian create-trip labs banner transliteration with proper Cyrillic copy for consistent locale quality.
-- [x] [Fixed] 🌐 Corrected create-trip labs banner localization spelling/diacritics in German, Polish, Portuguese, Spanish, and French to remove transliterated ASCII copy.
-- [ ] [Internal] 🧹 Removed local absolute filesystem path references from markdown docs in favor of repository-relative paths.
-- [ ] [Internal] 📈 Added create-trip interaction event instrumentation and chunk-recovery observability updates to the analytics convention catalog.
+- [x] [Fixed] 🧩 Create Trip now auto-recovers from stale first-load assets, so users are less likely to hit a broken screen.
+- [x] [Improved] 🧭 Classic Card became the default planner flow with clearer required steps for destinations and dates.
+- [x] [Fixed] 🔁 Inspiration links now prefill the planner reliably again, so users can start faster without re-entering details.
+- [x] [Improved] 📱 Mobile trip snapshot controls are easier to read and use, with better spacing and clearer actions.
+- [x] [Improved] 🌍 Create Trip language quality improved across supported locales, including better translation consistency.
+- [x] [Improved] 🚀 Trip generation now transitions more smoothly into the trip view with clearer progress feedback while loading.
+- [x] [Improved] 🧪 The create-trip labs area now offers easier access to multiple planner concept variants for quick comparison.
+- [x] [Fixed] 🗓️ Calendar and weekday labeling fixes improved date clarity across timezones and locales.
+- [ ] [Internal] 📈 Added create-trip interaction instrumentation and chunk-recovery observability updates.
 - [ ] [Internal] 📄 Added prompt-mapping and DB-tracking strategy docs to define no-effect fields, effective defaults, and phased post-auth telemetry design.
+- [ ] [Internal] 🧹 Removed local absolute filesystem path references from markdown docs in favor of repository-relative paths.

--- a/content/updates/2026-02-13-mobile-trip-header-info-history-actions.md
+++ b/content/updates/2026-02-13-mobile-trip-header-info-history-actions.md
@@ -1,9 +1,9 @@
 ---
 id: rel-2026-02-13-mobile-trip-header-info-history-actions
-version: v0.47.0
+version: v0.43.0
 title: "Mobile trip header action cleanup"
 date: 2026-02-13
-published_at: 2026-02-17T20:04:10Z
+published_at: 2026-02-13T19:12:03Z
 status: published
 notify_in_app: false
 in_app_hours: 24

--- a/content/updates/2026-02-13-og-font-compat-and-share-sync-guards.md
+++ b/content/updates/2026-02-13-og-font-compat-and-share-sync-guards.md
@@ -1,15 +1,15 @@
 ---
 id: rel-2026-02-13-og-font-compat-and-share-sync-guards
-version: v0.40.0
+version: v0.41.0
 title: "OG image rendering restored and share-sync guard tightened"
 date: 2026-02-13
-published_at: 2026-02-13T15:36:57Z
+published_at: 2026-02-13T17:04:29Z
 status: published
 notify_in_app: false
 in_app_hours: 24
-summary: "Fixed Open Graph image rendering crashes and prevented share-link generation from proceeding when a trip is not yet persisted."
+summary: "Restored reliable social preview image rendering and prevented sharing before a trip has finished saving."
 ---
 
 ## Changes
-- [x] [Fixed] 🖼️ Restored `/api/og/site` and `/api/og/trip` rendering with consistent Bricolage Grotesque typography by loading matching Satori-compatible `.woff` files per weight (`400/700/800`) and falling back to Google Fonts/CDN sources when needed.
-- [x] [Improved] 🔗 Added a pre-share persistence check so share-link creation stops early when a trip is not synced to the database yet, avoiding backend `P0001` failures.
+- [x] [Fixed] 🖼️ Restored reliable social preview image rendering with consistent typography across shared links.
+- [x] [Improved] 🔗 Share links now wait for trip save completion so users avoid broken or incomplete shares.

--- a/content/updates/2026-02-13-polish-locale-rollout.md
+++ b/content/updates/2026-02-13-polish-locale-rollout.md
@@ -1,19 +1,19 @@
 ---
 id: rel-2026-02-13-polish-locale-rollout
-version: v0.45.0
+version: v0.40.0
 title: "Polish locale rollout and font coverage update"
 date: 2026-02-13
-published_at: 2026-02-17T20:03:10Z
+published_at: 2026-02-13T14:17:32Z
 status: published
 notify_in_app: false
 in_app_hours: 24
-summary: "Added full Polish localization across marketing/app namespaces, aligned language switching UX, and ensured Latin Extended font coverage for Polish characters."
+summary: "Added full Polish localization across site and planner flows, polished language switching, and improved support for Polish character rendering."
 ---
 
 ## Changes
-- [x] [New feature] 🇵🇱 Added Polish (`pl`) as a fully supported app and marketing language with translated copy across all active namespaces.
+- [x] [New feature] 🇵🇱 Added Polish as a fully supported language across the app and marketing pages.
 - [x] [Improved] 🧭 Updated language selectors so Polish appears as the final option in dropdown order across header/mobile/settings UI.
 - [x] [Improved] 🔤 Ensured Polish diacritics render correctly by loading Latin Extended font subsets for app and OG image generation paths.
-- [x] [Improved] 🌍 Localized the home example carousel CTA and card content (titles, tags, day/city labels, and destination names) with dedicated example-card locale maps.
+- [x] [Improved] 🌍 Localized home example carousel CTAs and card content, including titles, tags, and destination labels.
 - [ ] [Internal] 🗂️ Added an extendible locale-index in `countryTravelData.json` for translated country and island destination names keyed by destination code.
 - [ ] [Internal] 🗺️ Extended locale-aware sitemap, blog validation, and edge metadata locale lists to include Polish routing and SEO coverage.

--- a/content/updates/2026-02-14-trip-timeline-transfer-connectors.md
+++ b/content/updates/2026-02-14-trip-timeline-transfer-connectors.md
@@ -1,9 +1,9 @@
 ---
 id: rel-2026-02-14-trip-timeline-transfer-connectors
-version: v0.48.0
+version: v0.46.0
 title: "Timeline transfer lane compaction and connector upgrade"
 date: 2026-02-14
-published_at: 2026-02-17T20:04:40Z
+published_at: 2026-02-16T06:24:40Z
 status: published
 notify_in_app: false
 in_app_hours: 24
@@ -16,5 +16,5 @@ summary: "Trip timeline now uses denser transfer lanes, clearer transfer copy, a
 - [x] [Improved] 🔗 Transfer pills now use dedicated city-to-pill connector lines, with dashed styling when transfer routing is missing or failed.
 - [x] [Improved] 🏙️ City stay cards now use a cleaner compact layout and show full city/country + stay details via the delayed desktop tooltip.
 - [x] [Improved] 🔎 Transfer pills now adapt by zoom level (compact icon-only/N-A at very small zoom, readable icon+label at regular zoom, and duration metadata when space allows).
-- [x] [Fixed] 🛡️ Example and preview routes now fail gracefully when Supabase environment settings are missing or malformed instead of throwing an app-blocking error.
+- [x] [Fixed] 🛡️ Example and preview trips now fail gracefully with clearer fallback behavior instead of throwing app-blocking errors.
 - [ ] [Internal] 🧱 Added shared route-status typing and timeline prop plumbing so connector styling can react to map routing outcomes.

--- a/content/updates/2026-02-16-flagpack-real-flags.md
+++ b/content/updates/2026-02-16-flagpack-real-flags.md
@@ -1,17 +1,17 @@
 ---
 id: rel-2026-02-16-flagpack-real-flags
-version: v0.49.0
+version: v0.47.0
 title: "Flagpack rollout for consistent real flags"
 date: 2026-02-16
-published_at: 2026-02-17T20:05:10Z
+published_at: 2026-02-16T07:26:44Z
 status: published
 notify_in_app: false
 in_app_hours: 24
-summary: "Replaced emoji flag rendering with a shared Flagpack-based flag component across planner, inspiration, blog, and language UI."
+summary: "Replaced emoji flags with consistent real flag icons across planner, inspiration, blog, and language UI."
 ---
 
 ## Changes
 - [x] [Improved] 🏳️ Replaced emoji-flag rendering with real SVG flags in planner destination chips, pickers, labs, and country context cards.
 - [x] [Improved] 🌐 Updated language selectors, language suggestions, and English-article notices to use the new shared flag system.
-- [x] [Improved] 🧭 Updated inspirations cards, country pills, and trip-list row flags to render through `FlagIcon` for consistent display.
+- [x] [Improved] 🧭 Inspirations cards, country pills, and trip-list rows now show the same consistent real flag visuals.
 - [ ] [Internal] 📘 Added destination-system guidance to use `FlagIcon` + `flagpack` for all future flag-related UI work.

--- a/content/updates/2026-02-17-seollal-auth-korean-launch.md
+++ b/content/updates/2026-02-17-seollal-auth-korean-launch.md
@@ -1,9 +1,9 @@
 ---
 id: rel-2026-02-17-seollal-auth-korean-launch
-version: v0.42.0
+version: v0.49.0
 title: "Seollal spotlight: Korean launch + production auth"
 date: 2026-02-17
-published_at: 2026-02-17T19:58:29Z
+published_at: 2026-02-17T20:00:01Z
 status: published
 notify_in_app: true
 in_app_hours: 24

--- a/docs/UPDATE_FORMAT.md
+++ b/docs/UPDATE_FORMAT.md
@@ -33,7 +33,7 @@ summary: "One concise summary sentence."
 - `id`: unique stable release id.
 - `version`: release label shown in update UI (for example `v0.7.0`).
 - `date`: release date (`YYYY-MM-DD`).
-- `published_at`: exact publish timestamp (used for in-app 24h notice window). **Must be < 23:00 UTC** — the site renders dates in CET (UTC+1), so timestamps at or after 23:00 UTC display as the next calendar day. Set this to the current time when finalizing, and verify it stays before 23:00 UTC.
+- `published_at`: exact timestamp when the release became live on `main` (merge/deploy time), used for in-app 24h notice windows and ordering. **Must be < 23:00 UTC** — the site renders dates in CET (UTC+1), so timestamps at or after 23:00 UTC display as the next calendar day. Do **not** use feature start time or first draft time.
 - `status`: `published` or `draft`.
 - `notify_in_app`: if `true`, latest published release can appear inside trip view.
 - `in_app_hours`: notice lifetime in hours (current default: `24`).
@@ -65,6 +65,7 @@ Mark as `[ ]` (hidden) when the item:
 - Is a technical implementation detail (e.g. dependency swaps, refactors, internal tooling).
 - Describes *how* something was built rather than *what changed* for the user.
 - Would require developer context to understand.
+- Includes technical identifiers users should not see (route paths, API endpoints, function/class names, environment keys, or code snippets).
 
 Write visible items from the user's perspective — focus on the benefit, not the implementation.
 
@@ -75,7 +76,7 @@ Write visible items from the user's perspective — focus on the benefit, not th
 4. When ready to publish, bump the version to the next release number and set:
    - You can get the next merged/published version with `npm run updates:next-version`.
    - `status: published`
-   - `published_at` to the publish time
+   - `published_at` to when the change actually reached `main` (prefer production deploy timestamp; otherwise use main PR merge timestamp)
    - `notify_in_app` as needed
 5. Commit and push. Deploy will render it on `/updates`.
 6. Start the next draft file only for the next distinct feature/release.


### PR DESCRIPTION
## Summary
- rewrite visible `/updates` bullets to user-facing copy and hide technical implementation details under `[ ]`
- realign `published_at` and versions in the affected release range so ordering reflects when changes actually reached `main`
- update release-note docs/rules to enforce merge/deploy-based timestamps and no technical identifiers in visible items

## Test plan
- [x] run `npm run updates:validate`
- [x] verify `Seollal spotlight: Korean launch + production auth` is newest by `published_at`
- [x] verify no recent visible bullets include route/code identifiers

Made with [Cursor](https://cursor.com)