### PR TITLE
Phase 2 storage migration: auth cleanup + db settings

### DIFF
--- a/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
+++ b/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
@@ -7,10 +7,12 @@ published_at: 2026-02-24T13:20:00Z
 status: draft
 notify_in_app: false
 in_app_hours: 24
-summary: "Migrates auth/session and consent-adjacent storage callers to registry-backed storage policy helpers."
+summary: "Migrates auth/session, consent-adjacent, and planner-setting storage callers to registry-backed storage policy helpers."
 ---
 
 ## Changes
 - [ ] [Internal] 🔒 Migrated auth/session storage callers to `browserStorageService` helper APIs.
 - [ ] [Internal] 🧭 Migrated consent-adjacent banner and release-notice storage access to policy-backed helper APIs.
-- [ ] [Internal] 🧪 Added regression coverage for auth trace persistence and documented remaining migration batches.
+- [ ] [Internal] ♻️ Added registry-backed fallback handling for Supabase wildcard auth keys that can appear in session storage.
+- [ ] [Internal] 🧪 Added regression coverage for auth trace persistence, Supabase auth-key cleanup, and DB planner-setting persistence.
+- [ ] [Internal] 🗂️ Updated the migration checklist to mark auth/db storage-call migrations complete and track remaining Phase 2 files.

--- a/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
+++ b/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
@@ -20,11 +20,11 @@ This checklist tracks Phase 2 migration from raw browser storage access to `serv
 - [x] `components/marketing/TranslationNoticeBanner.tsx`
 - [x] `components/ReleaseNoticeDialog.tsx`
 - [x] `pages/UpdatesPage.tsx` (simulated-login debug read)
+- [x] `services/authService.ts` (Supabase wildcard/session cleanup path via registry-aware helper calls)
+- [x] `services/dbService.ts` (planner view preference writes)
 
 ## Remaining Direct Storage Usage (Next Batches)
-- [ ] `services/authService.ts` (Supabase wildcard/session cleanup path)
 - [ ] `services/consentState.ts` (consent bootstrap read path)
-- [ ] `services/dbService.ts` (planner view preference writes)
 - [ ] `services/storageService.ts` and `services/historyService.ts`
 - [ ] `components/tripview/*` persistence hooks
 - [ ] `components/TripManager.tsx` / `components/ItineraryMap.tsx` / `components/CountryInfo.tsx`

--- a/lib/legal/cookies.config.ts
+++ b/lib/legal/cookies.config.ts
@@ -18,6 +18,7 @@ export interface CookieDefinition {
   duration: string;
   provider: string;
   storage?: 'cookie' | 'localStorage' | 'sessionStorage';
+  storageFallbacks?: Array<'localStorage' | 'sessionStorage'>;
   notes?: string;
 }
 
@@ -51,6 +52,7 @@ export const COOKIE_REGISTRY: CookieRegistry = {
       duration: 'Session lifecycle (rotating)',
       provider: 'Supabase Auth',
       storage: 'localStorage',
+      storageFallbacks: ['sessionStorage'],
       notes: 'Can also appear in sessionStorage during OAuth edge cases; required for login persistence.',
     },
     {
@@ -59,6 +61,7 @@ export const COOKIE_REGISTRY: CookieRegistry = {
       duration: 'Session lifecycle (rotating)',
       provider: 'Supabase Auth',
       storage: 'localStorage',
+      storageFallbacks: ['sessionStorage'],
       notes: 'Can also appear in sessionStorage during OAuth edge cases.',
     },
     {
@@ -67,6 +70,7 @@ export const COOKIE_REGISTRY: CookieRegistry = {
       duration: 'Single OAuth flow',
       provider: 'Supabase Auth',
       storage: 'localStorage',
+      storageFallbacks: ['sessionStorage'],
       notes: 'May be stored in sessionStorage by Supabase internals during OAuth handshakes.',
     },
     {
@@ -468,6 +472,12 @@ export const validateCookieRegistry = (): { valid: boolean; errors: string[] } =
     if (!cookie.duration) errors.push(`Entry ${cookie.name} is missing duration`);
     if (!cookie.provider) errors.push(`Entry ${cookie.name} is missing provider`);
     if (!cookie.storage) errors.push(`Entry ${cookie.name} is missing storage medium`);
+    if (cookie.storage === 'cookie' && cookie.storageFallbacks && cookie.storageFallbacks.length > 0) {
+      errors.push(`Entry ${cookie.name} cannot define storageFallbacks when storage is cookie`);
+    }
+    if (cookie.storage && cookie.storage !== 'cookie' && cookie.storageFallbacks?.includes(cookie.storage)) {
+      errors.push(`Entry ${cookie.name} has duplicate storage fallback "${cookie.storage}"`);
+    }
   });
 
   return {

--- a/scripts/validate-storage-registry.ts
+++ b/scripts/validate-storage-registry.ts
@@ -23,7 +23,7 @@ interface ExpectedStorageKey {
 
 interface RegistryEntry {
   name: string;
-  storage: CookieDefinition['storage'];
+  storage: 'cookie' | StorageMedium;
 }
 
 interface DynamicAllowlistRule {
@@ -109,10 +109,14 @@ const toRegistryEntries = (): RegistryEntry[] => [
   ...COOKIE_REGISTRY.essential,
   ...COOKIE_REGISTRY.analytics,
   ...COOKIE_REGISTRY.marketing,
-].map((entry) => ({
-  name: entry.name,
-  storage: entry.storage ?? 'cookie',
-}));
+].flatMap((entry) => {
+  const storage = entry.storage ?? 'cookie';
+  const fallbackStorages = entry.storageFallbacks ?? [];
+  return [
+    { name: entry.name, storage },
+    ...fallbackStorages.map((fallbackStorage) => ({ name: entry.name, storage: fallbackStorage })),
+  ];
+});
 
 const escapeRegExp = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -1,6 +1,10 @@
 import { ISharedTripResult, ISharedTripVersionResult, ITrip, ITripShareRecord, IViewSettings, IUserSettings, ShareMode } from '../types';
 import { isUuid } from '../utils';
 import { supabase, isSupabaseEnabled } from './supabaseClient';
+import {
+    readLocalStorageItem,
+    writeLocalStorageItem,
+} from './browserStorageService';
 import { getAllTrips, setAllTrips } from './storageService';
 import { ANONYMOUS_TRIP_LIMIT, isTripExpiredByTimestamp } from '../config/productLimits';
 import { isSimulatedLoggedIn, setSimulatedLoggedIn, toggleSimulatedLogin } from './simulatedLoginService';
@@ -43,7 +47,7 @@ const SESSION_POLL_ATTEMPTS = 6;
 const isDebugEnabled = () => {
     if (typeof window === 'undefined') return false;
     try {
-        if (window.localStorage.getItem('tf_debug_db') === '1') return true;
+        if (readLocalStorageItem('tf_debug_db') === '1') return true;
     } catch {
         // ignore
     }
@@ -990,12 +994,12 @@ export const dbCanCreateTrip = async (): Promise<{
 
 export const applyUserSettingsToLocalStorage = (settings: IUserSettings | null) => {
     if (!settings || typeof window === 'undefined') return;
-    if (settings.mapStyle) localStorage.setItem('tf_map_style', settings.mapStyle);
-    if (settings.routeMode) localStorage.setItem('tf_route_mode', settings.routeMode);
-    if (settings.layoutMode) localStorage.setItem('tf_layout_mode', settings.layoutMode);
-    if (settings.timelineView) localStorage.setItem('tf_timeline_view', settings.timelineView);
-    if (typeof settings.showCityNames === 'boolean') localStorage.setItem('tf_city_names', String(settings.showCityNames));
-    if (typeof settings.zoomLevel === 'number') localStorage.setItem('tf_zoom_level', settings.zoomLevel.toFixed(2));
-    if (typeof settings.sidebarWidth === 'number') localStorage.setItem('tf_sidebar_width', String(settings.sidebarWidth));
-    if (typeof settings.timelineHeight === 'number') localStorage.setItem('tf_timeline_height', String(settings.timelineHeight));
+    if (settings.mapStyle) writeLocalStorageItem('tf_map_style', settings.mapStyle);
+    if (settings.routeMode) writeLocalStorageItem('tf_route_mode', settings.routeMode);
+    if (settings.layoutMode) writeLocalStorageItem('tf_layout_mode', settings.layoutMode);
+    if (settings.timelineView) writeLocalStorageItem('tf_timeline_view', settings.timelineView);
+    if (typeof settings.showCityNames === 'boolean') writeLocalStorageItem('tf_city_names', String(settings.showCityNames));
+    if (typeof settings.zoomLevel === 'number') writeLocalStorageItem('tf_zoom_level', settings.zoomLevel.toFixed(2));
+    if (typeof settings.sidebarWidth === 'number') writeLocalStorageItem('tf_sidebar_width', String(settings.sidebarWidth));
+    if (typeof settings.timelineHeight === 'number') writeLocalStorageItem('tf_timeline_height', String(settings.timelineHeight));
 };

--- a/tests/browser/authService.browser.test.ts
+++ b/tests/browser/authService.browser.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearSupabaseAuthStorage } from '../../services/authService';
+import {
+  readLocalStorageItem,
+  readSessionStorageItem,
+  writeLocalStorageItem,
+  writeSessionStorageItem,
+} from '../../services/browserStorageService';
+
+describe('services/authService clearSupabaseAuthStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it('clears wildcard Supabase auth keys from both local and session storage', () => {
+    expect(writeLocalStorageItem('sb-demo-auth-token', 'local-auth')).toBe(true);
+    expect(writeLocalStorageItem('sb-demo-refresh-token', 'local-refresh')).toBe(true);
+    expect(writeLocalStorageItem('sb-demo-code-verifier', 'local-code')).toBe(true);
+    expect(writeSessionStorageItem('sb-demo-auth-token', 'session-auth')).toBe(true);
+    expect(writeSessionStorageItem('sb-demo-refresh-token', 'session-refresh')).toBe(true);
+    expect(writeSessionStorageItem('sb-demo-code-verifier', 'session-code')).toBe(true);
+    expect(writeLocalStorageItem('tf_map_style', 'standard')).toBe(true);
+    window.sessionStorage.setItem('sb-demo-provider-state', 'keep');
+
+    clearSupabaseAuthStorage();
+
+    expect(readLocalStorageItem('sb-demo-auth-token')).toBeNull();
+    expect(readLocalStorageItem('sb-demo-refresh-token')).toBeNull();
+    expect(readLocalStorageItem('sb-demo-code-verifier')).toBeNull();
+    expect(readSessionStorageItem('sb-demo-auth-token')).toBeNull();
+    expect(readSessionStorageItem('sb-demo-refresh-token')).toBeNull();
+    expect(readSessionStorageItem('sb-demo-code-verifier')).toBeNull();
+    expect(readLocalStorageItem('tf_map_style')).toBe('standard');
+    expect(window.sessionStorage.getItem('sb-demo-provider-state')).toBe('keep');
+  });
+});

--- a/tests/browser/browserStorageService.browser.test.ts
+++ b/tests/browser/browserStorageService.browser.test.ts
@@ -40,9 +40,11 @@ describe('services/browserStorageService', () => {
   it('resolves wildcard registry entries for local and session storage keys', () => {
     const localMatch = getRegisteredStorageEntry('tf_share_links:trip-123', 'localStorage');
     const sessionMatch = getRegisteredStorageEntry('tf_lazy_chunk_recovery:TripView', 'sessionStorage');
+    const supabaseSessionMatch = getRegisteredStorageEntry('sb-project-auth-token', 'sessionStorage');
 
     expect(localMatch?.category).toBe('essential');
     expect(sessionMatch?.category).toBe('essential');
+    expect(supabaseSessionMatch?.category).toBe('essential');
   });
 
   it('purges optional keys while keeping essential keys intact', () => {

--- a/tests/browser/dbService.browser.test.ts
+++ b/tests/browser/dbService.browser.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { applyUserSettingsToLocalStorage } from '../../services/dbService';
+
+describe('services/dbService applyUserSettingsToLocalStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('persists planner view settings through registry-backed storage helpers', () => {
+    applyUserSettingsToLocalStorage({
+      mapStyle: 'clean',
+      routeMode: 'realistic',
+      layoutMode: 'vertical',
+      timelineView: 'vertical',
+      showCityNames: false,
+      zoomLevel: 2.5,
+      sidebarWidth: 640,
+      timelineHeight: 420,
+    });
+
+    expect(window.localStorage.getItem('tf_map_style')).toBe('clean');
+    expect(window.localStorage.getItem('tf_route_mode')).toBe('realistic');
+    expect(window.localStorage.getItem('tf_layout_mode')).toBe('vertical');
+    expect(window.localStorage.getItem('tf_timeline_view')).toBe('vertical');
+    expect(window.localStorage.getItem('tf_city_names')).toBe('false');
+    expect(window.localStorage.getItem('tf_zoom_level')).toBe('2.50');
+    expect(window.localStorage.getItem('tf_sidebar_width')).toBe('640');
+    expect(window.localStorage.getItem('tf_timeline_height')).toBe('420');
+  });
+
+  it('skips writes when settings payload is null', () => {
+    window.localStorage.setItem('tf_map_style', 'dark');
+    applyUserSettingsToLocalStorage(null);
+    expect(window.localStorage.getItem('tf_map_style')).toBe('dark');
+  });
+});


### PR DESCRIPTION
## Summary
- migrate `services/authService.ts` Supabase auth key cleanup to registry-backed helper removal and export `clearSupabaseAuthStorage` for regression coverage
- migrate `services/dbService.ts` debug/settings localStorage calls to `browserStorageService` helpers
- add explicit `storageFallbacks` metadata for Supabase wildcard keys so session-storage OAuth edge keys remain policy-registered
- extend storage registry validation + migration checklist + draft phase-2 release note
- add browser tests for auth cleanup and db settings persistence

## Validation
- `pnpm storage:validate`
- `pnpm vitest run tests/browser/authService.browser.test.ts tests/browser/dbService.browser.test.ts tests/browser/browserStorageService.browser.test.ts`
- `pnpm test:core`
- `pnpm updates:validate`

Part of #127
