### PR TITLE
feat(storage): start phase2 migration to policy-backed helper APIs

### DIFF
--- a/app/bootstrap/useDebuggerBootstrap.ts
+++ b/app/bootstrap/useDebuggerBootstrap.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { readLocalStorageItem } from '../../services/browserStorageService';
 import { isSimulatedLoggedIn, toggleSimulatedLogin } from '../../services/simulatedLoginService';
 
 type AppDebugWindow = Window & typeof globalThis & {
@@ -26,7 +27,7 @@ const shouldEnableDebuggerOnBoot = (): boolean => {
         const params = new URLSearchParams(window.location.search);
         const debugParam = params.get('debug');
         if (debugParam === '1' || debugParam === 'true') return true;
-        return window.localStorage.getItem(DEBUG_AUTO_OPEN_STORAGE_KEY) === '1';
+        return readLocalStorageItem(DEBUG_AUTO_OPEN_STORAGE_KEY) === '1';
     } catch {
         return false;
     }

--- a/components/ReleaseNoticeDialog.tsx
+++ b/components/ReleaseNoticeDialog.tsx
@@ -5,6 +5,10 @@ import remarkGfm from 'remark-gfm';
 import { getLatestInAppRelease, getWebsiteVisibleItems, groupReleaseItemsByType } from '../services/releaseNotesService';
 import { ReleasePill } from './marketing/ReleasePill';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import {
+    readLocalStorageItem,
+    writeLocalStorageItem,
+} from '../services/browserStorageService';
 
 const RELEASE_NOTICE_DISMISSED_KEY = 'tf_release_notice_dismissed_release_id';
 
@@ -19,7 +23,7 @@ export const ReleaseNoticeDialog: React.FC<ReleaseNoticeDialogProps> = ({ enable
     const [dismissedReleaseId, setDismissedReleaseId] = useState<string | null>(() => {
         if (typeof window === 'undefined') return null;
         try {
-            return window.localStorage.getItem(RELEASE_NOTICE_DISMISSED_KEY);
+            return readLocalStorageItem(RELEASE_NOTICE_DISMISSED_KEY);
         } catch {
             return null;
         }
@@ -36,7 +40,7 @@ export const ReleaseNoticeDialog: React.FC<ReleaseNoticeDialogProps> = ({ enable
         setDismissedReleaseId(latestInAppRelease.id);
         if (typeof window === 'undefined') return;
         try {
-            window.localStorage.setItem(RELEASE_NOTICE_DISMISSED_KEY, latestInAppRelease.id);
+            writeLocalStorageItem(RELEASE_NOTICE_DISMISSED_KEY, latestInAppRelease.id);
         } catch {
             // ignore storage issues
         }

--- a/components/marketing/TranslationNoticeBanner.tsx
+++ b/components/marketing/TranslationNoticeBanner.tsx
@@ -5,13 +5,17 @@ import { useTranslation } from 'react-i18next';
 import { DEFAULT_LOCALE } from '../../config/locales';
 import { buildLocalizedMarketingPath, extractLocaleFromPath } from '../../config/routes';
 import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analyticsService';
+import {
+    readSessionStorageItem,
+    writeSessionStorageItem,
+} from '../../services/browserStorageService';
 
 const SESSION_DISMISS_KEY = 'tf_translation_notice_dismissed_session';
 
 const isDismissedForSession = (): boolean => {
     if (typeof window === 'undefined') return false;
     try {
-        return window.sessionStorage.getItem(SESSION_DISMISS_KEY) === '1';
+        return readSessionStorageItem(SESSION_DISMISS_KEY) === '1';
     } catch {
         return false;
     }
@@ -30,7 +34,7 @@ export const TranslationNoticeBanner: React.FC = () => {
         trackEvent('i18n_notice__dismiss', { locale: activeLocale });
         if (typeof window === 'undefined') return;
         try {
-            window.sessionStorage.setItem(SESSION_DISMISS_KEY, '1');
+            writeSessionStorageItem(SESSION_DISMISS_KEY, '1');
         } catch {
             // ignore
         }

--- a/components/navigation/LanguageSuggestionBanner.tsx
+++ b/components/navigation/LanguageSuggestionBanner.tsx
@@ -7,6 +7,12 @@ import { applyDocumentLocale, DEFAULT_LOCALE, LOCALE_FLAGS, SUPPORTED_LOCALES } 
 import { APP_NAME } from '../../config/appGlobals';
 import { buildLocalizedLocation } from '../../services/localeRoutingService';
 import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analyticsService';
+import {
+    readLocalStorageItem,
+    readSessionStorageItem,
+    writeLocalStorageItem,
+    writeSessionStorageItem,
+} from '../../services/browserStorageService';
 import i18n, { preloadLocaleNamespaces } from '../../i18n';
 import { FlagIcon } from '../flags/FlagIcon';
 
@@ -87,7 +93,7 @@ const getBrowserPreferredLocale = (currentLocale: AppLanguage): AppLanguage | nu
 const isDismissedForSession = (): boolean => {
     if (typeof window === 'undefined') return false;
     try {
-        return window.sessionStorage.getItem(SESSION_DISMISS_KEY) === '1';
+        return readSessionStorageItem(SESSION_DISMISS_KEY) === '1';
     } catch {
         return false;
     }
@@ -96,7 +102,7 @@ const isDismissedForSession = (): boolean => {
 const isSwitchAcknowledged = (): boolean => {
     if (typeof window === 'undefined') return false;
     try {
-        return window.localStorage.getItem(SWITCH_ACK_KEY) === '1';
+        return readLocalStorageItem(SWITCH_ACK_KEY) === '1';
     } catch {
         return false;
     }
@@ -131,7 +137,7 @@ export const LanguageSuggestionBanner: React.FC = () => {
         });
         if (typeof window === 'undefined') return;
         try {
-            window.sessionStorage.setItem(SESSION_DISMISS_KEY, '1');
+            writeSessionStorageItem(SESSION_DISMISS_KEY, '1');
         } catch {
             // ignore
         }
@@ -141,8 +147,8 @@ export const LanguageSuggestionBanner: React.FC = () => {
         setDismissed(true);
         if (typeof window !== 'undefined') {
             try {
-                window.sessionStorage.setItem(SESSION_DISMISS_KEY, '1');
-                window.localStorage.setItem(SWITCH_ACK_KEY, '1');
+                writeSessionStorageItem(SESSION_DISMISS_KEY, '1');
+                writeLocalStorageItem(SWITCH_ACK_KEY, '1');
             } catch {
                 // ignore
             }

--- a/config/paywall.ts
+++ b/config/paywall.ts
@@ -1,5 +1,10 @@
 import { ITrip, ITimelineItem } from '../types';
 import { isTripExpiredByTimestamp } from './productLimits';
+import {
+    readLocalStorageItem,
+    removeLocalStorageItem,
+    writeLocalStorageItem,
+} from '../services/browserStorageService';
 
 export type TripLifecycleState = 'active' | 'expired' | 'archived';
 export const TRIP_EXPIRY_DEBUG_EVENT = 'tf:trip-expiry-debug-updated';
@@ -76,7 +81,7 @@ const maskTripItemForPaywall = (item: ITimelineItem, cityIndexByItemId: Map<stri
 const readDebugTripExpiryOverrides = (): TripExpiryOverrides => {
     if (typeof window === 'undefined') return {};
     try {
-        const raw = window.localStorage.getItem(DEBUG_EXPIRED_OVERRIDES_STORAGE_KEY);
+        const raw = readLocalStorageItem(DEBUG_EXPIRED_OVERRIDES_STORAGE_KEY);
         if (!raw) return {};
         const parsed = JSON.parse(raw);
         if (!parsed || typeof parsed !== 'object') return {};
@@ -96,10 +101,10 @@ const writeDebugTripExpiryOverrides = (overrides: TripExpiryOverrides) => {
     if (typeof window === 'undefined') return;
     try {
         if (Object.keys(overrides).length === 0) {
-            window.localStorage.removeItem(DEBUG_EXPIRED_OVERRIDES_STORAGE_KEY);
+            removeLocalStorageItem(DEBUG_EXPIRED_OVERRIDES_STORAGE_KEY);
             return;
         }
-        window.localStorage.setItem(DEBUG_EXPIRED_OVERRIDES_STORAGE_KEY, JSON.stringify(overrides));
+        writeLocalStorageItem(DEBUG_EXPIRED_OVERRIDES_STORAGE_KEY, JSON.stringify(overrides));
     } catch {
         // ignore storage issues
     }

--- a/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
+++ b/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-02-24-storage-consent-policy-phase2-migration
+version: v0.58.0
+title: "Storage consent policy phase 2 migration"
+date: 2026-02-24
+published_at: 2026-02-24T13:20:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Migrates auth/session and consent-adjacent storage callers to registry-backed storage policy helpers."
+---
+
+## Changes
+- [ ] [Internal] 🔒 Migrated auth/session storage callers to `browserStorageService` helper APIs.
+- [ ] [Internal] 🧭 Migrated consent-adjacent banner and release-notice storage access to policy-backed helper APIs.
+- [ ] [Internal] 🧪 Added regression coverage for auth trace persistence and documented remaining migration batches.

--- a/docs/LLM_GUIDE.md
+++ b/docs/LLM_GUIDE.md
@@ -11,6 +11,7 @@ This doc is a compact, structured overview of the app to help future agents make
 - Netlify PR preview and feature-branch deploy workflow: `docs/NETLIFY_FEATURE_BRANCH_DEPLOY.md`.
 - For manual Netlify CLI draft deploys, follow `docs/NETLIFY_FEATURE_BRANCH_DEPLOY.md`: build with `dotenv-cli`, then deploy with `netlify deploy --no-build --dir=dist`.
 - Browser storage disclosures and policy source: `lib/legal/cookies.config.ts` (cookies/localStorage/sessionStorage registry).
+- Storage Phase 2 migration tracker: `docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md`.
 
 **Project Overview**
 - App type: Single-page travel planner with timeline + map + print/list views.

--- a/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
+++ b/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
@@ -1,0 +1,37 @@
+# Storage Policy Migration Checklist
+
+This checklist tracks Phase 2 migration from raw browser storage access to `services/browserStorageService.ts`.
+
+## Migration Rule
+- Use `readLocalStorageItem` / `writeLocalStorageItem` / `removeLocalStorageItem` for local storage.
+- Use `readSessionStorageItem` / `writeSessionStorageItem` / `removeSessionStorageItem` for session storage.
+- Do not introduce new direct `localStorage` / `sessionStorage` calls in runtime code.
+- Register every key in `lib/legal/cookies.config.ts` before using helper APIs.
+
+## Completed In Phase 2 (Current Batch)
+- [x] `services/authNavigationService.ts`
+- [x] `services/authUiPreferencesService.ts`
+- [x] `services/authTraceService.ts`
+- [x] `services/simulatedLoginService.ts`
+- [x] `config/paywall.ts` (debug expiry overrides)
+- [x] `app/bootstrap/useDebuggerBootstrap.ts`
+- [x] `services/lazyImportRecovery.ts`
+- [x] `components/navigation/LanguageSuggestionBanner.tsx`
+- [x] `components/marketing/TranslationNoticeBanner.tsx`
+- [x] `components/ReleaseNoticeDialog.tsx`
+- [x] `pages/UpdatesPage.tsx` (simulated-login debug read)
+
+## Remaining Direct Storage Usage (Next Batches)
+- [ ] `services/authService.ts` (Supabase wildcard/session cleanup path)
+- [ ] `services/consentState.ts` (consent bootstrap read path)
+- [ ] `services/dbService.ts` (planner view preference writes)
+- [ ] `services/storageService.ts` and `services/historyService.ts`
+- [ ] `components/tripview/*` persistence hooks
+- [ ] `components/TripManager.tsx` / `components/ItineraryMap.tsx` / `components/CountryInfo.tsx`
+- [ ] `components/admin/*` cache utilities and shell state
+- [ ] `components/OnPageDebugger.tsx`
+- [ ] `components/marketing/EarlyAccessBanner.tsx`
+
+## Verification
+- Run `pnpm storage:validate`.
+- Run targeted Vitest for touched modules and `pnpm test:core`.

--- a/pages/UpdatesPage.tsx
+++ b/pages/UpdatesPage.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
 import { ReleasePill } from '../components/marketing/ReleasePill';
 import { getPublishedReleaseNotes, getWebsiteVisibleItems, groupReleaseItemsByType } from '../services/releaseNotesService';
+import { readLocalStorageItem } from '../services/browserStorageService';
 
 const SIMULATED_LOGIN_STORAGE_KEY = 'tf_debug_simulated_login';
 const SIMULATED_LOGIN_DEBUG_EVENT = 'tf:simulated-login-debug';
@@ -41,7 +42,7 @@ const formatReleaseDate = (dateLike: string) => {
 const readStoredBoolean = (storageKey: string, fallbackValue: boolean): boolean => {
     if (typeof window === 'undefined') return fallbackValue;
     try {
-        const raw = window.localStorage.getItem(storageKey);
+        const raw = readLocalStorageItem(storageKey);
         if (raw === '1') return true;
         if (raw === '0') return false;
         return fallbackValue;

--- a/services/authNavigationService.ts
+++ b/services/authNavigationService.ts
@@ -1,4 +1,9 @@
 import { stripLocalePrefix } from '../config/routes';
+import {
+    readLocalStorageItem,
+    removeLocalStorageItem,
+    writeLocalStorageItem,
+} from './browserStorageService';
 
 const AUTH_RETURN_PATH_STORAGE_KEY = 'tf_auth_return_path_v1';
 const AUTH_PENDING_REDIRECT_STORAGE_KEY = 'tf_auth_pending_redirect_v1';
@@ -32,19 +37,19 @@ export const isSafeAuthReturnPath = (path: string | null | undefined): path is s
 export const rememberAuthReturnPath = (path: string | null | undefined): void => {
     if (typeof window === 'undefined') return;
     if (!isSafeAuthReturnPath(path)) return;
-    window.localStorage.setItem(AUTH_RETURN_PATH_STORAGE_KEY, path);
+    writeLocalStorageItem(AUTH_RETURN_PATH_STORAGE_KEY, path);
 };
 
 export const getRememberedAuthReturnPath = (): string | null => {
     if (typeof window === 'undefined') return null;
-    const stored = window.localStorage.getItem(AUTH_RETURN_PATH_STORAGE_KEY);
+    const stored = readLocalStorageItem(AUTH_RETURN_PATH_STORAGE_KEY);
     if (!isSafeAuthReturnPath(stored)) return null;
     return stored;
 };
 
 export const clearRememberedAuthReturnPath = (): void => {
     if (typeof window === 'undefined') return;
-    window.localStorage.removeItem(AUTH_RETURN_PATH_STORAGE_KEY);
+    removeLocalStorageItem(AUTH_RETURN_PATH_STORAGE_KEY);
 };
 
 interface PendingAuthRedirect {
@@ -80,14 +85,14 @@ export const setPendingAuthRedirect = (nextPath: string, source: string): void =
         source: source || 'unknown',
         createdAt: Date.now(),
     };
-    window.localStorage.setItem(AUTH_PENDING_REDIRECT_STORAGE_KEY, JSON.stringify(payload));
+    writeLocalStorageItem(AUTH_PENDING_REDIRECT_STORAGE_KEY, JSON.stringify(payload));
 };
 
 export const getPendingAuthRedirect = (): PendingAuthRedirect | null => {
     if (typeof window === 'undefined') return null;
-    const pending = parsePendingAuthRedirect(window.localStorage.getItem(AUTH_PENDING_REDIRECT_STORAGE_KEY));
+    const pending = parsePendingAuthRedirect(readLocalStorageItem(AUTH_PENDING_REDIRECT_STORAGE_KEY));
     if (!pending) {
-        window.localStorage.removeItem(AUTH_PENDING_REDIRECT_STORAGE_KEY);
+        removeLocalStorageItem(AUTH_PENDING_REDIRECT_STORAGE_KEY);
         return null;
     }
     return pending;
@@ -95,7 +100,7 @@ export const getPendingAuthRedirect = (): PendingAuthRedirect | null => {
 
 export const clearPendingAuthRedirect = (): void => {
     if (typeof window === 'undefined') return;
-    window.localStorage.removeItem(AUTH_PENDING_REDIRECT_STORAGE_KEY);
+    removeLocalStorageItem(AUTH_PENDING_REDIRECT_STORAGE_KEY);
 };
 
 export const resolvePreferredNextPath = (

--- a/services/authTraceService.ts
+++ b/services/authTraceService.ts
@@ -1,3 +1,8 @@
+import {
+    readLocalStorageItem,
+    writeLocalStorageItem,
+} from './browserStorageService';
+
 const AUTH_TRACE_STORAGE_KEY = 'tf_auth_trace_v1';
 const AUTH_TRACE_MAX_ENTRIES = 150;
 
@@ -17,7 +22,7 @@ const isBrowser = () => typeof window !== 'undefined';
 const readAuthTrace = (): AuthTraceEntry[] => {
     if (!isBrowser()) return [];
     try {
-        const raw = window.localStorage.getItem(AUTH_TRACE_STORAGE_KEY);
+        const raw = readLocalStorageItem(AUTH_TRACE_STORAGE_KEY);
         if (!raw) return [];
         const parsed = JSON.parse(raw);
         return Array.isArray(parsed) ? parsed as AuthTraceEntry[] : [];
@@ -29,7 +34,7 @@ const readAuthTrace = (): AuthTraceEntry[] => {
 const writeAuthTrace = (entries: AuthTraceEntry[]) => {
     if (!isBrowser()) return;
     try {
-        window.localStorage.setItem(AUTH_TRACE_STORAGE_KEY, JSON.stringify(entries.slice(-AUTH_TRACE_MAX_ENTRIES)));
+        writeLocalStorageItem(AUTH_TRACE_STORAGE_KEY, JSON.stringify(entries.slice(-AUTH_TRACE_MAX_ENTRIES)));
     } catch {
         // ignore storage limits/errors
     }
@@ -44,4 +49,3 @@ export const appendAuthTraceEntry = (entry: AuthTraceEntry) => {
 export const getAuthTraceEntries = (): AuthTraceEntry[] => readAuthTrace();
 
 export const clearAuthTraceEntries = () => writeAuthTrace([]);
-

--- a/services/authUiPreferencesService.ts
+++ b/services/authUiPreferencesService.ts
@@ -1,3 +1,9 @@
+import {
+    readLocalStorageItem,
+    removeLocalStorageItem,
+    writeLocalStorageItem,
+} from './browserStorageService';
+
 export type OAuthProviderPreference = 'google' | 'apple' | 'facebook' | 'kakao';
 
 interface StoredOAuthPreference {
@@ -16,7 +22,7 @@ const isValidProvider = (value: unknown): value is OAuthProviderPreference => {
 export const getLastUsedOAuthProvider = (): OAuthProviderPreference | null => {
     if (typeof window === 'undefined') return null;
     try {
-        const raw = window.localStorage.getItem(LAST_OAUTH_PROVIDER_STORAGE_KEY);
+        const raw = readLocalStorageItem(LAST_OAUTH_PROVIDER_STORAGE_KEY);
         if (!raw) return null;
         const parsed = JSON.parse(raw) as Partial<StoredOAuthPreference>;
         if (!isValidProvider(parsed.provider)) return null;
@@ -32,7 +38,7 @@ export const setLastUsedOAuthProvider = (provider: OAuthProviderPreference): voi
         provider,
         updatedAt: Date.now(),
     };
-    window.localStorage.setItem(LAST_OAUTH_PROVIDER_STORAGE_KEY, JSON.stringify(payload));
+    writeLocalStorageItem(LAST_OAUTH_PROVIDER_STORAGE_KEY, JSON.stringify(payload));
 };
 
 export const setPendingOAuthProvider = (provider: OAuthProviderPreference): void => {
@@ -41,18 +47,18 @@ export const setPendingOAuthProvider = (provider: OAuthProviderPreference): void
         provider,
         updatedAt: Date.now(),
     };
-    window.localStorage.setItem(PENDING_OAUTH_PROVIDER_STORAGE_KEY, JSON.stringify(payload));
+    writeLocalStorageItem(PENDING_OAUTH_PROVIDER_STORAGE_KEY, JSON.stringify(payload));
 };
 
 export const clearPendingOAuthProvider = (): void => {
     if (typeof window === 'undefined') return;
-    window.localStorage.removeItem(PENDING_OAUTH_PROVIDER_STORAGE_KEY);
+    removeLocalStorageItem(PENDING_OAUTH_PROVIDER_STORAGE_KEY);
 };
 
 export const consumePendingOAuthProvider = (): OAuthProviderPreference | null => {
     if (typeof window === 'undefined') return null;
     try {
-        const raw = window.localStorage.getItem(PENDING_OAUTH_PROVIDER_STORAGE_KEY);
+        const raw = readLocalStorageItem(PENDING_OAUTH_PROVIDER_STORAGE_KEY);
         if (!raw) return null;
         const parsed = JSON.parse(raw) as Partial<StoredOAuthPreference>;
         if (!isValidProvider(parsed.provider)) {

--- a/services/simulatedLoginService.ts
+++ b/services/simulatedLoginService.ts
@@ -1,3 +1,9 @@
+import {
+    readLocalStorageItem,
+    removeLocalStorageItem,
+    writeLocalStorageItem,
+} from './browserStorageService';
+
 export const SIMULATED_LOGIN_STORAGE_KEY = 'tf_debug_simulated_login';
 export const SIMULATED_LOGIN_DEBUG_EVENT = 'tf:simulated-login-debug';
 
@@ -6,7 +12,7 @@ let simulatedLoginOverride: boolean | null = null;
 const readSimulatedLoginOverride = (): boolean => {
     if (typeof window === 'undefined') return false;
     try {
-        return window.localStorage.getItem(SIMULATED_LOGIN_STORAGE_KEY) === '1';
+        return readLocalStorageItem(SIMULATED_LOGIN_STORAGE_KEY) === '1';
     } catch {
         return false;
     }
@@ -31,9 +37,9 @@ export const setSimulatedLoggedIn = (enabled: boolean): boolean => {
     if (typeof window !== 'undefined') {
         try {
             if (simulatedLoginOverride) {
-                window.localStorage.setItem(SIMULATED_LOGIN_STORAGE_KEY, '1');
+                writeLocalStorageItem(SIMULATED_LOGIN_STORAGE_KEY, '1');
             } else {
-                window.localStorage.removeItem(SIMULATED_LOGIN_STORAGE_KEY);
+                removeLocalStorageItem(SIMULATED_LOGIN_STORAGE_KEY);
             }
         } catch {
             // ignore storage issues

--- a/tests/browser/authTraceService.browser.test.ts
+++ b/tests/browser/authTraceService.browser.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  appendAuthTraceEntry,
+  clearAuthTraceEntries,
+  getAuthTraceEntries,
+} from '../../services/authTraceService';
+
+const createEntry = (index: number) => ({
+  ts: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+  flowId: `flow-${index}`,
+  attemptId: `attempt-${index}`,
+  step: 'oauth_callback',
+  result: 'start' as const,
+  provider: 'google',
+});
+
+describe('services/authTraceService', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clearAuthTraceEntries();
+  });
+
+  it('appends and reads auth trace entries', () => {
+    appendAuthTraceEntry(createEntry(1));
+    appendAuthTraceEntry(createEntry(2));
+
+    const entries = getAuthTraceEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].attemptId).toBe('attempt-1');
+    expect(entries[1].attemptId).toBe('attempt-2');
+  });
+
+  it('clears auth trace entries', () => {
+    appendAuthTraceEntry(createEntry(1));
+    clearAuthTraceEntries();
+
+    expect(getAuthTraceEntries()).toEqual([]);
+  });
+
+  it('keeps only the most recent bounded auth trace history', () => {
+    for (let index = 0; index < 180; index += 1) {
+      appendAuthTraceEntry(createEntry(index));
+    }
+
+    const entries = getAuthTraceEntries();
+    expect(entries).toHaveLength(150);
+    expect(entries[0].attemptId).toBe('attempt-30');
+    expect(entries[149].attemptId).toBe('attempt-179');
+  });
+});

--- a/tests/unit/authTraceService.node.test.ts
+++ b/tests/unit/authTraceService.node.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendAuthTraceEntry,
+  clearAuthTraceEntries,
+  getAuthTraceEntries,
+} from '../../services/authTraceService';
+
+describe('services/authTraceService (node environment)', () => {
+  it('returns empty entries and keeps no-op writes safe without window', () => {
+    expect(getAuthTraceEntries()).toEqual([]);
+    expect(() =>
+      appendAuthTraceEntry({
+        ts: '2026-01-01T00:00:00.000Z',
+        flowId: 'flow-node',
+        attemptId: 'attempt-node',
+        step: 'node_safe',
+        result: 'start',
+      })
+    ).not.toThrow();
+    expect(() => clearAuthTraceEntries()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- start issue #127 Phase 2 by migrating auth/session and consent-adjacent storage callsites to `browserStorageService` helper APIs
- remove direct browser storage access in migrated modules (auth navigation/preferences/trace, simulated login, paywall debug overrides, lazy import recovery, language + translation banners, release notice, updates debug read)
- add a dedicated migration tracker/checklist doc for remaining callsites and next batches
- add regression tests for auth trace persistence in browser and node environments
- add a draft release note for this feature branch

## Scope notes
- This PR intentionally does **not** migrate `services/authService.ts` Supabase wildcard cleanup yet, because it needs a dedicated pass for mixed local/session wildcard handling.
- Remaining migration targets are tracked in `docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md`.

## Validation
- pnpm storage:validate
- pnpm test:core
- pnpm updates:validate

## Related
- Refs #127
