### PR TITLE
fix: restore OG custom font rendering and broaden weight coverage

### DIFF
--- a/content/updates/2026-02-18-og-font-latin-priority-fix.md
+++ b/content/updates/2026-02-18-og-font-latin-priority-fix.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-02-18-og-font-latin-priority-fix
+version: v0.50.0
+title: "OG preview typography fallback regression fix"
+date: 2026-02-18
+published_at: 2026-02-18T14:30:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Fixed a social preview typography regression and expanded OG font-weight coverage so title styles stay consistent."
+---
+
+## Changes
+- [x] [Fixed] 🔤 Shared and page social preview titles now render with the intended brand typography more consistently.
+- [x] [Improved] 🎚️ Social previews now keep branded typography across a wider range of headline font weights.
+- [ ] [Internal] 🧱 Updated OG font loading priority so full Latin font files are selected before partial extended subsets.
+- [ ] [Internal] 🧮 Added OG font-weight alias coverage from 100 to 900 so future weight tweaks avoid system-font fallback.

--- a/netlify/edge-functions/trip-og-image.tsx
+++ b/netlify/edge-functions/trip-og-image.tsx
@@ -56,8 +56,13 @@ const VERSION_REGEX =
 
 type LoadedHeadingFont = {
   data: ArrayBuffer;
-  weight: 400 | 700 | 800;
+  weight: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
 };
+
+type BaseHeadingFontWeight = 400 | 700 | 800;
+type OgHeadingFontWeight = LoadedHeadingFont["weight"];
+const BASE_HEADING_FONT_WEIGHTS: readonly BaseHeadingFontWeight[] = [400, 700, 800];
+const OG_HEADING_FONT_WEIGHTS: readonly OgHeadingFontWeight[] = [100, 200, 300, 400, 500, 600, 700, 800, 900];
 
 const headingFontPromiseByOrigin = new Map<string, Promise<LoadedHeadingFont[]>>();
 const WOFF_SIGNATURE = "wOFF";
@@ -75,7 +80,9 @@ const fetchFontArrayBuffer = async (fontUrl: string): Promise<ArrayBuffer | null
   }
 };
 
-const buildHeadingFontUrls = (requestUrl: URL, weight: 400 | 700 | 800): string[] => {
+// og_edge picks the first matching font per weight and does not merge unicode-range subsets.
+// Keep full latin files first so ASCII headlines do not fall back to system fonts.
+const buildHeadingFontUrls = (requestUrl: URL, weight: BaseHeadingFontWeight): string[] => {
   const local400LatinExt = new URL(LOCAL_HEADLINE_FONT_400_LATIN_EXT_WOFF_PATH, requestUrl.origin).toString();
   const local400 = new URL(LOCAL_HEADLINE_FONT_400_WOFF_PATH, requestUrl.origin).toString();
   const local700LatinExt = new URL(LOCAL_HEADLINE_FONT_700_LATIN_EXT_WOFF_PATH, requestUrl.origin).toString();
@@ -91,30 +98,30 @@ const buildHeadingFontUrls = (requestUrl: URL, weight: 400 | 700 | 800): string[
 
   if (weight === 800) {
     return [
-      local800LatinExt,
       local800,
+      local800LatinExt,
       GOOGLE_HEADLINE_FONT_800_WOFF_URL,
-      cdn800LatinExt,
       cdn800,
+      cdn800LatinExt,
     ];
   }
 
   if (weight === 700) {
     return [
-      local700LatinExt,
       local700,
+      local700LatinExt,
       GOOGLE_HEADLINE_FONT_700_WOFF_URL,
-      cdn700LatinExt,
       cdn700,
+      cdn700LatinExt,
     ];
   }
 
   return [
-    local400LatinExt,
     local400,
+    local400LatinExt,
     GOOGLE_HEADLINE_FONT_400_WOFF_URL,
-    cdn400LatinExt,
     cdn400,
+    cdn400LatinExt,
   ];
 };
 
@@ -131,7 +138,7 @@ const isSupportedOgFont = (fontData: ArrayBuffer): boolean => {
 
 const loadHeadingFontByWeight = async (
   requestUrl: URL,
-  weight: 400 | 700 | 800,
+  weight: BaseHeadingFontWeight,
 ): Promise<ArrayBuffer | null> => {
   for (const fontUrl of buildHeadingFontUrls(requestUrl, weight)) {
     const fontData = await fetchFontArrayBuffer(fontUrl);
@@ -140,21 +147,61 @@ const loadHeadingFontByWeight = async (
   return null;
 };
 
+const toExpandedOgHeadingFonts = (
+  loadedByWeight: Map<BaseHeadingFontWeight, ArrayBuffer>,
+): LoadedHeadingFont[] => {
+  const availableEntries = BASE_HEADING_FONT_WEIGHTS
+    .map((weight) => {
+      const data = loadedByWeight.get(weight);
+      return data ? ({ weight, data }) : null;
+    })
+    .filter((entry): entry is { weight: BaseHeadingFontWeight; data: ArrayBuffer } => Boolean(entry));
+
+  if (availableEntries.length === 0) return [];
+
+  return OG_HEADING_FONT_WEIGHTS.map((targetWeight) => {
+    const exact = targetWeight === 400 || targetWeight === 700 || targetWeight === 800
+      ? loadedByWeight.get(targetWeight)
+      : null;
+    if (exact) {
+      return { weight: targetWeight, data: exact };
+    }
+
+    let closest = availableEntries[0];
+    for (const candidate of availableEntries.slice(1)) {
+      const currentDistance = Math.abs(candidate.weight - targetWeight);
+      const closestDistance = Math.abs(closest.weight - targetWeight);
+      if (currentDistance < closestDistance) {
+        closest = candidate;
+      }
+    }
+
+    return {
+      weight: targetWeight,
+      data: closest.data,
+    };
+  });
+};
+
 const loadHeadingFonts = async (requestUrl: URL): Promise<LoadedHeadingFont[]> => {
   const cacheKey = requestUrl.origin;
   let fontPromise = headingFontPromiseByOrigin.get(cacheKey);
 
   if (!fontPromise) {
     fontPromise = (async () => {
-      const font400 = await loadHeadingFontByWeight(requestUrl, 400);
-      const font700 = await loadHeadingFontByWeight(requestUrl, 700);
-      const font800 = await loadHeadingFontByWeight(requestUrl, 800);
+      const fontResults = await Promise.all(
+        BASE_HEADING_FONT_WEIGHTS.map(async (weight) => ({
+          weight,
+          data: await loadHeadingFontByWeight(requestUrl, weight),
+        })),
+      );
 
-      const fonts: LoadedHeadingFont[] = [];
-      if (font400) fonts.push({ data: font400, weight: 400 });
-      if (font700) fonts.push({ data: font700, weight: 700 });
-      if (font800) fonts.push({ data: font800, weight: 800 });
-      return fonts;
+      const loadedByWeight = new Map<BaseHeadingFontWeight, ArrayBuffer>();
+      for (const result of fontResults) {
+        if (result.data) loadedByWeight.set(result.weight, result.data);
+      }
+
+      return toExpandedOgHeadingFonts(loadedByWeight);
     })();
     headingFontPromiseByOrigin.set(cacheKey, fontPromise);
   }


### PR DESCRIPTION
## Summary
- fix OG font source ordering so full latin files are loaded before latin-ext subsets
- keep custom OG typography resilient to future font-weight changes by registering weights 100-900 from the closest loaded Bricolage source
- add release note draft for this regression fix

## Root cause
The OG renderer selected latin-ext subset files first. `og_edge` applies the first loaded font per weight and does not merge unicode subsets, so ASCII title glyphs could fall back to system fonts.

## Validation
- npm run edge:validate
- npm run updates:validate
- npx tsc --noEmit *(fails due existing unrelated repo-wide TS issues, not introduced by this PR)*