### PR TITLE
feat(admin): complete phase1 trip override + owner deep-link tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,15 @@ This repository uses markdown release files as the source of truth for product u
 - Follow `docs/UPDATE_FORMAT.md` for all release entries.
 - Follow `docs/UX_COPY_GUIDELINES.md` for any user-facing text changes (marketing pages, CTA copy, planner microcopy).
 - Follow `docs/I18N_PAGE_WORKFLOW.md` for locale/translation/namespace changes.
-- For user-facing copy changes, request user style sign-off in English and German before finalizing unless the user explicitly opts out.
+- For user-facing copy changes in marketing/planner surfaces, request user style sign-off in English and German before finalizing unless the user explicitly opts out.
+- Admin workspace copy (`/admin/*`, admin tables, drawers, and admin-only controls) is English-only by default and is exempt from EN/DE style sign-off and translation requirements unless the user explicitly asks for localization.
 - For locale interpolation, use ICU placeholders (`{name}`), never `{{name}}`.
-- When adding locale keys, update all active locales (`en`, `es`, `de`, `fr`, `pt`, `ru`, `it`, `pl`, `ko`) and validate namespace placement (`common/pages/legal` vs route-specific namespace).
+- When adding locale keys for localized user-facing surfaces, update all active locales (`en`, `es`, `de`, `fr`, `pt`, `ru`, `it`, `pl`, `ko`) and validate namespace placement (`common/pages/legal` vs route-specific namespace). Admin-only UI copy is excluded unless localization is explicitly requested.
 - Run `npm run i18n:validate` for locale-related changes before finalizing.
 - Release-note copy in `content/updates/*.md` is exempt from EN/DE style sign-off prompts; do not request bilingual sign-off for release notes unless the user explicitly asks for it.
 - Follow `docs/ANALYTICS_CONVENTION.md` for all new or changed analytics instrumentation.
 - For clickable UI on marketing/planner flows, add analytics using `trackEvent(...)` and `getAnalyticsDebugAttributes(...)` in the established format unless explicitly excluded.
+- Reuse existing shared components/hooks before creating new UI patterns. For confirmation/prompt flows, use the styled app dialog system (`useAppDialog` from `components/AppDialogProvider`) instead of native browser prompts.
 - After completing any feature/fix/change, update `content/updates/*.md`.
 - Maintain exactly one release note file per worktree/feature. Do not create multiple incremental release-note files for the same work.
 - Update/finalize that single release note shortly before opening the PR, once final scope is clear.

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -158,7 +158,7 @@ export const AdminShell: React.FC<AdminShellProps> = ({
     ));
 
     return (
-        <div className="min-h-screen bg-slate-100 text-slate-900">
+        <div className="min-h-dvh bg-slate-100 text-slate-900">
             {isMobileSidebarOpen && (
                 <div
                     className="fixed inset-0 z-50 bg-slate-950/45 lg:hidden"
@@ -211,9 +211,9 @@ export const AdminShell: React.FC<AdminShellProps> = ({
                 )}
             </aside>
 
-            <div className="flex min-h-screen w-full">
+            <div className="flex min-h-dvh w-full">
                 <div className="relative hidden lg:block">
-                    <aside className={`flex h-screen shrink-0 flex-col border-r border-slate-200 bg-white/95 p-4 transition-[width] duration-200 ${isSidebarCollapsed ? 'w-20' : 'w-72'}`}>
+                    <aside className={`flex h-dvh shrink-0 flex-col border-r border-slate-200 bg-white/95 p-4 transition-[width] duration-200 ${isSidebarCollapsed ? 'w-20' : 'w-72'}`}>
                         <NavLink
                             to="/admin/dashboard"
                             className={`flex items-center rounded-xl border border-slate-200 bg-white ${isSidebarCollapsed ? 'justify-center p-2' : 'gap-2 px-3 py-2'}`}
@@ -262,7 +262,7 @@ export const AdminShell: React.FC<AdminShellProps> = ({
                     </button>
                 </div>
 
-                <main className="min-w-0 flex-1">
+                <main className="min-w-0 flex-1 min-h-dvh">
                     <header className="sticky top-0 z-40 border-b border-slate-200 bg-white/95 backdrop-blur">
                         <div className="flex flex-col gap-3 px-4 py-4 md:px-6 lg:flex-row lg:items-end lg:justify-between">
                             <div className="min-w-0">

--- a/content/updates/2026-02-17-admin-rbac-entitlements-workspace.md
+++ b/content/updates/2026-02-17-admin-rbac-entitlements-workspace.md
@@ -7,7 +7,7 @@ published_at: 2026-02-17T20:40:00Z
 status: draft
 notify_in_app: false
 in_app_hours: 24
-summary: "Introduced a full admin operations workspace, role-aware account menu, and mandatory profile onboarding/settings flow for authenticated users."
+summary: "Introduced a full admin operations workspace with safer trip overrides, deep-linked owner drawers, and bulk admin actions across users and trips."
 ---
 
 ## Changes
@@ -41,6 +41,19 @@ summary: "Introduced a full admin operations workspace, role-aware account menu,
 - [x] [Improved] 🔗 Added direct trip-open links in admin trip listings and connected-trip sections so visual verification is one click away.
 - [x] [Improved] 🧭 Enabled admins to open any trip directly from admin tables, while keeping owner-only behavior unchanged for regular users.
 - [x] [Improved] 👤 Made trip owner cells open a user-information drawer for faster account context checks without leaving trip operations.
+- [x] [Improved] 🛡️ Added a default read-only safety mode for admin-opened trips, with an explicit edit override switch for authorized admins.
+- [x] [Improved] 🔎 Added direct owner-profile deep links from admin trip views so support can jump into the correct user drawer instantly.
+- [x] [Improved] ✅ Added multi-select checkboxes in Users and Trips tables with bulk soft-delete and permanent-delete actions.
+- [x] [Fixed] 🪟 Restored outside-click drawer close behavior for deep-linked user details so drawers no longer reopen unexpectedly.
+- [x] [Improved] 🧳 Reworked connected-trip controls in the user drawer so trip links keep full width while status/date controls stay compact.
+- [x] [Improved] 🔗 Added owner deep-link opening inside the Trips workspace so support can inspect owner drawers without switching screens.
+- [x] [Fixed] ⏱️ Suppressed release popups for admin trip sessions and during active loading overlays to avoid stacked modal/loading states.
+- [x] [Fixed] 🧭 Removed misleading loading overlays on expired admin-opened trips and added clearer unfinished-itinerary messaging.
+- [x] [Fixed] 📏 Fixed desktop admin sidebar sizing so the rail reliably fills the full viewport height.
+- [x] [Improved] 🔐 Added login-type filtering in User Provisioning with social/username-password/unknown modes plus provider-level social selection.
+- [x] [Improved] 🪪 Upgraded login badges in the user table with provider-specific icons/colors and better multi-provider visibility.
+- [x] [Improved] 📈 Added per-user trip counters in User Provisioning and surfaced active/total trip totals directly in the user details header.
+- [x] [Improved] 🧭 Added a one-click “Open in Trips” shortcut from user details to jump into filtered trip lifecycle view for that owner.
 - [ ] [Internal] 🗒️ Documented deferred admin-shell and user-management follow-up backlog for the next layout-focused iteration.
 - [x] [Fixed] 🔎 Improved admin filtering so search and date-range controls update Users, Trips, Tiers, and Audit views consistently.
 - [x] [Fixed] 🧮 Fixed admin workspace data panels failing to load by aligning backend response types for users/trips/audit queries.
@@ -52,3 +65,9 @@ summary: "Introduced a full admin operations workspace, role-aware account menu,
 - [ ] [Internal] 🧩 Isolated admin routes into a dedicated lazy-loaded workspace router so non-admin paths avoid admin chunk preload/bundle impact.
 - [ ] [Internal] 📘 Added explicit RBAC hardening TODOs documenting the migration from compatibility permissions to strict role-only checks.
 - [ ] [Internal] 🧯 Updated SQL migration order to drop/recreate legacy RPCs (`get_current_user_access`, `admin_list_users`, `admin_get_user_profile`) when return signatures evolve.
+- [ ] [Internal] 🧬 Switched admin user identity resolution to aggregate providers from auth identities so account-type classification is more reliable.
+- [ ] [Internal] 🗂️ Added a deferred open-issue playbook for identity linking/account merge policy, data migration, and admin safety checks.
+- [ ] [Internal] 🧾 Added a dedicated audited admin override commit path for non-owned trip edits with lifecycle lock enforcement.
+- [ ] [Internal] 🧱 Added a dedicated admin-only hard-delete trip RPC with audit logging so permanent removals are tracked server-side.
+- [ ] [Internal] 🧭 Updated agent copy/i18n rules so admin workspace text is English-only by default and exempt from EN/DE sign-off prompts.
+- [ ] [Internal] 🧩 Standardized admin destructive confirmations on the shared styled app dialog (`useAppDialog`) and documented prompt-component reuse in repo guidelines.

--- a/docs/ADMIN_TRIP_ACCESS_PHASE1.md
+++ b/docs/ADMIN_TRIP_ACCESS_PHASE1.md
@@ -5,16 +5,27 @@
 - Admin users can open any trip route (`/trip/:tripId`) even when they are not the trip owner.
 - Access is enforced in Supabase via admin permission checks (`trips.read`) in `public.admin_get_trip_for_view(...)`.
 - Non-admin users keep existing owner-based behavior.
+- Admin fallback trips now open read-only by default, with an explicit admin override switch to enable editing.
+- Trip view now shows direct owner identity context and a one-click jump into the owner drawer in Admin Users.
+- Admin override writes now use a dedicated audited RPC path (`public.admin_override_trip_commit(...)`) guarded by `trips.write`.
 
-## Intentionally deferred
+## Lifecycle guardrails
 
-- "Admin override mode" for editing non-owned trips.
-- Read-only banner/indicator inside trip view when opened via admin fallback.
-- Direct owner identity block/link in trip view itself (outside admin tables/drawers).
+- Archived trips stay read-only in trip view, even in admin fallback.
+- Expired trips stay read-only in trip view, even in admin fallback.
+- Editing non-owned trips requires explicit enablement each time the trip page is opened.
 
 ## Main implementation files
 
 - `docs/supabase.sql`
   - Added `public.admin_get_trip_for_view(p_trip_id text)`
+  - Added `public.admin_override_trip_commit(...)`
 - `services/dbService.ts`
-  - `dbGetTrip(...)` now attempts admin fallback only when owner-scoped fetch returns no row.
+  - `dbGetTrip(...)` now attempts admin fallback only when owner-scoped fetch returns no row and returns access metadata.
+  - Added `dbAdminOverrideTripCommit(...)` wrapper.
+- `App.tsx`
+  - Trip loader now passes admin access context into trip view and routes admin override commits through the new RPC.
+- `components/TripView.tsx`
+  - Added admin fallback banner, explicit override switch, and owner deep-link CTA.
+- `pages/AdminUsersPage.tsx`
+  - Added URL-driven drawer deep links (`/admin/users?user=<uuid>&drawer=user`).

--- a/docs/ADMIN_WORKSPACE_FOLLOWUPS.md
+++ b/docs/ADMIN_WORKSPACE_FOLLOWUPS.md
@@ -21,11 +21,6 @@ This note captures open admin/user-management items that are intentionally defer
 
 ## Open UX/Feature Follow-ups
 
-- [ ] Consider unifying user-edit access from Trips into the same full user editor drawer route state.
-  - Current behavior: Trips page opens an owner info drawer and provides a jump button to users page.
-  - Primary file: `pages/AdminTripsPage.tsx`
-  - Supporting file: `pages/AdminUsersPage.tsx`
-
 - [ ] Final polish pass for data-table filter UX parity once the shell layout refactor is done.
   - Current filter components are functional; final visual rhythm and spacing should be revisited after shell refactor.
   - Primary shared component: `components/admin/AdminFilterMenu.tsx`
@@ -59,6 +54,12 @@ This note captures open admin/user-management items that are intentionally defer
 - User details drawer:
   - Connected trip titles now open trip URLs directly.
   - Trip title area widened to avoid early ellipsis.
+  - File: `pages/AdminUsersPage.tsx`
+
+- Trip-owner deep links:
+  - Trips and trip-view admin fallback now deep-link directly into the Users drawer via URL state.
+  - File: `pages/AdminTripsPage.tsx`
+  - File: `components/TripView.tsx`
   - File: `pages/AdminUsersPage.tsx`
 
 ## Quick Resume Checklist (Next Admin Iteration)

--- a/docs/ANALYTICS_CONVENTION.md
+++ b/docs/ANALYTICS_CONVENTION.md
@@ -146,6 +146,8 @@ All analytics events use a **BEM-inspired** naming format enforced by a TypeScri
 |-------|--------|---------|------|
 | `trip_view__auth--login` | — | `{ trip_id }` | `TripView.tsx` |
 | `trip_view__auth--logout` | — | `{ trip_id }` | `TripView.tsx` |
+| `trip_view__admin_override--toggle` | — | `{ trip_id, enabled }` | `TripView.tsx` |
+| `trip_view__admin_owner--open_users` | — | `{ trip_id, owner_id }` | `TripView.tsx` |
 
 ### Not Found
 | Event | Detail | Payload | File |

--- a/docs/I18N_PAGE_WORKFLOW.md
+++ b/docs/I18N_PAGE_WORKFLOW.md
@@ -103,6 +103,7 @@ When adding a new key:
 1. Keep the URL unprefixed (no locale segment).
 2. Use active app language for text + formatting.
 3. Do not introduce locale-specific tool path variants unless explicitly approved.
+4. Admin workspace copy (`/admin/*`) is English-only by default; do not add locale keys for admin-only labels unless localization is explicitly requested.
 
 ## AI Translation Disclaimer
 - Localized marketing pages show translation disclaimer banner via `components/marketing/TranslationNoticeBanner.tsx`.

--- a/docs/UX_COPY_GUIDELINES.md
+++ b/docs/UX_COPY_GUIDELINES.md
@@ -57,10 +57,12 @@ This guide defines how to write copy for TravelFlow marketing pages, CTAs, and p
   - show final DE copy block
   - ask if tone should be more playful, more premium, or more direct
 - If feedback is unclear, ask a focused follow-up question before shipping.
+- Exemption: Admin workspace copy (`/admin/*`, admin tables/drawers/modals, admin-only controls) is English-only by default and does not require EN/DE sign-off unless explicitly requested.
 
 ## Agent Checklist For Copy Changes
 1. Check this file before editing marketing/planner text.
 2. Draft copy in EN first, then adapt to DE with transcreation (not literal translation).
 3. Validate consistency with existing UI terminology.
-4. Request EN/DE style sign-off from the user.
-5. Only finalize after feedback or explicit user opt-out.
+4. Request EN/DE style sign-off from the user for localized marketing/planner copy.
+5. Skip bilingual sign-off for admin-only copy unless explicitly requested.
+6. Only finalize after feedback or explicit user opt-out where sign-off applies.

--- a/docs/open-issues/identity-linking-and-account-merge-playbook.md
+++ b/docs/open-issues/identity-linking-and-account-merge-playbook.md
@@ -1,0 +1,70 @@
+# Identity Linking + Account Merge Best Practices (Deferred)
+
+## Status
+Open issue (deferred). Not planned for the current release.
+
+## Short Description
+Define and implement a safe strategy for linking multiple auth identities (email/password + social providers) to one user account, and for handling existing duplicate users that share the same email.
+
+## Why This Matters
+- Admin tooling currently surfaces identity providers, but duplicate accounts can still exist.
+- Same email across providers is not always a safe automatic-merge signal.
+- Incorrect merges can cause data loss, privilege leaks, or broken login flows.
+
+## Scope To Design (Later)
+- Identity-linking rules for new and existing users.
+- Duplicate-account detection and review workflow.
+- Admin-safe account merge flow (with audit trail and rollback strategy).
+- Post-merge data integrity validation.
+
+## Key Decisions We Should Make
+1. Trust policy for automatic merge:
+- Never auto-merge by email only, or only for verified emails + approved providers?
+
+2. Source of truth for identity ownership:
+- Keep Supabase auth user as canonical identity root, with app profile attached.
+
+3. Merge direction strategy:
+- Keep oldest account, keep most active account, or manual admin choice.
+
+4. Provider conflict handling:
+- What happens if provider identity is already linked to another user.
+
+5. Session + token behavior:
+- Re-auth requirements and active session invalidation after merge.
+
+## Security + Compliance Checklist
+- Enforce permission gate for all merge/link operations.
+- Require explicit admin confirmation for destructive steps.
+- Write structured audit logs for every link/unlink/merge action.
+- Prevent merge when role/tier mismatch introduces privilege escalation.
+- Add dry-run preview before commit.
+
+## Data Migration Considerations
+- Move ownership safely for trips, versions, shares, settings, and profile references.
+- Preserve timestamps and provenance metadata where possible.
+- Recompute derived counters/materialized stats after merge.
+- Protect against partial merges using transaction boundaries.
+
+## UX Considerations
+- Show clear duplicate signals in admin user drawer.
+- Explain why users are flagged as possible duplicates.
+- Provide a merge preview with before/after summary.
+- Offer explicit “do not suggest merge for this pair” suppression.
+
+## Testing Requirements
+- Unit tests for merge eligibility rules.
+- Integration tests for data move + identity relinking.
+- Permission tests for read-only admin vs write admin.
+- Recovery test for interrupted/failed merge operations.
+
+## Open Questions
+- Should we allow user self-serve account linking, admin-only linking, or both?
+- Should merge be reversible for a limited time window?
+- How should we handle localization/account preferences when both accounts differ?
+
+## Suggested Future Deliverables
+- `docs/IDENTITY_LINKING_POLICY.md`
+- SQL/RPC migrations for merge/link workflows
+- Admin UI flow: duplicate review + merge preview + merge commit
+- Runbook for support/admin operations

--- a/pages/AdminAiBenchmarkPage.tsx
+++ b/pages/AdminAiBenchmarkPage.tsx
@@ -28,6 +28,7 @@ import { dbGetAccessToken, ensureDbSession } from '../services/dbService';
 import { getDaysDifference, getDefaultTripDates, getDestinationPromptLabel, resolveDestinationName } from '../utils';
 import { useAuth } from '../hooks/useAuth';
 import { AdminShell } from '../components/admin/AdminShell';
+import { useAppDialog } from '../components/AppDialogProvider';
 import {
     Select,
     SelectContent,
@@ -398,6 +399,7 @@ export const AdminAiBenchmarkPage: React.FC = () => {
     const defaultDates = useMemo(() => getDefaultTripDates(), []);
     const [searchParams, setSearchParams] = useSearchParams();
     const { isAuthenticated } = useAuth();
+    const { confirm: confirmDialog } = useAppDialog();
 
     const [accessToken, setAccessToken] = useState<string | null>(null);
 
@@ -1129,7 +1131,13 @@ export const AdminAiBenchmarkPage: React.FC = () => {
             return;
         }
 
-        const confirmed = window.confirm('Delete benchmark trips and benchmark rows for this session? This cannot be undone.');
+        const confirmed = await confirmDialog({
+            title: 'Delete benchmark session data',
+            message: 'Delete benchmark trips and benchmark rows for this session? This cannot be undone.',
+            confirmLabel: 'Delete',
+            cancelLabel: 'Cancel',
+            tone: 'danger',
+        });
         if (!confirmed) return;
 
         setLoading(true);
@@ -1161,7 +1169,7 @@ export const AdminAiBenchmarkPage: React.FC = () => {
         } finally {
             setLoading(false);
         }
-    }, [fetchBenchmarkApi, searchParams, session, setSearchParams]);
+    }, [confirmDialog, fetchBenchmarkApi, searchParams, session, setSearchParams]);
 
     const addSelectionRow = useCallback(() => {
         setSelectionRows((current) => [...current, createSelectionRow()]);

--- a/services/adminService.ts
+++ b/services/adminService.ts
@@ -7,6 +7,7 @@ export interface AdminUserRecord {
     email: string | null;
     is_anonymous?: boolean;
     auth_provider?: string | null;
+    auth_providers?: string[] | null;
     activation_status?: 'activated' | 'invited' | 'pending' | 'anonymous' | null;
     last_sign_in_at?: string | null;
     display_name?: string | null;
@@ -20,6 +21,8 @@ export interface AdminUserRecord {
     account_status?: 'active' | 'disabled' | 'deleted';
     disabled_at?: string | null;
     disabled_by?: string | null;
+    active_trips?: number | null;
+    total_trips?: number | null;
     system_role: 'admin' | 'user';
     tier_key: PlanTierKey;
     entitlements_override: Record<string, unknown> | null;
@@ -202,6 +205,14 @@ export const adminUpdateTrip = async (
         p_apply_owner_id: Object.prototype.hasOwnProperty.call(patch, 'ownerId'),
     });
     if (error) throw new Error(error.message || 'Could not update trip.');
+};
+
+export const adminHardDeleteTrip = async (tripId: string): Promise<void> => {
+    const client = requireSupabase();
+    const { error } = await client.rpc('admin_hard_delete_trip', {
+        p_trip_id: tripId,
+    });
+    if (error) throw new Error(error.message || 'Could not hard-delete trip.');
 };
 
 export const adminUpdatePlanEntitlements = async (


### PR DESCRIPTION
## Summary
- complete Phase 1 admin trip-access follow-ups from `docs/ADMIN_TRIP_ACCESS_PHASE1.md`
- add secure admin override write path wiring and read-only-by-default trip banner/switch UX
- add owner deep-link routing (`/admin/users?user=<uuid>&drawer=user`) from Trips + TripView
- support direct Users drawer deep-links and URL sync/close behavior
- add multi-select bulk soft/hard delete actions for Users and Trips tables
- fix admin UI issues (outside-click drawer close, loading/release modal overlap, sidebar height, connected trips controls)
- add richer login identity model in Admin Users (provider arrays from auth identities, login pills/icons, login-type filters with social provider subgroup + indeterminate parent state)
- add user trip counters (`active_trips`, `total_trips`) to users table and details header, plus shortcut to filtered Trips view
- add deferred open-issue playbook for identity linking/account merge best practices

## Data / SQL
- updated `admin_get_trip_for_view` signature support and introduced `admin_override_trip_commit`
- updated `admin_list_users` + `admin_get_user_profile` to return `auth_providers`, `active_trips`, and `total_trips`
- included safe drop/recreate handling for changed function return signatures

## Docs
- updated admin phase/follow-up docs and repo agent UX/i18n/admin prompt guidance
- updated existing release note file with shipped scope
- added `docs/open-issues/identity-linking-and-account-merge-playbook.md`

## Validation
- `npm run build`
