### PR TITLE
hotfix(edge): restore OG metadata routes with explicit allowlist

### DIFF
--- a/content/updates/2026-02-24-edge-availability-hotfix.md
+++ b/content/updates/2026-02-24-edge-availability-hotfix.md
@@ -7,9 +7,11 @@ published_at: 2026-02-24T18:40:00Z
 status: draft
 notify_in_app: false
 in_app_hours: 24
-summary: "Stabilizes site availability by disabling global edge interception during upstream timeout incidents."
+summary: "Stabilizes site availability while restoring targeted OG metadata routing for marketing pages."
 ---
 
 ## Changes
 - [x] [Fixed] 🛟 Restored reliable page and asset loading during intermittent edge timeout spikes.
+- [x] [Fixed] 🖼️ Restored blog and localized page social previews with targeted metadata routing instead of site-wide interception.
 - [ ] [Internal] 🧭 Disabled catch-all site-wide edge interception as an emergency availability mitigation while keeping targeted edge routes active.
+- [ ] [Internal] 🧱 Added explicit route allowlists for metadata middleware and blocked future catch-all edge bindings in validation.

--- a/docs/EDGE_FUNCTIONS.md
+++ b/docs/EDGE_FUNCTIONS.md
@@ -10,7 +10,7 @@ Shared helpers live in `netlify/edge-lib/`.
 | `ai-generate.ts` | `/api/ai/generate` | Server-side AI itinerary generation endpoint (Gemini, OpenAI, Anthropic, OpenRouter allowlisted models) | API |
 | `ai-benchmark.ts` | `/api/internal/ai/benchmark`, `/api/internal/ai/benchmark/export`, `/api/internal/ai/benchmark/cleanup`, `/api/internal/ai/benchmark/rating`, `/api/internal/ai/benchmark/telemetry`, `/api/internal/ai/benchmark/preferences` | Internal benchmark API (session/run persistence, execution, export, cleanup, persisted run ratings, telemetry summaries, and admin preference persistence for benchmark model targets/presets) with bearer-token admin role enforcement (`get_current_user_access`). Session export supports `includeLogs=1` to bundle prompt/scenario + run logs. | API |
 | `admin-iam.ts` | `/api/internal/admin/iam` | Internal admin identity API for invite/direct user provisioning and hard-delete actions via Supabase Auth admin endpoints. | API |
-| `site-og-meta.ts` | `/`, `/create-trip`, `/features`, `/updates`, `/blog`, `/blog/*`, `/login`, `/imprint`, `/privacy`, `/terms`, `/cookies`, `/inspirations`, `/inspirations/*`, `/pricing`, `/admin/*` | Injects SEO & Open Graph meta tags into marketing page HTML | Middleware |
+| `site-og-meta.ts` | `/`, `/create-trip`, `/features`, `/updates`, `/blog`, `/blog/*`, `/pricing`, `/faq`, `/share-unavailable`, `/login`, `/contact`, `/imprint`, `/privacy`, `/terms`, `/cookies`, `/inspirations`, `/inspirations/*`, plus localized prefixes `/{locale}` and `/{locale}/*` for `es,de,fr,pt,ru,it,pl,ko` | Injects SEO & Open Graph meta tags into marketing page HTML | Middleware |
 | `site-og-image.tsx` | `/api/og/site` | Generates 1200x630 branded OG images for site pages | Image generator |
 | `trip-og-meta.ts` | `/s/*`, `/trip/*` | Injects OG meta tags for shared and private trip pages | Middleware |
 | `trip-og-image.tsx` | `/api/og/trip` | Generates dynamic OG images showing trip route, duration, distance | Image generator |
@@ -49,6 +49,13 @@ Trip/share pages ──▶ trip-og-meta.ts ──context.next()──▶ SPA ind
 > Mixing inline config with `netlify.toml` config crashes the entire edge function bundle at runtime, producing **500 errors on every page**.
 
 The CI validator (`scripts/validate-edge-functions.mjs`) enforces this rule at build time.
+
+### Catch-all route policy
+
+- Do not add `[[edge_functions]] path = "/*"` in `netlify.toml`.
+- Catch-all edge bindings are treated as a production availability risk because upstream timeouts can convert into full-site `502` incidents.
+- Use explicit path allowlists (for example: `/`, `/blog`, `/blog/*`, `/api/og/*`) and keep static/internal platform paths outside edge middleware.
+- CI fails if a catch-all edge binding is added.
 
 ## Required environment variables
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -74,6 +74,138 @@
   function = "site-og-image"
 
 [[edge_functions]]
+  path = "/"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/create-trip"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/updates"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/blog"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/blog/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/faq"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/share-unavailable"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/contact"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
   path = "/s/*"
   function = "trip-og-meta"
 

--- a/scripts/edge-validation-utils.mjs
+++ b/scripts/edge-validation-utils.mjs
@@ -1,0 +1,24 @@
+/**
+ * Parse [[edge_functions]] blocks from netlify.toml.
+ */
+export const parseEdgeFunctionEntries = (toml) => {
+  const entries = [];
+  const blockRegex = /\[\[edge_functions\]\]([\s\S]*?)(?=\n\[\[|\n\[|$)/g;
+  let blockMatch;
+
+  while ((blockMatch = blockRegex.exec(toml)) !== null) {
+    const block = blockMatch[1] || "";
+    const pathMatch = block.match(/path\s*=\s*"([^"]+)"/);
+    const functionMatch = block.match(/function\s*=\s*"([^"]+)"/);
+    if (!pathMatch || !functionMatch) continue;
+    entries.push({
+      path: pathMatch[1],
+      functionName: functionMatch[1],
+    });
+  }
+
+  return entries;
+};
+
+export const findCatchAllEdgeEntries = (entries) =>
+  entries.filter((entry) => entry.path.trim() === "/*");

--- a/scripts/validate-edge-functions.mjs
+++ b/scripts/validate-edge-functions.mjs
@@ -11,6 +11,10 @@
 
 import { readFileSync, readdirSync } from "node:fs";
 import { resolve, basename } from "node:path";
+import {
+  findCatchAllEdgeEntries,
+  parseEdgeFunctionEntries,
+} from "./edge-validation-utils.mjs";
 
 const ROOT = resolve(import.meta.dirname, "..");
 const EF_DIR = resolve(ROOT, "netlify/edge-functions");
@@ -45,10 +49,19 @@ for (const file of efFiles) {
 
 const toml = readFileSync(TOML_PATH, "utf-8");
 const tomlFunctionNames = new Set();
-const entryRegex = /\[\[edge_functions\]\][^[]*?function\s*=\s*"([^"]+)"/g;
-let match;
-while ((match = entryRegex.exec(toml)) !== null) {
-  tomlFunctionNames.add(match[1]);
+const edgeEntries = parseEdgeFunctionEntries(toml);
+for (const entry of edgeEntries) {
+  tomlFunctionNames.add(entry.functionName);
+}
+
+const catchAllEntries = findCatchAllEdgeEntries(edgeEntries);
+for (const entry of catchAllEntries) {
+  console.error(
+    `ERROR: netlify.toml defines catch-all edge route "${entry.path}" -> "${entry.functionName}". ` +
+      `Catch-all edge bindings are forbidden because upstream edge/runtime timeouts can take down the full site. ` +
+      `Use explicit route allowlists for edge middleware.`
+  );
+  errors++;
 }
 
 // Check toml entries point to real files

--- a/tests/unit/edgeValidationUtils.test.ts
+++ b/tests/unit/edgeValidationUtils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findCatchAllEdgeEntries,
+  parseEdgeFunctionEntries,
+} from '../../scripts/edge-validation-utils.mjs';
+
+describe('edge validation utils', () => {
+  it('parses edge function entries from netlify.toml blocks', () => {
+    const toml = `
+[[edge_functions]]
+  path = "/api/health"
+  function = "health"
+
+[[edge_functions]]
+  path = "/trip/*"
+  function = "trip-og-meta"
+
+[[headers]]
+  for = "/assets/*"
+`;
+
+    const entries = parseEdgeFunctionEntries(toml);
+    expect(entries).toEqual([
+      { path: '/api/health', functionName: 'health' },
+      { path: '/trip/*', functionName: 'trip-og-meta' },
+    ]);
+  });
+
+  it('detects catch-all edge route bindings', () => {
+    const entries = [
+      { path: '/api/health', functionName: 'health' },
+      { path: '/*', functionName: 'site-og-meta' },
+      { path: '/trip/*', functionName: 'trip-og-meta' },
+    ];
+
+    const catchAll = findCatchAllEdgeEntries(entries);
+    expect(catchAll).toEqual([{ path: '/*', functionName: 'site-og-meta' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- restore `site-og-meta` routing with explicit allowlist paths in `netlify.toml` (including localized marketing prefixes)
- keep global catch-all disabled to avoid a repeat of the full-site edge timeout outage
- add edge route guardrails: CI fails if `[[edge_functions]] path = "/*"` is introduced
- add incident postmortem in `docs/incidents/2026-02-24-edge-timeout-site-outage.md`
- update the draft release note for this hotfix

## Validation
- `pnpm edge:validate`
- `pnpm updates:validate`
- `pnpm test tests/unit/edgeValidationUtils.test.ts`
- `pnpm test:core`
- local smoke via `pnpm dev:netlify` + curl:
  - `/blog/how-to-plan-multi-city-trip` -> `x-nf-edge-functions: site-og-meta`
  - `/de/blog/how-to-plan-multi-city-trip` -> `x-nf-edge-functions: site-og-meta`
  - `/trip/test-trip-id` -> `x-nf-edge-functions: trip-og-meta`
