### PR TITLE
feat(storage): issue #125 follow-up hardening pass

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,14 @@
 ## Summary
 - 
 
+## Related Issues
+- Refs #
+- Closes #
+
 ## Validation
 - [ ] `pnpm test:core`
 - [ ] `pnpm build`
+- [ ] `pnpm storage:validate`
 
 ## New Module Guard
 - [ ] New module guard completed

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate storage registry
+        run: pnpm storage:validate
+
       - name: New module guard (services/config => tests checklist entry)
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This repository uses markdown release files as the source of truth for product u
 - Keep route slugs English-only for canonical URLs. Do not add localized slug aliases or compatibility redirects (for example `/impressum`) unless a dedicated issue explicitly requests it. Locale support is prefix-only (`/{locale}/...`) on top of English slugs.
 - Treat `lib/legal/cookies.config.ts` as the single source of truth for browser persistence disclosures (cookies + localStorage + sessionStorage). Any new/changed/removed storage key must be updated there and reflected by the legal cookie policy page.
 - Run `pnpm storage:validate` when browser storage keys are introduced or changed; do not merge storage keys that are not registered.
+- When a PR resolves a GitHub issue, include a closing keyword in the PR description (for example `Closes #123`) so merge to `main` auto-closes the issue.
 - For user-facing copy changes in marketing/planner surfaces, request user style sign-off in English and German before finalizing unless the user explicitly opts out.
 - Admin workspace copy (`/admin/*`, admin tables, drawers, and admin-only controls) is English-only by default and is exempt from EN/DE style sign-off and translation requirements unless the user explicitly asks for localization.
 - For locale interpolation, use ICU placeholders (`{name}`), never `{{name}}`.

--- a/content/updates/2026-02-24-storage-registry-governance-follow-up.md
+++ b/content/updates/2026-02-24-storage-registry-governance-follow-up.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-02-24-storage-registry-governance-follow-up
+version: v0.57.0
+title: "Storage registry governance follow-up"
+date: 2026-02-24
+published_at: 2026-02-24T09:45:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Storage governance follow-up improves validation reliability and CI visibility for browser persistence disclosures."
+---
+
+## Changes
+- [x] [Improved] 🛡️ Browser-storage governance checks are now more reliable for dynamic key helpers used by the app.
+- [ ] [Internal] 🧪 Added an explicit PR quality workflow step to run `pnpm storage:validate`.
+- [ ] [Internal] 🧭 Updated PR template guidance so issue links and auto-close keywords are added consistently.

--- a/scripts/validate-storage-registry.ts
+++ b/scripts/validate-storage-registry.ts
@@ -10,6 +10,11 @@ interface FileConstDefinition {
   line: number;
 }
 
+interface HelperFunctionDefinition {
+  name: string;
+  wildcardKey: string;
+}
+
 interface ExpectedStorageKey {
   key: string;
   storage: StorageMedium;
@@ -21,11 +26,43 @@ interface RegistryEntry {
   storage: CookieDefinition['storage'];
 }
 
+interface DynamicAllowlistRule {
+  filePattern: RegExp;
+  expressionPattern: RegExp;
+  reason: string;
+}
+
 const ROOT = process.cwd();
 const SOURCE_TARGETS = ['App.tsx', 'i18n.ts', 'components', 'pages', 'services', 'config', 'hooks', 'lib'];
 const KEY_PREFIXES = ['tf_', 'travelflow_', 'admin.', 'sb-'];
 const STORAGE_CALL_PATTERN = /(?:window\.)?(localStorage|sessionStorage)\.(?:getItem|setItem|removeItem)\(\s*([^,)]+)\s*(?:,|\))/g;
 const CONST_STRING_PATTERN = /\bconst\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(["'`])([^"'`]+)\2/g;
+const HELPER_TEMPLATE_PATTERN = /\bconst\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*\([^)]*\)\s*(?::\s*[^=]+)?=>\s*`([^`]+)`/g;
+const DERIVED_KEY_ASSIGNMENT_PATTERN = /\bconst\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*([A-Za-z_$][A-Za-z0-9_$]*)\([^)]*\)\s*;/g;
+const CALL_EXPRESSION_PATTERN = /^([A-Za-z_$][A-Za-z0-9_$]*)\([^)]*\)$/;
+
+const DYNAMIC_ALLOWLIST: DynamicAllowlistRule[] = [
+  {
+    filePattern: /^components\/OnPageDebugger\.tsx$/,
+    expressionPattern: /^storageKey$/,
+    reason: 'Generic helper wrapper over fixed debug storage constants in the same file.',
+  },
+  {
+    filePattern: /^components\/admin\/adminLocalCache\.ts$/,
+    expressionPattern: /^key$/,
+    reason: 'Generic admin cache helper; concrete keys are validated at callsites.',
+  },
+  {
+    filePattern: /^pages\/UpdatesPage\.tsx$/,
+    expressionPattern: /^storageKey$/,
+    reason: 'Generic helper wrapper over fixed key constants in the same file.',
+  },
+  {
+    filePattern: /^services\/authService\.ts$/,
+    expressionPattern: /^key$/,
+    reason: 'Dynamic key cleanup loop; wildcard Supabase auth keys are registry-tracked.',
+  },
+];
 
 const isTsSourceFile = (filePath: string): boolean =>
   /\.(ts|tsx)$/.test(filePath) && !/(\.test\.|\.spec\.)/.test(filePath);
@@ -42,8 +79,21 @@ const toLineNumber = (content: string, index: number): number =>
 const trimInlineComments = (value: string): string =>
   value.replace(/\/\/.*$/, '').trim();
 
+const countOccurrences = (value: string, char: string): number =>
+  value.split(char).length - 1;
+
+const rebalanceParentheses = (value: string): string => {
+  const openCount = countOccurrences(value, '(');
+  const closeCount = countOccurrences(value, ')');
+  if (openCount <= closeCount) return value;
+  return `${value}${')'.repeat(openCount - closeCount)}`;
+};
+
+const normalizeExpression = (raw: string): string =>
+  rebalanceParentheses(trimInlineComments(raw.trim()));
+
 const parseStringLiteral = (raw: string): string | null => {
-  const trimmed = trimInlineComments(raw.trim());
+  const trimmed = normalizeExpression(raw);
   if ((trimmed.startsWith("'") && trimmed.endsWith("'")) || (trimmed.startsWith('"') && trimmed.endsWith('"'))) {
     return trimmed.slice(1, -1);
   }
@@ -86,6 +136,67 @@ const inferConstStorage = (
   if (constName.includes('LOCAL')) return ['localStorage'];
   if (fileStorageUsage.size > 0) return [...fileStorageUsage];
   return ['localStorage'];
+};
+
+const parseHelperWildcardKey = (
+  templateBody: string,
+  localConstMap: Map<string, FileConstDefinition>,
+): string | null => {
+  const fromConstPrefix = templateBody.match(/^\$\{([A-Za-z_$][A-Za-z0-9_$]*)\}\$\{[A-Za-z_$][A-Za-z0-9_$]*\}$/);
+  if (fromConstPrefix) {
+    const prefixConst = localConstMap.get(fromConstPrefix[1]);
+    if (!prefixConst || !hasStorageKeyPrefix(prefixConst.value)) return null;
+    return `${prefixConst.value}*`;
+  }
+
+  const fromLiteralPrefix = templateBody.match(/^([^$`]+)\$\{[A-Za-z_$][A-Za-z0-9_$]*\}$/);
+  if (fromLiteralPrefix) {
+    const prefix = fromLiteralPrefix[1];
+    if (!hasStorageKeyPrefix(prefix)) return null;
+    return `${prefix}*`;
+  }
+
+  return null;
+};
+
+const findHelperFunctions = (
+  content: string,
+  localConstMap: Map<string, FileConstDefinition>,
+): Map<string, HelperFunctionDefinition> => {
+  const helpers = new Map<string, HelperFunctionDefinition>();
+  for (const match of content.matchAll(HELPER_TEMPLATE_PATTERN)) {
+    const [, helperName, templateBody] = match;
+    if (!helperName || !templateBody) continue;
+    const wildcardKey = parseHelperWildcardKey(templateBody, localConstMap);
+    if (!wildcardKey) continue;
+    helpers.set(helperName, {
+      name: helperName,
+      wildcardKey,
+    });
+  }
+  return helpers;
+};
+
+const findDerivedKeyVariables = (
+  content: string,
+  helperFunctionMap: Map<string, HelperFunctionDefinition>,
+): Map<string, string> => {
+  const derivedKeyMap = new Map<string, string>();
+  for (const match of content.matchAll(DERIVED_KEY_ASSIGNMENT_PATTERN)) {
+    const [, variableName, helperName] = match;
+    if (!variableName || !helperName) continue;
+    const helper = helperFunctionMap.get(helperName);
+    if (!helper) continue;
+    derivedKeyMap.set(variableName, helper.wildcardKey);
+  }
+  return derivedKeyMap;
+};
+
+const findAllowlistReason = (filePath: string, expression: string): string | null => {
+  const rule = DYNAMIC_ALLOWLIST.find(
+    (entry) => entry.filePattern.test(filePath) && entry.expressionPattern.test(expression),
+  );
+  return rule ? rule.reason : null;
 };
 
 const readFileIfExists = async (target: string): Promise<Array<{ filePath: string; content: string }>> => {
@@ -131,8 +242,10 @@ const main = async () => {
   const registryEntries = toRegistryEntries();
   const expected: ExpectedStorageKey[] = [];
   const unresolved: string[] = [];
+  const allowlistedDynamic: string[] = [];
 
   for (const { filePath, content } of files) {
+    const relativePath = toRelative(filePath);
     const localConstMap = new Map<string, FileConstDefinition>();
     const fileStorageUsage = new Set<StorageMedium>();
     const normalizedContent = normalizeLineEnding(content);
@@ -149,27 +262,55 @@ const main = async () => {
       });
     }
 
+    const helperFunctionMap = findHelperFunctions(normalizedContent, localConstMap);
+    const derivedKeyMap = findDerivedKeyVariables(normalizedContent, helperFunctionMap);
+
     for (const match of normalizedContent.matchAll(STORAGE_CALL_PATTERN)) {
       const [, storageRaw, argRaw] = match;
       if (!storageRaw || !argRaw) continue;
       const storage = storageRaw as StorageMedium;
       fileStorageUsage.add(storage);
       const sourceLine = toLineNumber(normalizedContent, match.index ?? 0);
-      const source = `${toRelative(filePath)}:${sourceLine}`;
-      const literal = parseStringLiteral(argRaw);
+      const source = `${relativePath}:${sourceLine}`;
+      const expression = normalizeExpression(argRaw);
+
+      const literal = parseStringLiteral(expression);
       if (literal && hasStorageKeyPrefix(literal)) {
         expected.push({ key: literal, storage, source });
         continue;
       }
-      if (isIdentifier(argRaw)) {
-        const keyDef = localConstMap.get(argRaw.trim());
+
+      if (isIdentifier(expression)) {
+        const keyDef = localConstMap.get(expression);
         if (keyDef && hasStorageKeyPrefix(keyDef.value)) {
           const key = keyDef.name.includes('PREFIX') ? `${keyDef.value}*` : keyDef.value;
           expected.push({ key, storage, source });
           continue;
         }
+        const derivedKey = derivedKeyMap.get(expression);
+        if (derivedKey) {
+          expected.push({ key: derivedKey, storage, source });
+          continue;
+        }
       }
-      unresolved.push(`${source} -> ${trimInlineComments(argRaw.trim())}`);
+
+      const callMatch = expression.match(CALL_EXPRESSION_PATTERN);
+      if (callMatch) {
+        const helperName = callMatch[1];
+        const helper = helperFunctionMap.get(helperName);
+        if (helper) {
+          expected.push({ key: helper.wildcardKey, storage, source });
+          continue;
+        }
+      }
+
+      const allowlistReason = findAllowlistReason(relativePath, expression);
+      if (allowlistReason) {
+        allowlistedDynamic.push(`${source} -> ${expression} (${allowlistReason})`);
+        continue;
+      }
+
+      unresolved.push(`${source} -> ${expression}`);
     }
 
     for (const keyDef of localConstMap.values()) {
@@ -180,7 +321,7 @@ const main = async () => {
         expected.push({
           key,
           storage,
-          source: `${toRelative(filePath)}:${keyDef.line}`,
+          source: `${relativePath}:${keyDef.line}`,
         });
       });
     }
@@ -206,6 +347,10 @@ const main = async () => {
   if (missing.length > 0) {
     console.error('[storage:validate] Missing storage registry entries:');
     missing.forEach((item) => console.error(`- ${item}`));
+  }
+
+  if (allowlistedDynamic.length > 0) {
+    console.log(`[storage:validate] Allowlisted dynamic refs: ${allowlistedDynamic.length}`);
   }
 
   if (unresolved.length > 0) {


### PR DESCRIPTION
## Summary
- harden storage validator dynamic-key detection for helper-derived and intermediate key variables
- add explicit dynamic allowlist handling so known wrappers are documented without noisy unresolved output
- run pnpm storage:validate as an explicit PR quality workflow step
- extend PR template with issue-linking and storage validation checklist guidance
- add a draft release-note entry for issue #125 follow-up work

## Related Issues
- Refs #125
- Closes #125

## Validation
- [x] pnpm storage:validate
- [x] pnpm updates:validate
- [x] pnpm test:core
