### PR TITLE
Phase 2 storage migration: map and country persistence

### DIFF
--- a/components/CountryInfo.tsx
+++ b/components/CountryInfo.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ICountryInfo } from '../types';
 import { Banknote, Globe, Zap, FileText, ExternalLink, ArrowRightLeft } from 'lucide-react';
+import { readLocalStorageItem, writeLocalStorageItem } from '../services/browserStorageService';
 
 interface CountryInfoProps {
     info: Partial<ICountryInfo> | ICountryInfo;
@@ -38,24 +39,24 @@ export const CountryInfo: React.FC<CountryInfoProps> = ({ info }) => {
     // Converter State with Persistence
     const [amount, setAmount] = useState<number>(() => {
         if (typeof window === 'undefined') return 1;
-        const saved = localStorage.getItem('tf_country_amount');
+        const saved = readLocalStorageItem('tf_country_amount');
         const parsed = saved ? parseFloat(saved) : 1;
         return isNaN(parsed) ? 1 : parsed;
     });
 
     const [direction, setDirection] = useState<'eurToLocal' | 'localToEur'>(() => {
         if (typeof window === 'undefined') return 'eurToLocal';
-        const saved = localStorage.getItem('tf_country_dir');
+        const saved = readLocalStorageItem('tf_country_dir');
         return (saved === 'eurToLocal' || saved === 'localToEur') ? saved : 'eurToLocal';
     });
 
     // Persistence Effects
     useEffect(() => {
-        localStorage.setItem('tf_country_amount', amount.toString());
+        writeLocalStorageItem('tf_country_amount', amount.toString());
     }, [amount]);
 
     useEffect(() => {
-        localStorage.setItem('tf_country_dir', direction);
+        writeLocalStorageItem('tf_country_dir', direction);
     }, [direction]);
 
     const convertedValue = exchangeRate === null

--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -9,6 +9,7 @@ import {
     buildPaywalledTripDisplay,
 } from '../config/paywall';
 import { trackEvent } from '../services/analyticsService';
+import { removeLocalStorageItem } from '../services/browserStorageService';
 import { useLoginModal } from '../hooks/useLoginModal';
 import { buildPathFromLocationParts } from '../services/authNavigationService';
 import { useAuth } from '../hooks/useAuth';
@@ -1023,11 +1024,7 @@ const useTripViewRender = ({
 
     useEffect(() => {
         if (typeof window === 'undefined') return;
-        try {
-            window.localStorage.removeItem('tf_country_info_expanded');
-        } catch {
-            // ignore storage issues
-        }
+        removeLocalStorageItem('tf_country_info_expanded');
     }, []);
 
     const currentViewSettings: IViewSettings = useMemo(() => ({

--- a/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
+++ b/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
@@ -17,6 +17,7 @@ summary: "Migrates auth/session, consent-adjacent, planner-setting, and trip per
 - [ ] [Internal] 🧩 Migrated tripview planner persistence hooks (`useTripLayoutControlsState`, `useTripResizeControls`, `useTripViewSettingsSync`) to policy-backed storage helpers.
 - [ ] [Internal] 🔗 Migrated tripview share persistence hooks (`useTripCopyNoticeToast`, `useTripShareLifecycle`) to policy-backed storage helpers.
 - [ ] [Internal] 🧱 Migrated admin cache utility and early-access banner storage access to policy-backed helper APIs.
+- [ ] [Internal] 🗺️ Migrated map/country persistence paths (`TripManager`, `ItineraryMap`, `CountryInfo`, and legacy cleanup in `TripView`) to policy-backed storage helpers.
 - [ ] [Internal] 💾 Migrated trip persistence services (`storageService` and `historyService`) to policy-backed storage helpers.
 - [ ] [Internal] ♻️ Added registry-backed fallback handling for Supabase wildcard auth keys that can appear in session storage.
 - [ ] [Internal] 🧪 Added regression coverage for auth trace persistence, Supabase auth-key cleanup, and DB planner-setting persistence.

--- a/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
+++ b/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
@@ -31,9 +31,12 @@ This checklist tracks Phase 2 migration from raw browser storage access to `serv
 - [x] `components/tripview/useTripShareLifecycle.ts`
 - [x] `components/admin/adminLocalCache.ts`
 - [x] `components/marketing/EarlyAccessBanner.tsx`
+- [x] `components/TripManager.tsx` (country cache persistence)
+- [x] `components/ItineraryMap.tsx` (route cache persistence)
+- [x] `components/CountryInfo.tsx` (converter persistence)
+- [x] `components/TripView.tsx` (legacy cleanup key removal)
 
 ## Remaining Direct Storage Usage (Next Batches)
-- [ ] `components/TripManager.tsx` / `components/ItineraryMap.tsx` / `components/CountryInfo.tsx`
 - [ ] `components/admin/AdminShell.tsx` (shell state persistence)
 - [ ] `components/OnPageDebugger.tsx`
 

--- a/test/browser/CountryInfo.browser.test.tsx
+++ b/test/browser/CountryInfo.browser.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { CountryInfo } from '../../components/CountryInfo';
+
+describe('components/CountryInfo', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('hydrates converter controls from persisted storage values', async () => {
+    window.localStorage.setItem('tf_country_amount', '5');
+    window.localStorage.setItem('tf_country_dir', 'localToEur');
+
+    render(
+      <CountryInfo
+        info={{
+          currencyCode: 'USD',
+          exchangeRate: 2,
+          languages: ['English'],
+        }}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument();
+    expect(screen.getByText('2.5')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Swap conversion direction'));
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem('tf_country_dir')).toBe('eurToLocal');
+    });
+  });
+
+  it('falls back to defaults for invalid persisted values', async () => {
+    window.localStorage.setItem('tf_country_amount', 'not-a-number');
+    window.localStorage.setItem('tf_country_dir', 'invalid-direction');
+
+    render(
+      <CountryInfo
+        info={{
+          currencyCode: 'USD',
+          exchangeRate: 2,
+          languages: ['English'],
+        }}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem('tf_country_amount')).toBe('1');
+      expect(window.localStorage.getItem('tf_country_dir')).toBe('eurToLocal');
+    });
+  });
+});

--- a/tests/browser/itineraryMapRouteCache.browser.test.ts
+++ b/tests/browser/itineraryMapRouteCache.browser.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  ROUTE_FAILURE_TTL_MS,
+  ROUTE_PERSIST_TTL_MS,
+  buildPersistedRouteCachePayload,
+  filterHydratedRouteCacheEntries,
+} from '../../components/ItineraryMap';
+
+describe('components/ItineraryMap route cache helpers', () => {
+  it('filters persisted route entries by status and ttl', () => {
+    const now = Date.now();
+    const filtered = filterHydratedRouteCacheEntries({
+      freshOk: { status: 'ok', updatedAt: now - 1000, path: [] },
+      staleOk: { status: 'ok', updatedAt: now - ROUTE_PERSIST_TTL_MS - 10, path: [] },
+      freshFailed: { status: 'failed', updatedAt: now - 1000 },
+      staleFailed: { status: 'failed', updatedAt: now - ROUTE_FAILURE_TTL_MS - 10 },
+      invalid: { status: 'ok' } as unknown,
+    }, now);
+
+    expect(filtered.map(([key]) => key).sort()).toEqual(['freshFailed', 'freshOk']);
+  });
+
+  it('serializes route cache payload with ttl-aware filtering', () => {
+    const now = Date.now();
+    const routeCache = new Map<string, { status: 'ok' | 'failed'; updatedAt: number; path?: Array<{ lat: number; lng: number }> }>();
+    routeCache.set('freshOk', { status: 'ok', updatedAt: now - 2000, path: [{ lat: 1, lng: 2 }] });
+    routeCache.set('staleOk', { status: 'ok', updatedAt: now - ROUTE_PERSIST_TTL_MS - 1, path: [{ lat: 2, lng: 3 }] });
+    routeCache.set('freshFailed', { status: 'failed', updatedAt: now - 1000, path: [{ lat: 3, lng: 4 }] });
+    routeCache.set('staleFailed', { status: 'failed', updatedAt: now - ROUTE_FAILURE_TTL_MS - 1 });
+
+    const payload = buildPersistedRouteCachePayload(routeCache, now);
+
+    expect(payload).toEqual({
+      freshOk: { status: 'ok', updatedAt: now - 2000, path: [{ lat: 1, lng: 2 }] },
+      freshFailed: { status: 'failed', updatedAt: now - 1000 },
+    });
+  });
+});

--- a/tests/browser/tripManagerCountryCache.browser.test.ts
+++ b/tests/browser/tripManagerCountryCache.browser.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  readTripManagerCountryCache,
+  writeTripManagerCountryCache,
+} from '../../components/TripManager';
+
+const COUNTRY_CACHE_KEY = 'travelflow_country_cache_v1';
+
+describe('components/TripManager country cache helpers', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns empty cache when storage is missing', () => {
+    expect(readTripManagerCountryCache()).toEqual({});
+  });
+
+  it('reads and writes country cache payloads', () => {
+    writeTripManagerCountryCache({
+      '1.0000,2.0000': {
+        countryCode: 'de',
+        countryName: 'Germany',
+      },
+    });
+
+    expect(window.localStorage.getItem(COUNTRY_CACHE_KEY)).toBe(JSON.stringify({
+      '1.0000,2.0000': {
+        countryCode: 'de',
+        countryName: 'Germany',
+      },
+    }));
+    expect(readTripManagerCountryCache()).toEqual({
+      '1.0000,2.0000': {
+        countryCode: 'de',
+        countryName: 'Germany',
+      },
+    });
+  });
+
+  it('returns empty cache for malformed payloads', () => {
+    window.localStorage.setItem(COUNTRY_CACHE_KEY, '{invalid-json');
+    expect(readTripManagerCountryCache()).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- migrate map/country persistence paths to `browserStorageService` helper APIs:
  - `TripManager` country cache read/write
  - `ItineraryMap` route cache hydration/persistence
  - `CountryInfo` converter read/write
  - `TripView` legacy cleanup key removal
- add regression tests for route-cache helper filtering/serialization, trip-manager country cache helpers, and country converter persistence behavior
- update the Phase 2 storage migration checklist and keep the single draft release note current

## Validation
- `pnpm storage:validate`
- `pnpm vitest run tests/browser/tripManagerCountryCache.browser.test.ts tests/browser/itineraryMapRouteCache.browser.test.ts test/browser/CountryInfo.browser.test.tsx`
- `pnpm test:core`
- `pnpm updates:validate`

Part of #127
