### PR TITLE
Phase 2 storage migration: admin cache + early access

### DIFF
--- a/components/admin/adminLocalCache.ts
+++ b/components/admin/adminLocalCache.ts
@@ -1,7 +1,9 @@
+import { readLocalStorageItem, writeLocalStorageItem } from '../../services/browserStorageService';
+
 export const readAdminCache = <T>(key: string, fallbackValue: T): T => {
     if (typeof window === 'undefined') return fallbackValue;
     try {
-        const rawValue = window.localStorage.getItem(key);
+        const rawValue = readLocalStorageItem(key);
         if (!rawValue) return fallbackValue;
         return JSON.parse(rawValue) as T;
     } catch {
@@ -12,7 +14,7 @@ export const readAdminCache = <T>(key: string, fallbackValue: T): T => {
 export const writeAdminCache = (key: string, value: unknown): void => {
     if (typeof window === 'undefined') return;
     try {
-        window.localStorage.setItem(key, JSON.stringify(value));
+        writeLocalStorageItem(key, JSON.stringify(value));
     } catch {
         // ignore cache write errors (quota/private mode), UI still works from live fetches
     }

--- a/components/marketing/EarlyAccessBanner.tsx
+++ b/components/marketing/EarlyAccessBanner.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { X, Flask } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analyticsService';
+import { readLocalStorageItem, writeLocalStorageItem } from '../../services/browserStorageService';
 
 const STORAGE_KEY = 'tf_early_access_dismissed';
 
@@ -9,7 +10,7 @@ export const EarlyAccessBanner: React.FC = () => {
     const { t } = useTranslation('common');
     const [dismissed, setDismissed] = useState(() => {
         try {
-            return localStorage.getItem(STORAGE_KEY) === '1';
+            return readLocalStorageItem(STORAGE_KEY) === '1';
         } catch {
             return false;
         }
@@ -21,7 +22,7 @@ export const EarlyAccessBanner: React.FC = () => {
         setDismissed(true);
         trackEvent('banner__early_access--dismiss');
         try {
-            localStorage.setItem(STORAGE_KEY, '1');
+            writeLocalStorageItem(STORAGE_KEY, '1');
         } catch {
             // ignore
         }

--- a/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
+++ b/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
@@ -16,6 +16,7 @@ summary: "Migrates auth/session, consent-adjacent, planner-setting, and trip per
 - [ ] [Internal] 🧾 Migrated consent bootstrap reads (`consentState`) to registry-backed storage helper APIs.
 - [ ] [Internal] 🧩 Migrated tripview planner persistence hooks (`useTripLayoutControlsState`, `useTripResizeControls`, `useTripViewSettingsSync`) to policy-backed storage helpers.
 - [ ] [Internal] 🔗 Migrated tripview share persistence hooks (`useTripCopyNoticeToast`, `useTripShareLifecycle`) to policy-backed storage helpers.
+- [ ] [Internal] 🧱 Migrated admin cache utility and early-access banner storage access to policy-backed helper APIs.
 - [ ] [Internal] 💾 Migrated trip persistence services (`storageService` and `historyService`) to policy-backed storage helpers.
 - [ ] [Internal] ♻️ Added registry-backed fallback handling for Supabase wildcard auth keys that can appear in session storage.
 - [ ] [Internal] 🧪 Added regression coverage for auth trace persistence, Supabase auth-key cleanup, and DB planner-setting persistence.

--- a/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
+++ b/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
@@ -29,12 +29,13 @@ This checklist tracks Phase 2 migration from raw browser storage access to `serv
 - [x] `components/tripview/useTripViewSettingsSync.ts`
 - [x] `components/tripview/useTripCopyNoticeToast.ts`
 - [x] `components/tripview/useTripShareLifecycle.ts`
+- [x] `components/admin/adminLocalCache.ts`
+- [x] `components/marketing/EarlyAccessBanner.tsx`
 
 ## Remaining Direct Storage Usage (Next Batches)
 - [ ] `components/TripManager.tsx` / `components/ItineraryMap.tsx` / `components/CountryInfo.tsx`
-- [ ] `components/admin/*` cache utilities and shell state
+- [ ] `components/admin/AdminShell.tsx` (shell state persistence)
 - [ ] `components/OnPageDebugger.tsx`
-- [ ] `components/marketing/EarlyAccessBanner.tsx`
 
 ## Verification
 - Run `pnpm storage:validate`.

--- a/test/browser/marketing/EarlyAccessBanner.browser.test.tsx
+++ b/test/browser/marketing/EarlyAccessBanner.browser.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const trackEventMock = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../../services/analyticsService', () => ({
+  trackEvent: (...args: unknown[]) => trackEventMock(...args),
+  getAnalyticsDebugAttributes: () => ({}),
+}));
+
+import { EarlyAccessBanner } from '../../../components/marketing/EarlyAccessBanner';
+
+describe('components/marketing/EarlyAccessBanner', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    trackEventMock.mockReset();
+  });
+
+  it('does not render when previously dismissed', () => {
+    window.localStorage.setItem('tf_early_access_dismissed', '1');
+    render(<EarlyAccessBanner />);
+    expect(screen.queryByLabelText('earlyAccess.dismiss')).toBeNull();
+  });
+
+  it('persists dismissal and tracks analytics event', () => {
+    render(<EarlyAccessBanner />);
+
+    const dismissButton = screen.getByLabelText('earlyAccess.dismiss');
+    fireEvent.click(dismissButton);
+
+    expect(trackEventMock).toHaveBeenCalledWith('banner__early_access--dismiss');
+    expect(window.localStorage.getItem('tf_early_access_dismissed')).toBe('1');
+    expect(screen.queryByLabelText('earlyAccess.dismiss')).toBeNull();
+  });
+});

--- a/tests/browser/admin/adminLocalCache.browser.test.ts
+++ b/tests/browser/admin/adminLocalCache.browser.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { readAdminCache, writeAdminCache } from '../../../components/admin/adminLocalCache';
+
+describe('components/admin/adminLocalCache', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns fallback when cache key is missing', () => {
+    expect(readAdminCache('admin.users.cache.v1', { rows: [] })).toEqual({ rows: [] });
+  });
+
+  it('writes and reads cached payloads', () => {
+    writeAdminCache('admin.users.cache.v1', { rows: [{ id: 'u1' }] });
+    expect(readAdminCache('admin.users.cache.v1', { rows: [] })).toEqual({ rows: [{ id: 'u1' }] });
+  });
+
+  it('returns fallback for malformed stored json', () => {
+    window.localStorage.setItem('admin.users.cache.v1', '{invalid-json');
+    expect(readAdminCache('admin.users.cache.v1', { rows: ['fallback'] })).toEqual({ rows: ['fallback'] });
+  });
+});


### PR DESCRIPTION
## Summary
- migrate `components/admin/adminLocalCache.ts` and `components/marketing/EarlyAccessBanner.tsx` to `browserStorageService` helper APIs
- add browser regression coverage for admin cache read/write behavior and early-access banner dismissal persistence
- update the Phase 2 storage migration checklist and keep the single draft release note current

## Validation
- `pnpm storage:validate`
- `pnpm vitest run tests/browser/admin/adminLocalCache.browser.test.ts test/browser/marketing/EarlyAccessBanner.browser.test.tsx`
- `pnpm test:core`
- `pnpm updates:validate`

Part of #127
