### PR TITLE
Phase 2 storage migration: consent bootstrap path

### DIFF
--- a/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
+++ b/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
@@ -13,6 +13,7 @@ summary: "Migrates auth/session, consent-adjacent, planner-setting, and trip per
 ## Changes
 - [ ] [Internal] 🔒 Migrated auth/session storage callers to `browserStorageService` helper APIs.
 - [ ] [Internal] 🧭 Migrated consent-adjacent banner and release-notice storage access to policy-backed helper APIs.
+- [ ] [Internal] 🧾 Migrated consent bootstrap reads (`consentState`) to registry-backed storage helper APIs.
 - [ ] [Internal] 💾 Migrated trip persistence services (`storageService` and `historyService`) to policy-backed storage helpers.
 - [ ] [Internal] ♻️ Added registry-backed fallback handling for Supabase wildcard auth keys that can appear in session storage.
 - [ ] [Internal] 🧪 Added regression coverage for auth trace persistence, Supabase auth-key cleanup, and DB planner-setting persistence.

--- a/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
+++ b/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
@@ -23,9 +23,9 @@ This checklist tracks Phase 2 migration from raw browser storage access to `serv
 - [x] `services/authService.ts` (Supabase wildcard/session cleanup path via registry-aware helper calls)
 - [x] `services/dbService.ts` (planner view preference writes)
 - [x] `services/storageService.ts` and `services/historyService.ts`
+- [x] `services/consentState.ts` (consent bootstrap read path)
 
 ## Remaining Direct Storage Usage (Next Batches)
-- [ ] `services/consentState.ts` (consent bootstrap read path)
 - [ ] `components/tripview/*` persistence hooks
 - [ ] `components/TripManager.tsx` / `components/ItineraryMap.tsx` / `components/CountryInfo.tsx`
 - [ ] `components/admin/*` cache utilities and shell state

--- a/services/consentState.ts
+++ b/services/consentState.ts
@@ -1,3 +1,5 @@
+import { readLocalStorageItem } from './browserStorageService';
+
 export const CONSENT_STORAGE_KEY = 'tf_cookie_consent_choice_v1';
 
 export type ConsentChoice = 'all' | 'essential';
@@ -6,9 +8,8 @@ export const isConsentChoice = (value: unknown): value is ConsentChoice =>
   value === 'all' || value === 'essential';
 
 export const readConsentChoiceFromStorage = (): ConsentChoice | null => {
-  if (typeof window === 'undefined') return null;
   try {
-    const stored = window.localStorage.getItem(CONSENT_STORAGE_KEY);
+    const stored = readLocalStorageItem(CONSENT_STORAGE_KEY);
     return isConsentChoice(stored) ? stored : null;
   } catch {
     return null;

--- a/tests/browser/consentState.browser.test.ts
+++ b/tests/browser/consentState.browser.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { CONSENT_STORAGE_KEY, readConsentChoiceFromStorage } from '../../services/consentState';
+
+describe('services/consentState', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('reads valid consent choices from storage', () => {
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, 'all');
+    expect(readConsentChoiceFromStorage()).toBe('all');
+
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, 'essential');
+    expect(readConsentChoiceFromStorage()).toBe('essential');
+  });
+
+  it('returns null for invalid consent values', () => {
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, 'invalid');
+    expect(readConsentChoiceFromStorage()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- migrate `services/consentState.ts` bootstrap consent read to `browserStorageService` (`readLocalStorageItem`)
- add browser regression coverage for consent-state storage reads
- update the Phase 2 storage migration checklist and keep the single draft release note current

## Validation
- `pnpm storage:validate`
- `pnpm vitest run tests/browser/consentState.browser.test.ts tests/browser/consentService.browser.test.ts tests/browser/browserStorageService.browser.test.ts`
- `pnpm test:core`
- `pnpm updates:validate`

Part of #127
