### PR TITLE
refactor(storage): migrate AdminShell + OnPageDebugger helpers

### DIFF
--- a/components/OnPageDebugger.tsx
+++ b/components/OnPageDebugger.tsx
@@ -20,6 +20,11 @@ import {
     ANALYTICS_DEBUG_PAYLOAD_ATTR,
     ANALYTICS_DEBUG_SELECTOR,
 } from '../services/analyticsService';
+import {
+    readLocalStorageItem,
+    removeLocalStorageItem,
+    writeLocalStorageItem,
+} from '../services/browserStorageService';
 import { APP_NAME } from '../config/appGlobals';
 import { isSimulatedLoggedIn, setSimulatedLoggedIn as setDbSimulatedLoggedIn } from '../services/simulatedLoginService';
 import {
@@ -211,10 +216,9 @@ const readMetaSnapshot = (): MetaSnapshot => {
     };
 };
 
-const readStoredDebuggerBoolean = (storageKey: string, fallbackValue: boolean): boolean => {
-    if (typeof window === 'undefined') return fallbackValue;
+export const readStoredDebuggerBoolean = (storageKey: string, fallbackValue: boolean): boolean => {
     try {
-        const raw = window.localStorage.getItem(storageKey);
+        const raw = readLocalStorageItem(storageKey);
         if (raw === '1') return true;
         if (raw === '0') return false;
         return fallbackValue;
@@ -223,14 +227,13 @@ const readStoredDebuggerBoolean = (storageKey: string, fallbackValue: boolean): 
     }
 };
 
-const persistStoredDebuggerBoolean = (storageKey: string, value: boolean, fallbackValue: boolean): void => {
-    if (typeof window === 'undefined') return;
+export const persistStoredDebuggerBoolean = (storageKey: string, value: boolean, fallbackValue: boolean): void => {
     try {
         if (value === fallbackValue) {
-            window.localStorage.removeItem(storageKey);
+            removeLocalStorageItem(storageKey);
             return;
         }
-        window.localStorage.setItem(storageKey, value ? '1' : '0');
+        writeLocalStorageItem(storageKey, value ? '1' : '0');
     } catch {
         // Ignore storage access issues.
     }

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -17,6 +17,11 @@ import {
 import { APP_NAME } from '../../config/appGlobals';
 import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analyticsService';
 import {
+    readLocalStorageItem,
+    readSessionStorageItem,
+    writeLocalStorageItem,
+} from '../../services/browserStorageService';
+import {
     SIMULATED_LOGIN_DEBUG_EVENT,
     SIMULATED_LOGIN_STORAGE_KEY,
     isSimulatedLoggedIn,
@@ -45,14 +50,16 @@ interface AdminShellProps {
 const SIDEBAR_COLLAPSE_PERSIST_KEY = 'tf_admin_sidebar_collapsed_v1';
 const DEV_ADMIN_BYPASS_DISABLED_SESSION_KEY = 'tf_dev_admin_bypass_disabled';
 
-const getStoredSidebarCollapseState = (): boolean => {
-    if (typeof window === 'undefined') return false;
-    return window.localStorage.getItem(SIDEBAR_COLLAPSE_PERSIST_KEY) === '1';
+export const getStoredSidebarCollapseState = (): boolean => {
+    return readLocalStorageItem(SIDEBAR_COLLAPSE_PERSIST_KEY) === '1';
 };
 
-const persistSidebarCollapseState = (next: boolean): void => {
-    if (typeof window === 'undefined') return;
-    window.localStorage.setItem(SIDEBAR_COLLAPSE_PERSIST_KEY, next ? '1' : '0');
+export const persistSidebarCollapseState = (next: boolean): void => {
+    writeLocalStorageItem(SIDEBAR_COLLAPSE_PERSIST_KEY, next ? '1' : '0');
+};
+
+export const isDevAdminBypassDisabled = (): boolean => {
+    return readSessionStorageItem(DEV_ADMIN_BYPASS_DISABLED_SESSION_KEY) === '1';
 };
 
 const itemIcon = (icon: (typeof ADMIN_NAV_ITEMS)[number]['icon']) => {
@@ -118,7 +125,7 @@ export const AdminShell: React.FC<AdminShellProps> = ({
         }
 
         const bypassConfigured = import.meta.env.DEV && import.meta.env.VITE_DEV_ADMIN_BYPASS === 'true';
-        const bypassDisabled = window.sessionStorage.getItem(DEV_ADMIN_BYPASS_DISABLED_SESSION_KEY) === '1';
+        const bypassDisabled = isDevAdminBypassDisabled();
         const bypassSessionUser = (access?.userId || '').trim() === 'dev-admin-id';
         setIsDevAdminBypassActive(bypassConfigured && !bypassDisabled && bypassSessionUser);
     }, [access?.userId]);

--- a/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
+++ b/content/updates/2026-02-24-storage-consent-policy-phase2-migration.md
@@ -18,6 +18,7 @@ summary: "Migrates auth/session, consent-adjacent, planner-setting, and trip per
 - [ ] [Internal] 🔗 Migrated tripview share persistence hooks (`useTripCopyNoticeToast`, `useTripShareLifecycle`) to policy-backed storage helpers.
 - [ ] [Internal] 🧱 Migrated admin cache utility and early-access banner storage access to policy-backed helper APIs.
 - [ ] [Internal] 🗺️ Migrated map/country persistence paths (`TripManager`, `ItineraryMap`, `CountryInfo`, and legacy cleanup in `TripView`) to policy-backed storage helpers.
+- [ ] [Internal] 🧰 Migrated `AdminShell` and `OnPageDebugger` storage helpers to policy-backed storage APIs, leaving only intentional low-level storage boundaries.
 - [ ] [Internal] 💾 Migrated trip persistence services (`storageService` and `historyService`) to policy-backed storage helpers.
 - [ ] [Internal] ♻️ Added registry-backed fallback handling for Supabase wildcard auth keys that can appear in session storage.
 - [ ] [Internal] 🧪 Added regression coverage for auth trace persistence, Supabase auth-key cleanup, and DB planner-setting persistence.

--- a/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
+++ b/docs/STORAGE_POLICY_MIGRATION_CHECKLIST.md
@@ -35,10 +35,11 @@ This checklist tracks Phase 2 migration from raw browser storage access to `serv
 - [x] `components/ItineraryMap.tsx` (route cache persistence)
 - [x] `components/CountryInfo.tsx` (converter persistence)
 - [x] `components/TripView.tsx` (legacy cleanup key removal)
+- [x] `components/admin/AdminShell.tsx` (shell state persistence)
+- [x] `components/OnPageDebugger.tsx`
 
 ## Remaining Direct Storage Usage (Next Batches)
-- [ ] `components/admin/AdminShell.tsx` (shell state persistence)
-- [ ] `components/OnPageDebugger.tsx`
+- [ ] No remaining application-level direct storage access. Keep `services/browserStorageService.ts` and `services/authService.ts` low-level key-iteration paths as the intentional runtime boundary.
 
 ## Verification
 - Run `pnpm storage:validate`.

--- a/tests/browser/admin/AdminShell.storage.browser.test.ts
+++ b/tests/browser/admin/AdminShell.storage.browser.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getStoredSidebarCollapseState,
+  isDevAdminBypassDisabled,
+  persistSidebarCollapseState,
+} from '../../../components/admin/AdminShell';
+
+describe('components/admin/AdminShell storage helpers', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it('reads and writes sidebar collapse state', () => {
+    expect(getStoredSidebarCollapseState()).toBe(false);
+
+    persistSidebarCollapseState(true);
+    expect(getStoredSidebarCollapseState()).toBe(true);
+    expect(window.localStorage.getItem('tf_admin_sidebar_collapsed_v1')).toBe('1');
+
+    persistSidebarCollapseState(false);
+    expect(getStoredSidebarCollapseState()).toBe(false);
+    expect(window.localStorage.getItem('tf_admin_sidebar_collapsed_v1')).toBe('0');
+  });
+
+  it('reads dev-admin bypass disabled flag from session storage', () => {
+    expect(isDevAdminBypassDisabled()).toBe(false);
+
+    window.sessionStorage.setItem('tf_dev_admin_bypass_disabled', '1');
+    expect(isDevAdminBypassDisabled()).toBe(true);
+  });
+});

--- a/tests/browser/onPageDebuggerStorage.browser.test.ts
+++ b/tests/browser/onPageDebuggerStorage.browser.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  persistStoredDebuggerBoolean,
+  readStoredDebuggerBoolean,
+} from '../../components/OnPageDebugger';
+
+const KEY = 'tf_debug_auto_open';
+
+describe('components/OnPageDebugger storage helpers', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('reads persisted debug toggles with fallback behavior', () => {
+    expect(readStoredDebuggerBoolean(KEY, false)).toBe(false);
+
+    window.localStorage.setItem(KEY, '1');
+    expect(readStoredDebuggerBoolean(KEY, false)).toBe(true);
+
+    window.localStorage.setItem(KEY, '0');
+    expect(readStoredDebuggerBoolean(KEY, true)).toBe(false);
+
+    window.localStorage.setItem(KEY, 'invalid');
+    expect(readStoredDebuggerBoolean(KEY, true)).toBe(true);
+  });
+
+  it('persists custom values and removes fallback-equivalent values', () => {
+    persistStoredDebuggerBoolean(KEY, true, false);
+    expect(window.localStorage.getItem(KEY)).toBe('1');
+
+    persistStoredDebuggerBoolean(KEY, false, false);
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- migrate `AdminShell` storage reads/writes to `browserStorageService` helper APIs
- migrate `OnPageDebugger` storage helper utilities to policy-backed storage helpers
- add browser regression tests for both helper modules and update Phase 2 checklist/release draft

## Testing
- pnpm storage:validate
- pnpm vitest run tests/browser/admin/AdminShell.storage.browser.test.ts tests/browser/onPageDebuggerStorage.browser.test.ts
- pnpm test:core
- pnpm updates:validate

Closes #127
