### PR TITLE
hotfix(edge): disable catch-all edge interception

### DIFF
--- a/content/updates/2026-02-24-edge-availability-hotfix.md
+++ b/content/updates/2026-02-24-edge-availability-hotfix.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-02-24-edge-availability-hotfix
+version: v0.58.0
+title: "Edge availability hotfix"
+date: 2026-02-24
+published_at: 2026-02-24T18:40:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Stabilizes site availability by disabling global edge interception during upstream timeout incidents."
+---
+
+## Changes
+- [x] [Fixed] 🛟 Restored reliable page and asset loading during intermittent edge timeout spikes.
+- [ ] [Internal] 🧭 Disabled catch-all site-wide edge interception as an emergency availability mitigation while keeping targeted edge routes active.

--- a/netlify.toml
+++ b/netlify.toml
@@ -81,10 +81,6 @@
   path = "/trip/*"
   function = "trip-og-meta"
 
-[[edge_functions]]
-  path = "/*"
-  function = "site-og-meta"
-
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
## Summary
- disable the `/* -> site-og-meta` edge binding to stop global request interception during upstream timeout incidents
- keep targeted edge functions (`/api/*`, `/s/*`, `/trip/*`) unchanged
- add a draft release-note entry for the availability hotfix

## Validation
- pnpm edge:validate
- pnpm updates:validate

## Context
Production showed intermittent edge failures (`Upstream lookup timed out`) that bubbled as `502` for core paths like `/` and `/favicon.ico`.
This hotfix prioritizes site availability by removing catch-all edge execution from the critical path.
