### PR TITLE
Phase 2 storage migration: tripview share hooks

### DIFF
--- a/components/tripview/useTripCopyNoticeToast.ts
+++ b/components/tripview/useTripCopyNoticeToast.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { readSessionStorageItem, removeSessionStorageItem } from '../../services/browserStorageService';
 
 type CopyNoticeToastTone = 'add' | 'info' | 'neutral' | 'remove';
 
@@ -13,28 +14,19 @@ export const useTripCopyNoticeToast = ({
 }: UseTripCopyNoticeToastParams) => {
     useEffect(() => {
         if (typeof window === 'undefined') return;
-        let raw: string | null = null;
-        try {
-            raw = window.sessionStorage.getItem('tf_trip_copy_notice');
-        } catch {
-            raw = null;
-        }
+        const raw = readSessionStorageItem('tf_trip_copy_notice');
         if (!raw) return;
         try {
             const payload = JSON.parse(raw);
             if (payload?.tripId !== tripId) return;
-            window.sessionStorage.removeItem('tf_trip_copy_notice');
+            removeSessionStorageItem('tf_trip_copy_notice');
             const sourceTitle = typeof payload.sourceTitle === 'string' && payload.sourceTitle.trim().length > 0
                 ? payload.sourceTitle.trim()
                 : null;
             const message = sourceTitle ? `Copied "${sourceTitle}"` : 'Trip copied successfully';
             showToast(message, { tone: 'add', title: 'Copied' });
         } catch {
-            try {
-                window.sessionStorage.removeItem('tf_trip_copy_notice');
-            } catch {
-                // ignore
-            }
+            removeSessionStorageItem('tf_trip_copy_notice');
         }
     }, [tripId, showToast]);
 };

--- a/components/tripview/useTripShareLifecycle.ts
+++ b/components/tripview/useTripShareLifecycle.ts
@@ -2,6 +2,11 @@ import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 
 
 import { DB_ENABLED } from '../../config/db';
 import {
+    readLocalStorageItem,
+    removeLocalStorageItem,
+    writeLocalStorageItem,
+} from '../../services/browserStorageService';
+import {
     dbRevokeTripShares,
     dbSetTripSharingEnabled,
     ensureDbSession,
@@ -15,7 +20,7 @@ const getShareLinksStorageKey = (tripId: string) => `${SHARE_LINK_STORAGE_PREFIX
 const readStoredShareLinks = (tripId: string): Partial<Record<ShareMode, string>> => {
     if (typeof window === 'undefined') return {};
     try {
-        const raw = window.localStorage.getItem(getShareLinksStorageKey(tripId));
+        const raw = readLocalStorageItem(getShareLinksStorageKey(tripId));
         if (!raw) return {};
         const parsed = JSON.parse(raw) as Record<string, unknown>;
         const links: Partial<Record<ShareMode, string>> = {};
@@ -29,11 +34,7 @@ const readStoredShareLinks = (tripId: string): Partial<Record<ShareMode, string>
 
 const clearStoredShareLinks = (tripId: string) => {
     if (typeof window === 'undefined') return;
-    try {
-        window.localStorage.removeItem(getShareLinksStorageKey(tripId));
-    } catch {
-        // ignore storage issues
-    }
+    removeLocalStorageItem(getShareLinksStorageKey(tripId));
 };
 
 interface UseTripShareLifecycleOptions {
@@ -72,11 +73,7 @@ export const useTripShareLifecycle = ({
 
     useEffect(() => {
         if (typeof window === 'undefined') return;
-        try {
-            window.localStorage.setItem(getShareLinksStorageKey(tripId), JSON.stringify(shareUrlsByMode));
-        } catch {
-            // ignore storage issues
-        }
+        writeLocalStorageItem(getShareLinksStorageKey(tripId), JSON.stringify(shareUrlsByMode));
     }, [tripId, shareUrlsByMode]);
 
     useEffect(() => {

--- a/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
+++ b/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
@@ -15,6 +15,7 @@ summary: "Migrates auth/session, consent-adjacent, planner-setting, and trip per
 - [ ] [Internal] 🧭 Migrated consent-adjacent banner and release-notice storage access to policy-backed helper APIs.
 - [ ] [Internal] 🧾 Migrated consent bootstrap reads (`consentState`) to registry-backed storage helper APIs.
 - [ ] [Internal] 🧩 Migrated tripview planner persistence hooks (`useTripLayoutControlsState`, `useTripResizeControls`, `useTripViewSettingsSync`) to policy-backed storage helpers.
+- [ ] [Internal] 🔗 Migrated tripview share persistence hooks (`useTripCopyNoticeToast`, `useTripShareLifecycle`) to policy-backed storage helpers.
 - [ ] [Internal] 💾 Migrated trip persistence services (`storageService` and `historyService`) to policy-backed storage helpers.
 - [ ] [Internal] ♻️ Added registry-backed fallback handling for Supabase wildcard auth keys that can appear in session storage.
 - [ ] [Internal] 🧪 Added regression coverage for auth trace persistence, Supabase auth-key cleanup, and DB planner-setting persistence.

--- a/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
+++ b/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
@@ -27,9 +27,10 @@ This checklist tracks Phase 2 migration from raw browser storage access to `serv
 - [x] `components/tripview/useTripLayoutControlsState.ts`
 - [x] `components/tripview/useTripResizeControls.ts`
 - [x] `components/tripview/useTripViewSettingsSync.ts`
+- [x] `components/tripview/useTripCopyNoticeToast.ts`
+- [x] `components/tripview/useTripShareLifecycle.ts`
 
 ## Remaining Direct Storage Usage (Next Batches)
-- [ ] `components/tripview/useTripCopyNoticeToast.ts` and `components/tripview/useTripShareLifecycle.ts` (remaining tripview persistence hooks)
 - [ ] `components/TripManager.tsx` / `components/ItineraryMap.tsx` / `components/CountryInfo.tsx`
 - [ ] `components/admin/*` cache utilities and shell state
 - [ ] `components/OnPageDebugger.tsx`

--- a/tests/browser/tripview/useTripCopyNoticeToast.browser.test.ts
+++ b/tests/browser/tripview/useTripCopyNoticeToast.browser.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTripCopyNoticeToast } from '../../../components/tripview/useTripCopyNoticeToast';
+
+describe('components/tripview/useTripCopyNoticeToast', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('shows copied toast for matching trip payload and clears session key', async () => {
+    window.sessionStorage.setItem('tf_trip_copy_notice', JSON.stringify({
+      tripId: 'trip-1',
+      sourceTitle: 'Summer Plan',
+    }));
+
+    const showToast = vi.fn();
+    renderHook(() => useTripCopyNoticeToast({ tripId: 'trip-1', showToast }));
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith('Copied "Summer Plan"', { tone: 'add', title: 'Copied' });
+    });
+    expect(window.sessionStorage.getItem('tf_trip_copy_notice')).toBeNull();
+  });
+
+  it('ignores payload for a different trip and keeps the key untouched', async () => {
+    window.sessionStorage.setItem('tf_trip_copy_notice', JSON.stringify({
+      tripId: 'trip-2',
+      sourceTitle: 'Another Trip',
+    }));
+
+    const showToast = vi.fn();
+    renderHook(() => useTripCopyNoticeToast({ tripId: 'trip-1', showToast }));
+
+    await waitFor(() => {
+      expect(showToast).not.toHaveBeenCalled();
+    });
+    expect(window.sessionStorage.getItem('tf_trip_copy_notice')).not.toBeNull();
+  });
+
+  it('clears malformed payloads defensively', async () => {
+    window.sessionStorage.setItem('tf_trip_copy_notice', '{bad-json');
+
+    const showToast = vi.fn();
+    renderHook(() => useTripCopyNoticeToast({ tripId: 'trip-1', showToast }));
+
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem('tf_trip_copy_notice')).toBeNull();
+    });
+    expect(showToast).not.toHaveBeenCalled();
+  });
+});

--- a/tests/browser/tripview/useTripShareLifecycle.browser.test.ts
+++ b/tests/browser/tripview/useTripShareLifecycle.browser.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../config/db', () => ({
+  DB_ENABLED: false,
+}));
+
+vi.mock('../../../services/dbApi', () => ({
+  ensureDbSession: vi.fn(async () => null),
+  dbSetTripSharingEnabled: vi.fn(async () => true),
+  dbRevokeTripShares: vi.fn(async () => 0),
+}));
+
+import { useTripShareLifecycle } from '../../../components/tripview/useTripShareLifecycle';
+
+const STORAGE_KEY = 'tf_share_links:trip-1';
+
+describe('components/tripview/useTripShareLifecycle', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('hydrates stored share links and persists updates', async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      view: 'https://example.com/view',
+      edit: 'https://example.com/edit',
+    }));
+
+    const { result } = renderHook(() =>
+      useTripShareLifecycle({
+        tripId: 'trip-1',
+        canShare: true,
+        isTripLockedByExpiry: false,
+      }),
+    );
+
+    expect(result.current.shareUrlsByMode).toEqual({
+      view: 'https://example.com/view',
+      edit: 'https://example.com/edit',
+    });
+
+    act(() => {
+      result.current.setShareUrlsByMode({ view: 'https://example.com/new-view' });
+    });
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify({
+        view: 'https://example.com/new-view',
+      }));
+    });
+  });
+
+  it('clears stored links and closes share panel when trip becomes locked (db disabled mode)', async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      view: 'https://example.com/view',
+    }));
+
+    const { result, rerender } = renderHook(
+      ({ isTripLockedByExpiry }: { isTripLockedByExpiry: boolean }) => useTripShareLifecycle({
+        tripId: 'trip-1',
+        canShare: true,
+        isTripLockedByExpiry,
+      }),
+      { initialProps: { isTripLockedByExpiry: false } },
+    );
+
+    act(() => {
+      result.current.setIsShareOpen(true);
+    });
+    expect(result.current.isShareOpen).toBe(true);
+
+    rerender({ isTripLockedByExpiry: true });
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe('{}');
+    });
+    await waitFor(() => {
+      expect(result.current.isShareOpen).toBe(false);
+      expect(result.current.shareUrlsByMode).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- migrate remaining tripview persistence hooks to policy-backed helpers:
  - `useTripCopyNoticeToast`
  - `useTripShareLifecycle`
- add browser regression tests for copy-notice and share lifecycle storage behavior
- update the Phase 2 storage migration checklist and keep the single draft release note current

## Validation
- `pnpm storage:validate`
- `pnpm vitest run tests/browser/tripview/useTripCopyNoticeToast.browser.test.ts tests/browser/tripview/useTripShareLifecycle.browser.test.ts tests/browser/tripview/useTripViewSettingsSync.browser.test.ts tests/browser/tripview/useTripLayoutControlsState.browser.test.ts tests/browser/tripview/useTripResizeControls.browser.test.ts`
- `pnpm test:core`
- `pnpm updates:validate`

Part of #127
