### PR TITLE
Phase 2 storage migration: trip persistence services

### DIFF
--- a/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
+++ b/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
@@ -7,12 +7,13 @@ published_at: 2026-02-24T13:20:00Z
 status: draft
 notify_in_app: false
 in_app_hours: 24
-summary: "Migrates auth/session, consent-adjacent, and planner-setting storage callers to registry-backed storage policy helpers."
+summary: "Migrates auth/session, consent-adjacent, planner-setting, and trip persistence storage callers to registry-backed storage policy helpers."
 ---
 
 ## Changes
 - [ ] [Internal] 🔒 Migrated auth/session storage callers to `browserStorageService` helper APIs.
 - [ ] [Internal] 🧭 Migrated consent-adjacent banner and release-notice storage access to policy-backed helper APIs.
+- [ ] [Internal] 💾 Migrated trip persistence services (`storageService` and `historyService`) to policy-backed storage helpers.
 - [ ] [Internal] ♻️ Added registry-backed fallback handling for Supabase wildcard auth keys that can appear in session storage.
 - [ ] [Internal] 🧪 Added regression coverage for auth trace persistence, Supabase auth-key cleanup, and DB planner-setting persistence.
 - [ ] [Internal] 🗂️ Updated the migration checklist to mark auth/db storage-call migrations complete and track remaining Phase 2 files.

--- a/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
+++ b/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
@@ -22,10 +22,10 @@ This checklist tracks Phase 2 migration from raw browser storage access to `serv
 - [x] `pages/UpdatesPage.tsx` (simulated-login debug read)
 - [x] `services/authService.ts` (Supabase wildcard/session cleanup path via registry-aware helper calls)
 - [x] `services/dbService.ts` (planner view preference writes)
+- [x] `services/storageService.ts` and `services/historyService.ts`
 
 ## Remaining Direct Storage Usage (Next Batches)
 - [ ] `services/consentState.ts` (consent bootstrap read path)
-- [ ] `services/storageService.ts` and `services/historyService.ts`
 - [ ] `components/tripview/*` persistence hooks
 - [ ] `components/TripManager.tsx` / `components/ItineraryMap.tsx` / `components/CountryInfo.tsx`
 - [ ] `components/admin/*` cache utilities and shell state

--- a/services/historyService.ts
+++ b/services/historyService.ts
@@ -1,4 +1,5 @@
 import { ITrip, IViewSettings } from "../types";
+import { readLocalStorageItem, writeLocalStorageItem } from "./browserStorageService";
 
 export interface HistoryEntry {
     id: string;
@@ -19,7 +20,7 @@ type HistoryStore = Record<string, HistoryEntry[]>;
 
 const loadStore = (): HistoryStore => {
     try {
-        const raw = localStorage.getItem(HISTORY_KEY);
+        const raw = readLocalStorageItem(HISTORY_KEY);
         if (!raw) return {};
         return JSON.parse(raw) as HistoryStore;
     } catch (e) {
@@ -30,7 +31,9 @@ const loadStore = (): HistoryStore => {
 
 const saveStore = (store: HistoryStore) => {
     try {
-        localStorage.setItem(HISTORY_KEY, JSON.stringify(store));
+        if (!writeLocalStorageItem(HISTORY_KEY, JSON.stringify(store))) {
+            throw new Error('History storage write failed');
+        }
     } catch (e) {
         console.error("Failed to save history store", e);
     }


### PR DESCRIPTION
## Summary
- migrate `services/storageService.ts` and `services/historyService.ts` from raw localStorage calls to `browserStorageService` helpers
- preserve existing write-failure semantics by treating helper `false` returns as storage write errors (no crashes, error logged)
- update Phase 2 storage migration checklist and keep the single draft release note current

## Validation
- `pnpm storage:validate`
- `pnpm vitest run tests/browser/storageService.browser.test.ts tests/browser/historyService.browser.test.ts`
- `pnpm test:core`
- `pnpm updates:validate`

Part of #127
