### PR TITLE
Phase 2 storage migration: tripview planner hooks

### DIFF
--- a/components/tripview/useTripLayoutControlsState.ts
+++ b/components/tripview/useTripLayoutControlsState.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { readLocalStorageItem } from '../../services/browserStorageService';
 import type { IViewSettings, MapStyle, RouteMode } from '../../types';
 
 interface UseTripLayoutControlsStateOptions {
@@ -13,20 +14,20 @@ export const useTripLayoutControlsState = ({
 }: UseTripLayoutControlsStateOptions) => {
     const [mapStyle, setMapStyle] = useState<MapStyle>(() => {
         if (initialViewSettings?.mapStyle) return initialViewSettings.mapStyle;
-        if (typeof window !== 'undefined') return (localStorage.getItem('tf_map_style') as MapStyle) || 'standard';
+        if (typeof window !== 'undefined') return (readLocalStorageItem('tf_map_style') as MapStyle) || 'standard';
         return 'standard';
     });
 
     const [routeMode, setRouteMode] = useState<RouteMode>(() => {
         if (initialViewSettings?.routeMode) return initialViewSettings.routeMode;
-        if (typeof window !== 'undefined') return (localStorage.getItem('tf_route_mode') as RouteMode) || 'simple';
+        if (typeof window !== 'undefined') return (readLocalStorageItem('tf_route_mode') as RouteMode) || 'simple';
         return 'simple';
     });
 
     const [showCityNames, setShowCityNames] = useState<boolean>(() => {
         if (initialViewSettings?.showCityNames !== undefined) return initialViewSettings.showCityNames;
         if (typeof window !== 'undefined') {
-            const stored = localStorage.getItem('tf_city_names');
+            const stored = readLocalStorageItem('tf_city_names');
             if (stored !== null) return stored === 'true';
         }
         return true;
@@ -35,7 +36,7 @@ export const useTripLayoutControlsState = ({
     const [layoutMode, setLayoutMode] = useState<'vertical' | 'horizontal'>(() => {
         if (initialViewSettings) return initialViewSettings.layoutMode;
         if (typeof window !== 'undefined') {
-            return (localStorage.getItem('tf_layout_mode') as 'vertical' | 'horizontal') || 'horizontal';
+            return (readLocalStorageItem('tf_layout_mode') as 'vertical' | 'horizontal') || 'horizontal';
         }
         return 'horizontal';
     });
@@ -43,26 +44,26 @@ export const useTripLayoutControlsState = ({
     const [timelineView, setTimelineView] = useState<'horizontal' | 'vertical'>(() => {
         if (initialViewSettings) return initialViewSettings.timelineView;
         if (typeof window !== 'undefined') {
-            return (localStorage.getItem('tf_timeline_view') as 'horizontal' | 'vertical') || 'horizontal';
+            return (readLocalStorageItem('tf_timeline_view') as 'horizontal' | 'vertical') || 'horizontal';
         }
         return 'horizontal';
     });
 
     const [sidebarWidth, setSidebarWidth] = useState(() => {
         if (initialViewSettings && initialViewSettings.sidebarWidth) return initialViewSettings.sidebarWidth;
-        if (typeof window !== 'undefined') return parseInt(localStorage.getItem('tf_sidebar_width') || '550', 10);
+        if (typeof window !== 'undefined') return parseInt(readLocalStorageItem('tf_sidebar_width') || '550', 10);
         return 550;
     });
 
     const [timelineHeight, setTimelineHeight] = useState(() => {
         if (initialViewSettings && initialViewSettings.timelineHeight) return initialViewSettings.timelineHeight;
-        if (typeof window !== 'undefined') return parseInt(localStorage.getItem('tf_timeline_height') || '400', 10);
+        if (typeof window !== 'undefined') return parseInt(readLocalStorageItem('tf_timeline_height') || '400', 10);
         return 400;
     });
 
     const [detailsWidth, setDetailsWidth] = useState(() => {
         if (typeof window !== 'undefined') {
-            const stored = parseInt(localStorage.getItem('tf_details_width') || `${defaultDetailsWidth}`, 10);
+            const stored = parseInt(readLocalStorageItem('tf_details_width') || `${defaultDetailsWidth}`, 10);
             if (Number.isFinite(stored)) return stored;
         }
         return defaultDetailsWidth;
@@ -71,7 +72,7 @@ export const useTripLayoutControlsState = ({
     const [zoomLevel, setZoomLevel] = useState(() => {
         if (typeof initialViewSettings?.zoomLevel === 'number') return initialViewSettings.zoomLevel;
         if (typeof window !== 'undefined') {
-            const stored = parseFloat(localStorage.getItem('tf_zoom_level') || '');
+            const stored = parseFloat(readLocalStorageItem('tf_zoom_level') || '');
             if (Number.isFinite(stored)) return stored;
         }
         return 1.0;

--- a/components/tripview/useTripResizeControls.ts
+++ b/components/tripview/useTripResizeControls.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
 
+import { writeLocalStorageItem } from '../../services/browserStorageService';
+
 interface UseTripResizeControlsOptions {
     layoutMode: 'vertical' | 'horizontal';
     timelineView: 'horizontal' | 'vertical';
@@ -143,13 +145,13 @@ export const useTripResizeControls = ({
 
     const stopResizing = useCallback(() => {
         if (isResizingRef.current === 'sidebar') {
-            localStorage.setItem('tf_sidebar_width', sidebarWidth.toString());
+            writeLocalStorageItem('tf_sidebar_width', sidebarWidth.toString());
         }
         if (isResizingRef.current === 'details') {
-            localStorage.setItem('tf_details_width', Math.round(detailsWidth).toString());
+            writeLocalStorageItem('tf_details_width', Math.round(detailsWidth).toString());
         }
         if (isResizingRef.current === 'timeline-h') {
-            localStorage.setItem('tf_timeline_height', timelineHeight.toString());
+            writeLocalStorageItem('tf_timeline_height', timelineHeight.toString());
         }
 
         isResizingRef.current = null;

--- a/components/tripview/useTripViewSettingsSync.ts
+++ b/components/tripview/useTripViewSettingsSync.ts
@@ -1,5 +1,6 @@
 import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
 
+import { writeLocalStorageItem } from '../../services/browserStorageService';
 import type { IViewSettings, MapStyle, RouteMode } from '../../types';
 import { applyViewSettingsToSearchParams } from '../../utils';
 
@@ -57,27 +58,27 @@ export const useTripViewSettingsSync = ({
     prevViewRef,
 }: UseTripViewSettingsSyncOptions) => {
     useEffect(() => {
-        localStorage.setItem('tf_map_style', mapStyle);
+        writeLocalStorageItem('tf_map_style', mapStyle);
     }, [mapStyle]);
 
     useEffect(() => {
-        localStorage.setItem('tf_route_mode', routeMode);
+        writeLocalStorageItem('tf_route_mode', routeMode);
     }, [routeMode]);
 
     useEffect(() => {
-        localStorage.setItem('tf_layout_mode', layoutMode);
+        writeLocalStorageItem('tf_layout_mode', layoutMode);
     }, [layoutMode]);
 
     useEffect(() => {
-        localStorage.setItem('tf_timeline_view', timelineView);
+        writeLocalStorageItem('tf_timeline_view', timelineView);
     }, [timelineView]);
 
     useEffect(() => {
-        localStorage.setItem('tf_city_names', String(showCityNames));
+        writeLocalStorageItem('tf_city_names', String(showCityNames));
     }, [showCityNames]);
 
     useEffect(() => {
-        localStorage.setItem('tf_zoom_level', zoomLevel.toFixed(2));
+        writeLocalStorageItem('tf_zoom_level', zoomLevel.toFixed(2));
     }, [zoomLevel]);
 
     useEffect(() => {

--- a/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
+++ b/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
@@ -14,6 +14,7 @@ summary: "Migrates auth/session, consent-adjacent, planner-setting, and trip per
 - [ ] [Internal] 🔒 Migrated auth/session storage callers to `browserStorageService` helper APIs.
 - [ ] [Internal] 🧭 Migrated consent-adjacent banner and release-notice storage access to policy-backed helper APIs.
 - [ ] [Internal] 🧾 Migrated consent bootstrap reads (`consentState`) to registry-backed storage helper APIs.
+- [ ] [Internal] 🧩 Migrated tripview planner persistence hooks (`useTripLayoutControlsState`, `useTripResizeControls`, `useTripViewSettingsSync`) to policy-backed storage helpers.
 - [ ] [Internal] 💾 Migrated trip persistence services (`storageService` and `historyService`) to policy-backed storage helpers.
 - [ ] [Internal] ♻️ Added registry-backed fallback handling for Supabase wildcard auth keys that can appear in session storage.
 - [ ] [Internal] 🧪 Added regression coverage for auth trace persistence, Supabase auth-key cleanup, and DB planner-setting persistence.

--- a/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
+++ b/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
@@ -24,9 +24,12 @@ This checklist tracks Phase 2 migration from raw browser storage access to `serv
 - [x] `services/dbService.ts` (planner view preference writes)
 - [x] `services/storageService.ts` and `services/historyService.ts`
 - [x] `services/consentState.ts` (consent bootstrap read path)
+- [x] `components/tripview/useTripLayoutControlsState.ts`
+- [x] `components/tripview/useTripResizeControls.ts`
+- [x] `components/tripview/useTripViewSettingsSync.ts`
 
 ## Remaining Direct Storage Usage (Next Batches)
-- [ ] `components/tripview/*` persistence hooks
+- [ ] `components/tripview/useTripCopyNoticeToast.ts` and `components/tripview/useTripShareLifecycle.ts` (remaining tripview persistence hooks)
 - [ ] `components/TripManager.tsx` / `components/ItineraryMap.tsx` / `components/CountryInfo.tsx`
 - [ ] `components/admin/*` cache utilities and shell state
 - [ ] `components/OnPageDebugger.tsx`

--- a/tests/browser/tripview/useTripLayoutControlsState.browser.test.ts
+++ b/tests/browser/tripview/useTripLayoutControlsState.browser.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useTripLayoutControlsState } from '../../../components/tripview/useTripLayoutControlsState';
+
+describe('components/tripview/useTripLayoutControlsState', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('hydrates layout controls from persisted storage keys', () => {
+    window.localStorage.setItem('tf_map_style', 'dark');
+    window.localStorage.setItem('tf_route_mode', 'realistic');
+    window.localStorage.setItem('tf_city_names', 'false');
+    window.localStorage.setItem('tf_layout_mode', 'vertical');
+    window.localStorage.setItem('tf_timeline_view', 'vertical');
+    window.localStorage.setItem('tf_sidebar_width', '620');
+    window.localStorage.setItem('tf_timeline_height', '460');
+    window.localStorage.setItem('tf_details_width', '540');
+    window.localStorage.setItem('tf_zoom_level', '2.25');
+
+    const { result } = renderHook(() =>
+      useTripLayoutControlsState({
+        defaultDetailsWidth: 500,
+      }),
+    );
+
+    expect(result.current.mapStyle).toBe('dark');
+    expect(result.current.routeMode).toBe('realistic');
+    expect(result.current.showCityNames).toBe(false);
+    expect(result.current.layoutMode).toBe('vertical');
+    expect(result.current.timelineView).toBe('vertical');
+    expect(result.current.sidebarWidth).toBe(620);
+    expect(result.current.timelineHeight).toBe(460);
+    expect(result.current.detailsWidth).toBe(540);
+    expect(result.current.zoomLevel).toBe(2.25);
+  });
+
+  it('prefers initial view settings over persisted storage where available', () => {
+    window.localStorage.setItem('tf_map_style', 'dark');
+    window.localStorage.setItem('tf_route_mode', 'realistic');
+    window.localStorage.setItem('tf_city_names', 'false');
+    window.localStorage.setItem('tf_layout_mode', 'vertical');
+    window.localStorage.setItem('tf_timeline_view', 'vertical');
+    window.localStorage.setItem('tf_sidebar_width', '620');
+    window.localStorage.setItem('tf_timeline_height', '460');
+    window.localStorage.setItem('tf_zoom_level', '2.25');
+
+    const { result } = renderHook(() =>
+      useTripLayoutControlsState({
+        defaultDetailsWidth: 500,
+        initialViewSettings: {
+          mapStyle: 'clean',
+          routeMode: 'simple',
+          showCityNames: true,
+          layoutMode: 'horizontal',
+          timelineView: 'horizontal',
+          zoomLevel: 1.5,
+          sidebarWidth: 580,
+          timelineHeight: 410,
+        },
+      }),
+    );
+
+    expect(result.current.mapStyle).toBe('clean');
+    expect(result.current.routeMode).toBe('simple');
+    expect(result.current.showCityNames).toBe(true);
+    expect(result.current.layoutMode).toBe('horizontal');
+    expect(result.current.timelineView).toBe('horizontal');
+    expect(result.current.sidebarWidth).toBe(580);
+    expect(result.current.timelineHeight).toBe(410);
+    expect(result.current.zoomLevel).toBe(1.5);
+  });
+});

--- a/tests/browser/tripview/useTripResizeControls.browser.test.ts
+++ b/tests/browser/tripview/useTripResizeControls.browser.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useTripResizeControls } from '../../../components/tripview/useTripResizeControls';
+
+const makeHookOptions = (
+  overrides: Partial<Parameters<typeof useTripResizeControls>[0]> = {},
+): Parameters<typeof useTripResizeControls>[0] => ({
+  layoutMode: 'horizontal',
+  timelineView: 'horizontal',
+  horizontalTimelineDayCount: 10,
+  clampZoomLevel: (value: number) => value,
+  setZoomLevel: vi.fn(),
+  sidebarWidth: 640,
+  setSidebarWidth: vi.fn(),
+  detailsWidth: 333.8,
+  setDetailsWidth: vi.fn(),
+  timelineHeight: 420,
+  setTimelineHeight: vi.fn(),
+  detailsPanelVisible: true,
+  minSidebarWidth: 320,
+  minTimelineHeight: 240,
+  minBottomMapHeight: 200,
+  minMapWidth: 420,
+  minTimelineColumnWidth: 320,
+  minDetailsWidth: 280,
+  hardMinDetailsWidth: 220,
+  resizerWidth: 6,
+  resizeKeyboardStep: 16,
+  horizontalTimelineAutoFitPadding: 64,
+  basePixelsPerDay: 40,
+  ...overrides,
+});
+
+describe('components/tripview/useTripResizeControls', () => {
+  it('persists sidebar width when sidebar resizing ends', () => {
+    const { result } = renderHook(() => useTripResizeControls(makeHookOptions({ sidebarWidth: 610 })));
+
+    act(() => {
+      result.current.startResizing('sidebar');
+      window.dispatchEvent(new MouseEvent('mouseup'));
+    });
+
+    expect(window.localStorage.getItem('tf_sidebar_width')).toBe('610');
+  });
+
+  it('persists details width when details resizing ends', () => {
+    const { result } = renderHook(() => useTripResizeControls(makeHookOptions({ detailsWidth: 333.8 })));
+
+    act(() => {
+      result.current.startResizing('details', 100);
+      window.dispatchEvent(new MouseEvent('mouseup'));
+    });
+
+    expect(window.localStorage.getItem('tf_details_width')).toBe('334');
+  });
+
+  it('persists timeline height when timeline resizing ends', () => {
+    const { result } = renderHook(() => useTripResizeControls(makeHookOptions({ timelineHeight: 455 })));
+
+    act(() => {
+      result.current.startResizing('timeline-h');
+      window.dispatchEvent(new MouseEvent('mouseup'));
+    });
+
+    expect(window.localStorage.getItem('tf_timeline_height')).toBe('455');
+  });
+});


### PR DESCRIPTION
## Summary
- migrate tripview planner persistence hooks to policy-backed helpers:
  - `useTripLayoutControlsState`
  - `useTripResizeControls`
  - `useTripViewSettingsSync`
- add browser regression tests for layout-state hydration and resize persistence
- update the Phase 2 storage migration checklist and keep the single draft release note current

## Validation
- `pnpm storage:validate`
- `pnpm vitest run tests/browser/tripview/useTripViewSettingsSync.browser.test.ts tests/browser/tripview/useTripLayoutControlsState.browser.test.ts tests/browser/tripview/useTripResizeControls.browser.test.ts`
- `pnpm test:core`
- `pnpm updates:validate`

Part of #127
