### PR TITLE
feat(storage): phase 1 consent-aware storage policy foundation

### DIFF
--- a/content/updates/2026-02-24-storage-consent-policy-phase1.md
+++ b/content/updates/2026-02-24-storage-consent-policy-phase1.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-02-24-storage-consent-policy-phase1
+version: v0.58.0
+title: "Storage consent policy phase 1"
+date: 2026-02-24
+published_at: 2026-02-24T10:15:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Phase 1 introduces a central storage policy helper and consent-aware optional storage enforcement."
+---
+
+## Changes
+- [x] [Improved] 🛡️ Optional browser-storage keys are now enforced through a central consent-aware policy helper in critical paths.
+- [x] [Improved] 🧹 Switching back to essential-only consent now clears optional analytics storage keys automatically.
+- [ ] [Internal] ✅ Added regression tests for storage policy behavior, wildcard registry lookups, and consent-triggered optional-key purge.

--- a/i18n.ts
+++ b/i18n.ts
@@ -3,6 +3,7 @@ import { initReactI18next } from 'react-i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES, isLocale } from './config/locales';
 import { APP_NAME } from './config/appGlobals';
+import { readLocalStorageItem, writeLocalStorageItem } from './services/browserStorageService';
 
 const localeModules = import.meta.glob('./locales/*/*.json');
 const preloadCache = new Set<string>();
@@ -31,7 +32,7 @@ const detectLocaleFromLocalStorage = (): string | null => {
     if (typeof window === 'undefined') return null;
 
     try {
-        return normalizeDetectedLocale(window.localStorage.getItem(LOCALE_STORAGE_KEY));
+        return normalizeDetectedLocale(readLocalStorageItem(LOCALE_STORAGE_KEY));
     } catch {
         return null;
     }
@@ -119,7 +120,7 @@ if (typeof window !== 'undefined') {
         const normalized = normalizeDetectedLocale(language);
         if (!normalized) return;
         try {
-            window.localStorage.setItem(LOCALE_STORAGE_KEY, normalized);
+            writeLocalStorageItem(LOCALE_STORAGE_KEY, normalized);
         } catch {
             // Ignore storage write failures (private mode/quota/security).
         }

--- a/lib/legal/cookies.config.ts
+++ b/lib/legal/cookies.config.ts
@@ -33,6 +33,9 @@ const matchesRegistryName = (registeredName: string, keyName: string): boolean =
   return new RegExp(pattern).test(keyName);
 };
 
+export const doesRegistryNameMatch = (registeredName: string, keyName: string): boolean =>
+  matchesRegistryName(registeredName, keyName);
+
 export const COOKIE_REGISTRY: CookieRegistry = {
   essential: [
     {
@@ -428,6 +431,16 @@ export const isCookieRegistered = (cookieName: string): boolean =>
 
 export const getCookieByName = (cookieName: string): CookieDefinition | undefined =>
   getAllCookies().find((cookie) => matchesRegistryName(cookie.name, cookieName));
+
+export const getCookieCategoryByName = (cookieName: string): CookieCategory | null => {
+  const categories: CookieCategory[] = ['essential', 'analytics', 'marketing'];
+  for (const category of categories) {
+    if (COOKIE_REGISTRY[category].some((cookie) => matchesRegistryName(cookie.name, cookieName))) {
+      return category;
+    }
+  }
+  return null;
+};
 
 export const validateCookieRegistry = (): { valid: boolean; errors: string[] } => {
   const errors: string[] = [];

--- a/services/appRuntimeUtils.ts
+++ b/services/appRuntimeUtils.ts
@@ -1,5 +1,6 @@
 import { AppLanguage } from '../types';
 import { DEFAULT_LOCALE, normalizeLocale } from '../config/locales';
+import { readLocalStorageItem, writeLocalStorageItem } from './browserStorageService';
 
 const APP_LANGUAGE_STORAGE_KEY = 'tf_app_language';
 const DEFAULT_APP_LANGUAGE: AppLanguage = DEFAULT_LOCALE;
@@ -22,10 +23,10 @@ export const buildTripUrl = (tripId: string, versionId?: string | null): string 
 
 export const getStoredAppLanguage = (): AppLanguage => {
     if (typeof window === 'undefined') return DEFAULT_APP_LANGUAGE;
-    return normalizeAppLanguage(window.localStorage.getItem(APP_LANGUAGE_STORAGE_KEY));
+    return normalizeAppLanguage(readLocalStorageItem(APP_LANGUAGE_STORAGE_KEY));
 };
 
 export const setStoredAppLanguage = (language: AppLanguage): void => {
     if (typeof window === 'undefined') return;
-    window.localStorage.setItem(APP_LANGUAGE_STORAGE_KEY, normalizeAppLanguage(language));
+    writeLocalStorageItem(APP_LANGUAGE_STORAGE_KEY, normalizeAppLanguage(language));
 };

--- a/services/browserStorageService.ts
+++ b/services/browserStorageService.ts
@@ -1,0 +1,173 @@
+import {
+  COOKIE_REGISTRY,
+  type CookieCategory,
+  type CookieDefinition,
+  doesRegistryNameMatch,
+} from '../lib/legal/cookies.config';
+import { isOptionalConsentGranted, readConsentChoiceFromStorage } from './consentState';
+
+export type BrowserStorageMedium = 'localStorage' | 'sessionStorage';
+
+export interface RegisteredStorageEntry {
+  category: CookieCategory;
+  definition: CookieDefinition;
+}
+
+const CATEGORIES: CookieCategory[] = ['essential', 'analytics', 'marketing'];
+const OPTIONAL_CATEGORIES: CookieCategory[] = ['analytics', 'marketing'];
+const isDevRuntime = Boolean((import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV);
+
+const warnPolicy = (message: string) => {
+  if (!isDevRuntime) return;
+  console.warn(`[browserStoragePolicy] ${message}`);
+};
+
+const getStorage = (medium: BrowserStorageMedium): Storage | null => {
+  if (typeof window === 'undefined') return null;
+  return medium === 'localStorage' ? window.localStorage : window.sessionStorage;
+};
+
+const resolveRegisteredEntry = (
+  keyName: string,
+  medium: BrowserStorageMedium,
+): RegisteredStorageEntry | null => {
+  for (const category of CATEGORIES) {
+    const match = COOKIE_REGISTRY[category].find((entry) =>
+      entry.storage === medium && doesRegistryNameMatch(entry.name, keyName));
+    if (match) {
+      return {
+        category,
+        definition: match,
+      };
+    }
+  }
+  return null;
+};
+
+const isCategoryAllowed = (category: CookieCategory): boolean => {
+  if (category === 'essential') return true;
+  return isOptionalConsentGranted(readConsentChoiceFromStorage());
+};
+
+const removeByRegistryPattern = (storage: Storage, registryName: string): number => {
+  if (!registryName.includes('*')) {
+    const existed = storage.getItem(registryName) !== null;
+    storage.removeItem(registryName);
+    return existed ? 1 : 0;
+  }
+
+  let removed = 0;
+  for (let index = storage.length - 1; index >= 0; index -= 1) {
+    const key = storage.key(index);
+    if (!key) continue;
+    if (!doesRegistryNameMatch(registryName, key)) continue;
+    storage.removeItem(key);
+    removed += 1;
+  }
+  return removed;
+};
+
+export const getRegisteredStorageEntry = (
+  keyName: string,
+  medium: BrowserStorageMedium,
+): RegisteredStorageEntry | null => resolveRegisteredEntry(keyName, medium);
+
+export const readBrowserStorageItem = (
+  medium: BrowserStorageMedium,
+  keyName: string,
+): string | null => {
+  const storage = getStorage(medium);
+  if (!storage) return null;
+
+  const registered = resolveRegisteredEntry(keyName, medium);
+  if (!registered) {
+    warnPolicy(`Blocked read for unregistered ${medium} key "${keyName}"`);
+    return null;
+  }
+  if (!isCategoryAllowed(registered.category)) return null;
+
+  try {
+    return storage.getItem(keyName);
+  } catch {
+    return null;
+  }
+};
+
+export const writeBrowserStorageItem = (
+  medium: BrowserStorageMedium,
+  keyName: string,
+  value: string,
+): boolean => {
+  const storage = getStorage(medium);
+  if (!storage) return false;
+
+  const registered = resolveRegisteredEntry(keyName, medium);
+  if (!registered) {
+    warnPolicy(`Blocked write for unregistered ${medium} key "${keyName}"`);
+    return false;
+  }
+  if (!isCategoryAllowed(registered.category)) return false;
+
+  try {
+    storage.setItem(keyName, value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const removeBrowserStorageItem = (
+  medium: BrowserStorageMedium,
+  keyName: string,
+): boolean => {
+  const storage = getStorage(medium);
+  if (!storage) return false;
+
+  const registered = resolveRegisteredEntry(keyName, medium);
+  if (!registered) {
+    warnPolicy(`Blocked remove for unregistered ${medium} key "${keyName}"`);
+    return false;
+  }
+
+  try {
+    storage.removeItem(keyName);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const purgeOptionalBrowserStorage = (): number => {
+  let removedCount = 0;
+  for (const category of OPTIONAL_CATEGORIES) {
+    for (const entry of COOKIE_REGISTRY[category]) {
+      if (entry.storage !== 'localStorage' && entry.storage !== 'sessionStorage') continue;
+      const storage = getStorage(entry.storage);
+      if (!storage) continue;
+      try {
+        removedCount += removeByRegistryPattern(storage, entry.name);
+      } catch {
+        // keep purging other entries even if one key fails
+      }
+    }
+  }
+  return removedCount;
+};
+
+export const readLocalStorageItem = (keyName: string): string | null =>
+  readBrowserStorageItem('localStorage', keyName);
+
+export const writeLocalStorageItem = (keyName: string, value: string): boolean =>
+  writeBrowserStorageItem('localStorage', keyName, value);
+
+export const removeLocalStorageItem = (keyName: string): boolean =>
+  removeBrowserStorageItem('localStorage', keyName);
+
+export const readSessionStorageItem = (keyName: string): string | null =>
+  readBrowserStorageItem('sessionStorage', keyName);
+
+export const writeSessionStorageItem = (keyName: string, value: string): boolean =>
+  writeBrowserStorageItem('sessionStorage', keyName, value);
+
+export const removeSessionStorageItem = (keyName: string): boolean =>
+  removeBrowserStorageItem('sessionStorage', keyName);

--- a/services/consentState.ts
+++ b/services/consentState.ts
@@ -1,0 +1,19 @@
+export const CONSENT_STORAGE_KEY = 'tf_cookie_consent_choice_v1';
+
+export type ConsentChoice = 'all' | 'essential';
+
+export const isConsentChoice = (value: unknown): value is ConsentChoice =>
+  value === 'all' || value === 'essential';
+
+export const readConsentChoiceFromStorage = (): ConsentChoice | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = window.localStorage.getItem(CONSENT_STORAGE_KEY);
+    return isConsentChoice(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+};
+
+export const isOptionalConsentGranted = (choice: ConsentChoice | null): boolean =>
+  choice === 'all';

--- a/tests/browser/browserStorageService.browser.test.ts
+++ b/tests/browser/browserStorageService.browser.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getRegisteredStorageEntry,
+  purgeOptionalBrowserStorage,
+  readLocalStorageItem,
+  readSessionStorageItem,
+  removeLocalStorageItem,
+  writeLocalStorageItem,
+  writeSessionStorageItem,
+} from '../../services/browserStorageService';
+import { CONSENT_STORAGE_KEY } from '../../services/consentState';
+
+describe('services/browserStorageService', () => {
+  it('allows essential storage keys regardless of optional consent', () => {
+    expect(writeLocalStorageItem(CONSENT_STORAGE_KEY, 'essential')).toBe(true);
+    expect(readLocalStorageItem(CONSENT_STORAGE_KEY)).toBe('essential');
+  });
+
+  it('blocks optional analytics storage when optional consent is not granted', () => {
+    expect(writeLocalStorageItem(CONSENT_STORAGE_KEY, 'essential')).toBe(true);
+    expect(writeLocalStorageItem('umami.cache', '{"enabled":true}')).toBe(false);
+    expect(readLocalStorageItem('umami.cache')).toBeNull();
+  });
+
+  it('allows optional analytics storage when optional consent is granted', () => {
+    expect(writeLocalStorageItem(CONSENT_STORAGE_KEY, 'all')).toBe(true);
+    expect(writeLocalStorageItem('umami.cache', '{"enabled":true}')).toBe(true);
+    expect(readLocalStorageItem('umami.cache')).toBe('{"enabled":true}');
+  });
+
+  it('blocks unknown unregistered keys', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(writeLocalStorageItem('tf_unknown_registry_key', '1')).toBe(false);
+    expect(readLocalStorageItem('tf_unknown_registry_key')).toBeNull();
+    expect(removeLocalStorageItem('tf_unknown_registry_key')).toBe(false);
+    warnSpy.mockRestore();
+  });
+
+  it('resolves wildcard registry entries for local and session storage keys', () => {
+    const localMatch = getRegisteredStorageEntry('tf_share_links:trip-123', 'localStorage');
+    const sessionMatch = getRegisteredStorageEntry('tf_lazy_chunk_recovery:TripView', 'sessionStorage');
+
+    expect(localMatch?.category).toBe('essential');
+    expect(sessionMatch?.category).toBe('essential');
+  });
+
+  it('purges optional keys while keeping essential keys intact', () => {
+    expect(writeLocalStorageItem(CONSENT_STORAGE_KEY, 'all')).toBe(true);
+    expect(writeLocalStorageItem('umami.cache', '{"enabled":true}')).toBe(true);
+    expect(writeLocalStorageItem('tf_share_links:trip-123', '{"view":"https://example"}')).toBe(true);
+    expect(writeSessionStorageItem('tf_lazy_chunk_recovery:TripView', '1')).toBe(true);
+
+    const removedCount = purgeOptionalBrowserStorage();
+
+    expect(removedCount).toBeGreaterThan(0);
+    expect(readLocalStorageItem('umami.cache')).toBeNull();
+    expect(readLocalStorageItem('tf_share_links:trip-123')).toBe('{"view":"https://example"}');
+    expect(readSessionStorageItem('tf_lazy_chunk_recovery:TripView')).toBe('1');
+  });
+});

--- a/tests/browser/consentService.browser.test.ts
+++ b/tests/browser/consentService.browser.test.ts
@@ -23,6 +23,15 @@ describe('services/consentService', () => {
     expect(readStoredConsent()).toBe('essential');
   });
 
+  it('purges optional storage when switching back to essential only', () => {
+    saveConsent('all');
+    window.localStorage.setItem('umami.cache', '{"enabled":true}');
+
+    saveConsent('essential');
+
+    expect(window.localStorage.getItem('umami.cache')).toBeNull();
+  });
+
   it('notifies subscribers on consent change', () => {
     const listener = vi.fn();
     const unsubscribe = subscribeToConsentChanges(listener);


### PR DESCRIPTION
## Summary
- implement Phase 1 storage policy foundation for issue #127
- add a central `browserStorageService` that enforces registry + consent policy for local/session storage access
- add `consentState` helpers and wire consent save flow to purge optional category keys when switching to essential-only
- migrate consent-critical runtime paths (`consentService`, `i18n`, `appRuntimeUtils`) to the helper
- add browser regression tests for policy behavior, wildcard matching, and consent-driven optional key purge
- add a draft release-note entry for this feature work

## Scope Note
This PR is intentionally Phase 1 of #127 (foundation). The larger migration of all direct storage callers remains open in #127.

## Related Issues
- Refs #127

## Validation
- [x] `pnpm storage:validate`
- [x] `pnpm updates:validate`
- [x] `pnpm test:core`

## New Module Guard
- [x] New module guard completed
- [x] If I added files under `services/` or `config/`, I listed matching `tests/**` paths below.

### Matching `tests/**` Entries (required when adding `services/` or `config/` files)
- `tests/browser/browserStorageService.browser.test.ts`
- `tests/browser/consentService.browser.test.ts`
