### PR TITLE
Fix shared-trip handoff for non-owners and keep rich trip OG previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Then open the app via `http://localhost:8888` so `/api/*` routes are handled by 
 - `/` marketing landing page
 - `/es/*`, `/de/*`, `/fr/*`, `/pt/*`, `/ru/*`, `/it/*`, `/pl/*`, `/ko/*` localized marketing pages (English stays on root paths)
 - `/create-trip` trip creation flow
-- `/trip/:tripId` planner
+- `/trip/:tripId` planner (owner/admin stays; non-owner viewers route to `/s/:token` when an active share exists; without share they are routed to login/share-unavailable)
 - `/example/:templateId` example trip playground (ephemeral, non-persistent)
 - `/s/:token` shared trip link
 - `/updates` marketing updates feed from markdown release files
@@ -109,6 +109,7 @@ For trip lifecycle state handling, lock behavior, and paywall rules, use:
 For DB-backed trips, history snapshots, sharing, and auth/RLS troubleshooting, use:
 
 - `docs/SUPABASE_RUNBOOK.md`
+- `docs/SHARE_USERFLOWS.md`
 
 ## Build
 
@@ -238,6 +239,7 @@ Sitemap behavior:
 
 - Non-trip pages (home, features, updates, blog, legal pages, etc.) use a dedicated `/api/og/site` image generator with page title + subline, TravelFlow branding, and an accent-gradient hero.
 - Shared links (`/s/:token`) use Netlify Edge Functions to inject route-specific Open Graph and Twitter meta tags into the HTML response.
+- Direct trip links (`/trip/:tripId`) with an active share use share-backed OG metadata/images, and non-owner viewers are routed to the canonical shared route (`/s/:token`).
 - OG images are generated at `/api/og/trip` with `og_edge` (Netlify-compatible `@vercel/og`), including:
   - trip title
   - weeks/months/total distance metrics

--- a/content/updates/2026-02-18-og-font-latin-priority-fix.md
+++ b/content/updates/2026-02-18-og-font-latin-priority-fix.md
@@ -1,17 +1,22 @@
 ---
 id: rel-2026-02-18-og-font-latin-priority-fix
 version: v0.50.0
-title: "OG preview typography fallback regression fix"
+title: "OG preview typography and shared-link resilience fixes"
 date: 2026-02-18
 published_at: 2026-02-18T14:30:00Z
 status: draft
 notify_in_app: false
 in_app_hours: 24
-summary: "Fixed a social preview typography regression and expanded OG font-weight coverage so title styles stay consistent."
+summary: "Fixed social preview typography fallbacks and restored rich trip previews when shared trip pages are opened from direct trip links."
 ---
 
 ## Changes
 - [x] [Fixed] 🔤 Shared and page social preview titles now render with the intended brand typography more consistently.
 - [x] [Improved] 🎚️ Social previews now keep branded typography across a wider range of headline font weights.
+- [x] [Fixed] 🔗 Shared trips now keep rich social previews even when a direct trip page link is shared.
+- [x] [Improved] ↪️ Direct trip links now route non-owner viewers to the shared version when an active share already exists.
+- [x] [Improved] 🔐 Non-shared private trip links now route users to clear next steps (login for unauthenticated visitors, unavailable state for non-owners) instead of dropping to trip creation.
 - [ ] [Internal] 🧱 Updated OG font loading priority so full Latin font files are selected before partial extended subsets.
 - [ ] [Internal] 🧮 Added OG font-weight alias coverage from 100 to 900 so future weight tweaks avoid system-font fallback.
+- [ ] [Internal] 🛡️ Added server-side share-token resolution for direct trip OG metadata/image rendering so preview data can be loaded from active share state.
+- [ ] [Internal] 🗺️ Added documented sharing userflow charts and redirect semantics for trip-vs-share route handling.

--- a/docs/SHARE_USERFLOWS.md
+++ b/docs/SHARE_USERFLOWS.md
@@ -1,0 +1,50 @@
+# Share Userflows
+
+This document defines how TravelFlow resolves share links and direct trip links.
+
+## Canonical rules
+
+1. `/s/:token` is the canonical public/shared route.
+2. `/trip/:tripId` is the owner planner route.
+3. Owner and admin users stay on `/trip/:tripId`.
+4. If a non-owner/non-admin opens `/trip/:tripId` and an active share token exists, the app routes to `/s/:token`.
+5. If no active share exists:
+   - logged-out users are sent to `/login` (with return-path memory),
+   - logged-in non-owners are sent to `/share-unavailable`.
+
+## Sharing flow chart
+
+```mermaid
+flowchart LR
+  A["User opens a link"] --> B{"Route type?"}
+  B -->|"\"/s/:token\""| C["Load shared trip via share token"]
+  B -->|"\"/trip/:tripId\""| D["Attempt trip load with access context"]
+
+  D --> E{"Owner or admin?"}
+  E -->|"Yes"| H["Stay on \"/trip/:tripId\""]
+  E -->|"No"| G["Resolve active share token via /api/trip-share-resolve"]
+  G --> I{"Active share exists?"}
+  I -->|"Yes"| J["Client route handoff to \"/s/:token\""]
+  I -->|"No"| M{"Logged in?"}
+  M -->|"No"| N["Navigate to \"/login\" with return path"]
+  M -->|"Yes"| O["Navigate to \"/share-unavailable\""]
+
+  C --> K["Render shared mode (view/edit)"]
+  J --> C
+  H --> L["Render planner route"]
+```
+
+## OG preview flow chart
+
+```mermaid
+flowchart LR
+  A["Crawler fetches trip/share URL"] --> B{"Route type?"}
+  B -->|"\"/s/:token\""| C["Resolve shared trip data by token"]
+  B -->|"\"/trip/:tripId\""| D["Resolve active share token by trip id"]
+  D --> E{"Token found?"}
+  E -->|"Yes"| F["Use shared trip data for OG metadata and image"]
+  E -->|"No"| G["Fallback trip OG metadata/image"]
+  C --> F
+  F --> H["Return rich OG tags + trip image"]
+  G --> I["Return generic fallback OG tags/image"]
+```

--- a/docs/SUPABASE_RUNBOOK.md
+++ b/docs/SUPABASE_RUNBOOK.md
@@ -166,11 +166,12 @@ Main write path (client):
 Share path:
 
 1. `rpc('create_share_token', ...)`.
-2. Open share URL `/s/:token`.
-3. Load shared data via `rpc('get_shared_trip', ...)`.
-4. Optional snapshot load via `rpc('get_shared_trip_version', ...)` when URL has `?v=<uuid>`.
-5. If share mode is `edit`, save changes via `rpc('update_shared_trip', ...)`.
-6. In `view` mode, editing controls are disabled; copy creates a new owned trip.
+2. Open share URL `/s/:token` (canonical shared route).
+3. If a direct planner URL (`/trip/:tripId`) is opened by a non-owner (and non-admin) for a trip that has an active share, the trip loader resolves the active share token and routes to `/s/:token`.
+4. Load shared data via `rpc('get_shared_trip', ...)`.
+5. Optional snapshot load via `rpc('get_shared_trip_version', ...)` when URL has `?v=<uuid>`.
+6. If share mode is `edit`, save changes via `rpc('update_shared_trip', ...)`.
+7. In `view` mode, editing controls are disabled; copy creates a new owned trip.
 
 ## Migration Behavior (LocalStorage -> DB)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -50,6 +50,10 @@
   function = "trip-map-preview"
 
 [[edge_functions]]
+  path = "/api/trip-share-resolve"
+  function = "trip-share-resolve"
+
+[[edge_functions]]
   path = "/api/og/trip"
   function = "trip-og-image"
 

--- a/netlify/edge-functions/trip-og-image.tsx
+++ b/netlify/edge-functions/trip-og-image.tsx
@@ -5,6 +5,7 @@ import {
   buildTripOgSummary,
   fallbackSummary,
   fetchSharedTrip,
+  fetchSharedTripByTripId,
   getMapsApiKeyFromEnv,
   isMapColorMode,
   isOgMapStyle,
@@ -560,6 +561,21 @@ export default async (request: Request): Promise<Response> => {
       }
     } else if (tripId) {
       routePath = buildDisplayPath({ tripId, versionId });
+      const sharedByTripId = await fetchSharedTripByTripId(tripId, versionId);
+      if (sharedByTripId) {
+        const sharedTrip = sharedByTripId.sharedTrip;
+        summary = await buildTripOgSummary(sharedTrip.trip, {
+          mapsApiKey,
+          mapStyle: mapStyleOverride ?? sharedTrip.viewSettings?.mapStyle,
+          routeMode: routeModeOverride ?? sharedTrip.viewSettings?.routeMode,
+          mapColorMode: mapColorModeOverride ?? sharedTrip.viewSettings?.mapColorMode ?? sharedTrip.trip.mapColorMode,
+          showStops: showStopsOverride ?? sharedTrip.viewSettings?.showStops,
+          showCities: showCitiesOverride ??
+            sharedTrip.viewSettings?.showCities ??
+            sharedTrip.viewSettings?.showCityNames,
+          showCityNames: sharedTrip.viewSettings?.showCityNames,
+        });
+      }
     }
 
     if (titleOverride) summary.title = titleOverride;

--- a/netlify/edge-functions/trip-share-resolve.ts
+++ b/netlify/edge-functions/trip-share-resolve.ts
@@ -1,0 +1,51 @@
+import { fetchActiveTripShareToken } from "../edge-lib/trip-og-data.ts";
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "no-store",
+};
+
+const isSafeParam = (value: string): boolean =>
+  value.length > 0 && value.length <= 180;
+
+export default async (request: Request): Promise<Response> => {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: JSON_HEADERS,
+    });
+  }
+
+  const url = new URL(request.url);
+  const tripId = (url.searchParams.get("trip") || "").trim();
+  const versionId = (url.searchParams.get("v") || "").trim();
+
+  if (!isSafeParam(tripId)) {
+    return new Response(JSON.stringify({ error: "Missing or invalid trip id" }), {
+      status: 400,
+      headers: JSON_HEADERS,
+    });
+  }
+
+  const shareToken = await fetchActiveTripShareToken(tripId);
+  if (!shareToken) {
+    return new Response(JSON.stringify({ error: "No active share token for this trip" }), {
+      status: 404,
+      headers: JSON_HEADERS,
+    });
+  }
+
+  const shareUrl = new URL(`/s/${encodeURIComponent(shareToken)}`, url.origin);
+  if (isSafeParam(versionId)) {
+    shareUrl.searchParams.set("v", versionId);
+  }
+
+  return new Response(JSON.stringify({
+    token: shareToken,
+    path: shareUrl.pathname + shareUrl.search,
+    url: shareUrl.toString(),
+  }), {
+    status: 200,
+    headers: JSON_HEADERS,
+  });
+};


### PR DESCRIPTION
## Summary
- add shared-link resolution endpoint (`/api/trip-share-resolve`) to map `/trip/:id` to the active `/s/:token` link when applicable
- update `/trip/:id` access flow so owners/admins keep direct access while non-owners are redirected to shared links (or clear fallback states)
- keep trip Open Graph previews rich for shared trip data
- document sharing behavior and decision flows, including Mermaid userflow charts

## Behavior changes
- non-owners hitting `/trip/:id` are redirected to `/s/:token` if an active share exists
- owners and admins are not auto-redirected away from direct trip pages
- authenticated non-owners without an active share are sent to `/share-unavailable`
- unauthenticated users without an active share are sent to `/login` with return URL

## Validation
- `npm run edge:validate`
- `npm run updates:validate`
