### PR TITLE
Publish release note for trip city panel merge

### DIFF
--- a/content/updates/2026-02-23-trip-city-panels-modern-uncertain-options.md
+++ b/content/updates/2026-02-23-trip-city-panels-modern-uncertain-options.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-02-23-trip-city-panels-modern-uncertain-options
-version: v0.56.0
+version: v0.55.0
 title: "Modernized City Panels and Uncertain Stop Variants"
 date: 2026-02-23
-published_at: 2026-02-23T14:00:00Z
-status: draft
+published_at: 2026-02-23T20:23:09Z
+status: published
 notify_in_app: true
 in_app_hours: 24
 summary: "Trip city panels now use softer modern color blending and can visually represent tentative city options."


### PR DESCRIPTION
## Summary
- publish the merged trip city panel release note from draft to published
- set the next strict release version (`v0.55.0`)
- set `published_at` to the actual merge timestamp (`2026-02-23T20:23:09Z`)

## Validation
- `pnpm updates:validate`
- `pnpm updates:next-version`
