### PR TITLE
hotfix(edge): prevent root outages from site-og-meta timeouts

### DIFF
--- a/content/updates/2026-02-24-edge-availability-hotfix.md
+++ b/content/updates/2026-02-24-edge-availability-hotfix.md
@@ -13,5 +13,7 @@ summary: "Stabilizes site availability while restoring targeted OG metadata rout
 ## Changes
 - [x] [Fixed] 🛟 Restored reliable page and asset loading during intermittent edge timeout spikes.
 - [x] [Fixed] 🖼️ Restored blog and localized page social previews with targeted metadata routing instead of site-wide interception.
+- [x] [Fixed] 🧭 Removed metadata middleware from the homepage and core app entry flow to prevent repeat edge timeout crashes on `/`.
 - [ ] [Internal] 🧭 Disabled catch-all site-wide edge interception as an emergency availability mitigation while keeping targeted edge routes active.
 - [ ] [Internal] 🧱 Added explicit route allowlists for metadata middleware and blocked future catch-all edge bindings in validation.
+- [ ] [Internal] 🛡️ Added site-og-meta scope enforcement and middleware upstream-fallback handling to reduce future edge crash blast radius.

--- a/docs/EDGE_FUNCTIONS.md
+++ b/docs/EDGE_FUNCTIONS.md
@@ -10,7 +10,7 @@ Shared helpers live in `netlify/edge-lib/`.
 | `ai-generate.ts` | `/api/ai/generate` | Server-side AI itinerary generation endpoint (Gemini, OpenAI, Anthropic, OpenRouter allowlisted models) | API |
 | `ai-benchmark.ts` | `/api/internal/ai/benchmark`, `/api/internal/ai/benchmark/export`, `/api/internal/ai/benchmark/cleanup`, `/api/internal/ai/benchmark/rating`, `/api/internal/ai/benchmark/telemetry`, `/api/internal/ai/benchmark/preferences` | Internal benchmark API (session/run persistence, execution, export, cleanup, persisted run ratings, telemetry summaries, and admin preference persistence for benchmark model targets/presets) with bearer-token admin role enforcement (`get_current_user_access`). Session export supports `includeLogs=1` to bundle prompt/scenario + run logs. | API |
 | `admin-iam.ts` | `/api/internal/admin/iam` | Internal admin identity API for invite/direct user provisioning and hard-delete actions via Supabase Auth admin endpoints. | API |
-| `site-og-meta.ts` | `/`, `/create-trip`, `/features`, `/updates`, `/blog`, `/blog/*`, `/pricing`, `/faq`, `/share-unavailable`, `/login`, `/contact`, `/imprint`, `/privacy`, `/terms`, `/cookies`, `/inspirations`, `/inspirations/*`, plus localized prefixes `/{locale}` and `/{locale}/*` for `es,de,fr,pt,ru,it,pl,ko` | Injects SEO & Open Graph meta tags into marketing page HTML | Middleware |
+| `site-og-meta.ts` | `/blog`, `/blog/*`, `/es/blog`, `/es/blog/*`, `/de/blog`, `/de/blog/*`, `/fr/blog`, `/fr/blog/*`, `/pt/blog`, `/pt/blog/*`, `/ru/blog`, `/ru/blog/*`, `/it/blog`, `/it/blog/*`, `/pl/blog`, `/pl/blog/*`, `/ko/blog`, `/ko/blog/*` | Injects SEO & Open Graph meta tags into blog page HTML | Middleware |
 | `site-og-image.tsx` | `/api/og/site` | Generates 1200x630 branded OG images for site pages | Image generator |
 | `trip-og-meta.ts` | `/s/*`, `/trip/*` | Injects OG meta tags for shared and private trip pages | Middleware |
 | `trip-og-image.tsx` | `/api/og/trip` | Generates dynamic OG images showing trip route, duration, distance | Image generator |
@@ -23,7 +23,7 @@ Shared helpers live in `netlify/edge-lib/`.
 ## Architecture
 
 ```
-Marketing pages ──▶ site-og-meta.ts ──context.next()──▶ SPA index.html
+Blog pages ──▶ site-og-meta.ts ──context.next()──▶ SPA index.html
                          │
                          ▼ (OG image URL points to)
                     site-og-image.tsx
@@ -56,6 +56,12 @@ The CI validator (`scripts/validate-edge-functions.mjs`) enforces this rule at b
 - Catch-all edge bindings are treated as a production availability risk because upstream timeouts can convert into full-site `502` incidents.
 - Use explicit path allowlists (for example: `/`, `/blog`, `/blog/*`, `/api/og/*`) and keep static/internal platform paths outside edge middleware.
 - CI fails if a catch-all edge binding is added.
+
+### Site metadata scope policy
+
+- `site-og-meta` is restricted to blog routes only.
+- Do not map `site-og-meta` to `/`, locale catch-alls (for example `/de/*`), or broad app routes.
+- CI fails if `site-og-meta` is configured outside the explicit blog allowlist in `netlify.toml`.
 
 ## Required environment variables
 

--- a/docs/incidents/2026-02-24-edge-timeout-site-outage.md
+++ b/docs/incidents/2026-02-24-edge-timeout-site-outage.md
@@ -31,6 +31,8 @@ The primary blast radius came from a catch-all edge middleware route (`[[edge_fu
 - 2026-02-24 ~17:43 UTC: production recovered to `200` on core routes and image transform probes.
 - 2026-02-24 ~18:00 UTC: follow-up regression identified (blog pages returned default OG metadata because `site-og-meta` had no active marketing-route bindings after catch-all removal).
 - 2026-02-24 ~18:xx UTC: targeted marketing allowlist routes added for `site-og-meta` (including localized marketing prefixes), restoring OG coverage without global interception.
+- 2026-02-24 ~19:17 UTC: second outage signal observed on `/` with `site-og-meta` timeout crashes (`Upstream lookup timed out`), indicating route scope was still too broad/high-traffic.
+- 2026-02-24 ~19:xx UTC: remediation narrowed `site-og-meta` to blog-only routes and added edge fallback logic for upstream lookup failures.
 
 ## Root Cause
 The production site had a catch-all edge middleware route:
@@ -61,6 +63,9 @@ When upstream edge lookups timed out, this catch-all interception turned localiz
 - Restored `site-og-meta` coverage using explicit route allowlists for marketing paths and locale-prefixed marketing URLs.
 - Added CI validator rule that fails if `netlify.toml` includes catch-all edge path `/*`.
 - Added explicit edge policy documentation forbidding catch-all bindings.
+- Restricted `site-og-meta` to blog-only routes to keep root/app navigation outside metadata middleware.
+- Added middleware fallback handling so `context.next()` timeouts no longer hard-crash the request path.
+- Added CI validator rule that fails if `site-og-meta` is mapped outside the blog route allowlist.
 
 ### Planned follow-ups (high priority)
 - Add synthetic monitoring checks (every 1 minute):

--- a/netlify.toml
+++ b/netlify.toml
@@ -74,30 +74,6 @@
   function = "site-og-image"
 
 [[edge_functions]]
-  path = "/"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/create-trip"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/features"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/inspirations"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/inspirations/*"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/updates"
-  function = "site-og-meta"
-
-[[edge_functions]]
   path = "/blog"
   function = "site-og-meta"
 
@@ -106,103 +82,67 @@
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/pricing"
+  path = "/es/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/faq"
+  path = "/es/blog/*"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/share-unavailable"
+  path = "/de/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/login"
+  path = "/de/blog/*"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/contact"
+  path = "/fr/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/imprint"
+  path = "/fr/blog/*"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/privacy"
+  path = "/pt/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/terms"
+  path = "/pt/blog/*"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/cookies"
+  path = "/ru/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/es"
+  path = "/ru/blog/*"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/es/*"
+  path = "/it/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/de"
+  path = "/it/blog/*"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/de/*"
+  path = "/pl/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/fr"
+  path = "/pl/blog/*"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/fr/*"
+  path = "/ko/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
-  path = "/pt"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/pt/*"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/ru"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/ru/*"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/it"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/it/*"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/pl"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/pl/*"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/ko"
-  function = "site-og-meta"
-
-[[edge_functions]]
-  path = "/ko/*"
+  path = "/ko/blog/*"
   function = "site-og-meta"
 
 [[edge_functions]]

--- a/scripts/edge-validation-utils.mjs
+++ b/scripts/edge-validation-utils.mjs
@@ -22,3 +22,33 @@ export const parseEdgeFunctionEntries = (toml) => {
 
 export const findCatchAllEdgeEntries = (entries) =>
   entries.filter((entry) => entry.path.trim() === "/*");
+
+const SITE_OG_META_ALLOWED_PATHS = new Set([
+  "/blog",
+  "/blog/*",
+  "/es/blog",
+  "/es/blog/*",
+  "/de/blog",
+  "/de/blog/*",
+  "/fr/blog",
+  "/fr/blog/*",
+  "/pt/blog",
+  "/pt/blog/*",
+  "/ru/blog",
+  "/ru/blog/*",
+  "/it/blog",
+  "/it/blog/*",
+  "/pl/blog",
+  "/pl/blog/*",
+  "/ko/blog",
+  "/ko/blog/*",
+]);
+
+export const findSiteOgMetaScopeViolations = (entries) =>
+  entries
+    .filter((entry) => entry.functionName === "site-og-meta")
+    .filter((entry) => !SITE_OG_META_ALLOWED_PATHS.has(entry.path.trim()))
+    .map((entry) => ({
+      ...entry,
+      reason: `site-og-meta must only be mapped to blog routes. Found disallowed path "${entry.path}".`,
+    }));

--- a/scripts/validate-edge-functions.mjs
+++ b/scripts/validate-edge-functions.mjs
@@ -14,6 +14,7 @@ import { resolve, basename } from "node:path";
 import {
   findCatchAllEdgeEntries,
   parseEdgeFunctionEntries,
+  findSiteOgMetaScopeViolations,
 } from "./edge-validation-utils.mjs";
 
 const ROOT = resolve(import.meta.dirname, "..");
@@ -61,6 +62,12 @@ for (const entry of catchAllEntries) {
       `Catch-all edge bindings are forbidden because upstream edge/runtime timeouts can take down the full site. ` +
       `Use explicit route allowlists for edge middleware.`
   );
+  errors++;
+}
+
+const siteOgMetaScopeViolations = findSiteOgMetaScopeViolations(edgeEntries);
+for (const violation of siteOgMetaScopeViolations) {
+  console.error(`ERROR: ${violation.reason}`);
   errors++;
 }
 

--- a/tests/unit/edgeValidationUtils.test.ts
+++ b/tests/unit/edgeValidationUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   findCatchAllEdgeEntries,
+  findSiteOgMetaScopeViolations,
   parseEdgeFunctionEntries,
 } from '../../scripts/edge-validation-utils.mjs';
 
@@ -35,5 +36,29 @@ describe('edge validation utils', () => {
 
     const catchAll = findCatchAllEdgeEntries(entries);
     expect(catchAll).toEqual([{ path: '/*', functionName: 'site-og-meta' }]);
+  });
+
+  it('detects disallowed site-og-meta route scope', () => {
+    const entries = [
+      { path: '/blog', functionName: 'site-og-meta' },
+      { path: '/de/blog/*', functionName: 'site-og-meta' },
+      { path: '/', functionName: 'site-og-meta' },
+      { path: '/de/*', functionName: 'site-og-meta' },
+      { path: '/trip/*', functionName: 'trip-og-meta' },
+    ];
+
+    const violations = findSiteOgMetaScopeViolations(entries);
+    expect(violations).toEqual([
+      {
+        path: '/',
+        functionName: 'site-og-meta',
+        reason: 'site-og-meta must only be mapped to blog routes. Found disallowed path "/".',
+      },
+      {
+        path: '/de/*',
+        functionName: 'site-og-meta',
+        reason: 'site-og-meta must only be mapped to blog routes. Found disallowed path "/de/*".',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- reduce `site-og-meta` blast radius by mapping it only to blog routes (`/blog*` and localized `/{locale}/blog*`)
- remove `site-og-meta` from `/` and broad app/marketing routes to avoid repeat full-app availability incidents
- harden `site-og-meta` against upstream timeout crashes by catching `context.next()` failures and falling back to the SPA index shell
- enforce policy in CI: `site-og-meta` is now validated against a strict blog-only allowlist
- update incident postmortem and edge-function docs with the recurrence + mitigation

## Why
Production showed repeated edge crashes on `/` with `site-og-meta` (`Upstream lookup timed out`).
This patch prioritizes availability first while keeping blog OG metadata coverage.

## Validation
- `pnpm edge:validate`
- `pnpm updates:validate`
- `pnpm test tests/unit/edgeValidationUtils.test.ts`
- `pnpm test:core`
- local smoke via `netlify dev`:
  - `/` no longer runs `site-og-meta`
  - `/blog/how-to-plan-multi-city-trip` runs `site-og-meta` and injects OG tags
  - `/de/blog/how-to-plan-multi-city-trip` runs `site-og-meta` and injects OG tags
