### PR TITLE
feat: static OG rollout and example route recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist-ssr
 # Performance artifacts
 /perf/
 /tmp/perf/
+public/images/og/site/generated/

--- a/content/updates/2026-02-24-edge-availability-hotfix.md
+++ b/content/updates/2026-02-24-edge-availability-hotfix.md
@@ -7,13 +7,13 @@ published_at: 2026-02-24T18:40:00Z
 status: draft
 notify_in_app: false
 in_app_hours: 24
-summary: "Stabilizes site availability while restoring targeted OG metadata routing for marketing pages."
+summary: "Stabilizes edge availability and restores reliable custom social previews across static pages, blog, and example trips."
 ---
 
 ## Changes
 - [x] [Fixed] 🛟 Restored reliable page and asset loading during intermittent edge timeout spikes.
-- [x] [Fixed] 🖼️ Restored blog and localized page social previews with targeted metadata routing instead of site-wide interception.
-- [x] [Fixed] 🧭 Removed metadata middleware from the homepage and core app entry flow to prevent repeat edge timeout crashes on `/`.
-- [ ] [Internal] 🧭 Disabled catch-all site-wide edge interception as an emergency availability mitigation while keeping targeted edge routes active.
-- [ ] [Internal] 🧱 Added explicit route allowlists for metadata middleware and blocked future catch-all edge bindings in validation.
-- [ ] [Internal] 🛡️ Added site-og-meta scope enforcement and middleware upstream-fallback handling to reduce future edge crash blast radius.
+- [x] [Fixed] 🖼️ Restored custom social previews for static pages, localized blog entries, and example trip pages.
+- [x] [Improved] ⚡ Switched static-page preview images to pre-generated assets for faster, more stable social-card delivery.
+- [ ] [Internal] 🧱 Added build-time static OG asset generation with deterministic hashed filenames plus manifest validation.
+- [ ] [Internal] 🛡️ Added explicit safe-route policy enforcement for metadata middleware and kept catch-all edge bindings blocked in CI.
+- [ ] [Internal] 🧭 Added static-first OG image lookup with dynamic image fallback and response tracing header (`x-travelflow-og-source`).

--- a/docs/incidents/2026-02-24-edge-timeout-site-outage.md
+++ b/docs/incidents/2026-02-24-edge-timeout-site-outage.md
@@ -60,12 +60,14 @@ When upstream edge lookups timed out, this catch-all interception turned localiz
 
 ### Implemented immediately
 - Removed catch-all edge binding from production routing (`/* -> site-og-meta`).
-- Restored `site-og-meta` coverage using explicit route allowlists for marketing paths and locale-prefixed marketing URLs.
+- Restored `site-og-meta` coverage using explicit route allowlists for static marketing/legal routes, `/create-trip`, and `/example/*` (including locale-prefixed variants).
 - Added CI validator rule that fails if `netlify.toml` includes catch-all edge path `/*`.
 - Added explicit edge policy documentation forbidding catch-all bindings.
-- Restricted `site-og-meta` to blog-only routes to keep root/app navigation outside metadata middleware.
 - Added middleware fallback handling so `context.next()` timeouts no longer hard-crash the request path.
-- Added CI validator rule that fails if `site-og-meta` is mapped outside the blog route allowlist.
+- Added build-time static OG image generation with hashed filenames and manifest lookup.
+- Added static-first `og:image` resolution with dynamic `/api/og/site` fallback when no static manifest entry is available.
+- Added CI validator rule that fails if `site-og-meta` is mapped outside the explicit safe-route allowlist.
+- Added build validation to guarantee manifest/asset coverage for all static OG route keys.
 
 ### Planned follow-ups (high priority)
 - Add synthetic monitoring checks (every 1 minute):

--- a/netlify.toml
+++ b/netlify.toml
@@ -74,11 +74,95 @@
   function = "site-og-image"
 
 [[edge_functions]]
+  path = "/"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/updates"
+  function = "site-og-meta"
+
+[[edge_functions]]
   path = "/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
   path = "/blog/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/faq"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/share-unavailable"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/contact"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/create-trip"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/example/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/updates"
   function = "site-og-meta"
 
 [[edge_functions]]
@@ -90,11 +174,131 @@
   function = "site-og-meta"
 
 [[edge_functions]]
+  path = "/es/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/faq"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/share-unavailable"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/contact"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/es/create-trip"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/updates"
+  function = "site-og-meta"
+
+[[edge_functions]]
   path = "/de/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
   path = "/de/blog/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/faq"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/share-unavailable"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/contact"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/de/create-trip"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/updates"
   function = "site-og-meta"
 
 [[edge_functions]]
@@ -106,11 +310,131 @@
   function = "site-og-meta"
 
 [[edge_functions]]
+  path = "/fr/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/faq"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/share-unavailable"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/contact"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/fr/create-trip"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/updates"
+  function = "site-og-meta"
+
+[[edge_functions]]
   path = "/pt/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
   path = "/pt/blog/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/faq"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/share-unavailable"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/contact"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pt/create-trip"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/updates"
   function = "site-og-meta"
 
 [[edge_functions]]
@@ -122,11 +446,131 @@
   function = "site-og-meta"
 
 [[edge_functions]]
+  path = "/ru/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/faq"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/share-unavailable"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/contact"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ru/create-trip"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/updates"
+  function = "site-og-meta"
+
+[[edge_functions]]
   path = "/it/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
   path = "/it/blog/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/faq"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/share-unavailable"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/contact"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/it/create-trip"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/updates"
   function = "site-og-meta"
 
 [[edge_functions]]
@@ -138,11 +582,111 @@
   function = "site-og-meta"
 
 [[edge_functions]]
+  path = "/pl/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/faq"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/share-unavailable"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/contact"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/pl/create-trip"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/features"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/inspirations"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/inspirations/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/updates"
+  function = "site-og-meta"
+
+[[edge_functions]]
   path = "/ko/blog"
   function = "site-og-meta"
 
 [[edge_functions]]
   path = "/ko/blog/*"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/pricing"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/faq"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/share-unavailable"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/login"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/contact"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/imprint"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/privacy"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/terms"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/cookies"
+  function = "site-og-meta"
+
+[[edge_functions]]
+  path = "/ko/create-trip"
   function = "site-og-meta"
 
 [[edge_functions]]
@@ -167,6 +711,11 @@
   for = "/images/blog/*"
   [headers.values]
     Cache-Control = "public, max-age=2592000, s-maxage=31536000, stale-while-revalidate=2592000"
+
+[[headers]]
+  for = "/images/og/site/generated/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
   for = "/fonts/*"

--- a/netlify/edge-functions/site-og-meta.ts
+++ b/netlify/edge-functions/site-og-meta.ts
@@ -1,882 +1,99 @@
-import { escapeHtml } from "../edge-lib/trip-og-data.ts";
-import { BLOG_OG_IMAGE_REVISION, getBlogImageMedia } from "../../data/blogImageMedia.ts";
-import { APP_DEFAULT_DESCRIPTION, APP_NAME, applyAppNameTemplate } from "../../config/appGlobals.ts";
+import {
+  SITE_CACHE_CONTROL,
+  TOOL_APP_CACHE_CONTROL,
+  buildDynamicSiteOgImageUrl,
+  buildSiteOgMetadata,
+  injectMetaTags,
+  shouldUseStrictToolHtmlCache,
+  type SiteOgMetadata,
+} from "../edge-lib/site-og-metadata.ts";
+import {
+  isSiteOgStaticManifest,
+  type SiteOgStaticManifest,
+} from "../edge-lib/site-og-static-manifest.ts";
 
-const SITE_NAME = APP_NAME;
-const DEFAULT_DESCRIPTION = APP_DEFAULT_DESCRIPTION;
-const SITE_CACHE_CONTROL = "public, max-age=0, s-maxage=900, stale-while-revalidate=86400";
-const TOOL_APP_CACHE_CONTROL = "public, max-age=0, s-maxage=60, stale-while-revalidate=60, must-revalidate";
-const DEFAULT_BLOG_OG_TINT = "#6366f1";
-const SUPPORTED_LOCALES = ["en", "es", "de", "fr", "pt", "ru", "it", "pl", "ko"] as const;
-type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
-const DEFAULT_LOCALE: SupportedLocale = "en";
+const SITE_OG_STATIC_MANIFEST_PATH = "/images/og/site/generated/manifest.json";
+const SITE_OG_STATIC_MANIFEST_TTL_MS = 60_000;
+const SITE_OG_STATIC_MANIFEST_TIMEOUT_MS = 1_200;
 
-interface AlternateLink {
-  hreflang: string;
-  href: string;
+interface ManifestCacheState {
+  fetchedAt: number;
+  manifest: SiteOgStaticManifest | null;
 }
 
-interface Metadata {
-  pageTitle: string;
-  description: string;
-  ogTitle: string;
-  ogDescription: string;
-  canonicalUrl: string;
-  ogImageUrl: string;
-  ogLogoUrl: string;
-  robots: string;
-  alternateLinks: AlternateLink[];
-  htmlLang: string;
-  htmlDir: "ltr" | "rtl";
-}
+let manifestCache: ManifestCacheState | null = null;
 
-interface PageDefinition {
-  title: string;
-  description: string;
-  ogTitle?: string;
-  ogDescription?: string;
-  robots?: string;
-  pill?: string;
-  blogOgImagePath?: string;
-  blogAccentTint?: string;
-  blogTintIntensity?: number;
-}
-
-type LocalizedPageDefinition = Partial<
-  Pick<PageDefinition, "title" | "description" | "ogTitle" | "ogDescription" | "pill">
->;
-
-const MARKETING_PATH_PATTERNS: RegExp[] = [
-  /^\/$/,
-  /^\/features$/,
-  /^\/inspirations$/,
-  /^\/inspirations\/themes$/,
-  /^\/inspirations\/best-time-to-travel$/,
-  /^\/inspirations\/countries$/,
-  /^\/inspirations\/events-and-festivals$/,
-  /^\/inspirations\/weekend-getaways$/,
-  /^\/inspirations\/country\/[^/]+$/,
-  /^\/updates$/,
-  /^\/blog$/,
-  /^\/blog\/[^/]+$/,
-  /^\/pricing$/,
-  /^\/faq$/,
-  /^\/share-unavailable$/,
-  /^\/login$/,
-  /^\/contact$/,
-  /^\/imprint$/,
-  /^\/privacy$/,
-  /^\/terms$/,
-  /^\/cookies$/,
-];
-
-const TOOL_PATH_PREFIXES = ["/create-trip", "/trip", "/s", "/example", "/admin", "/api"];
-const STRICT_TOOL_HTML_PREFIXES = ["/create-trip", "/admin", "/example"];
-
-const PAGE_META: Record<string, PageDefinition> = {
-  "/": {
-    title: "{{appName}}",
-    description: "Plan smarter trips with timeline + map routing and share them beautifully.",
-    pill: "{{appName}}",
-  },
-  "/create-trip": {
-    title: "Create Trip",
-    description: "Build your itinerary with flexible stops, routes, and timeline planning.",
-    pill: "TRIP PLANNER",
-  },
-  "/features": {
-    title: "Features",
-    description: "See everything {{appName}} offers for planning and sharing better adventures.",
-    pill: "FEATURES",
-  },
-  "/updates": {
-    title: "Product Updates",
-    description: "Catch the latest {{appName}} improvements and recently shipped features.",
-    pill: "PRODUCT UPDATES",
-  },
-  "/blog": {
-    title: "{{appName}} Blog",
-    description: "Guides, trip-planning ideas, and practical workflow tips from the {{appName}} team.",
-    pill: "BLOG",
-  },
-  "/login": {
-    title: "Login",
-    description: "Sign in and continue planning your next trip in {{appName}}.",
-  },
-  "/contact": {
-    title: "Contact",
-    description: "Reach out to report translation issues or localization feedback for {{appName}}.",
-  },
-  "/imprint": {
-    title: "Imprint",
-    description: "Legal notice and provider identification for {{appName}}.",
-  },
-  "/privacy": {
-    title: "Privacy Policy",
-    description: "Learn how {{appName}} handles personal data and privacy protection.",
-  },
-  "/terms": {
-    title: "Terms of Service",
-    description: "Read the terms that govern the use of {{appName}}.",
-  },
-  "/cookies": {
-    title: "Cookie Policy",
-    description: "Understand how {{appName}} uses cookies and similar technologies.",
-  },
-  "/inspirations": {
-    title: "Where Will You Go Next?",
-    description: "Browse curated trip ideas by theme, month, country, or upcoming festivals.",
-    pill: "TRIP INSPIRATIONS",
-  },
-  "/inspirations/themes": {
-    title: "Travel by Theme",
-    description: "Find curated trip ideas that match your travel style — adventure, food, photography, and more.",
-    pill: "TRIP INSPIRATIONS",
-  },
-  "/inspirations/best-time-to-travel": {
-    title: "When to Go Where",
-    description: "Month-by-month guide to the best time to visit destinations around the world.",
-    pill: "TRIP INSPIRATIONS",
-  },
-  "/inspirations/countries": {
-    title: "Explore by Country",
-    description: "Country-specific travel guides with best-month picks, top cities, and local tips.",
-    pill: "TRIP INSPIRATIONS",
-  },
-  "/inspirations/events-and-festivals": {
-    title: "Plan Around a Festival",
-    description: "Discover upcoming festivals and build your itinerary around the event.",
-    pill: "TRIP INSPIRATIONS",
-  },
-  "/inspirations/weekend-getaways": {
-    title: "Quick Escapes for Busy Travelers",
-    description: "2–3 day getaway ideas for spontaneous adventurers — pack light and make the most of a long weekend.",
-    pill: "TRIP INSPIRATIONS",
-  },
-  "/pricing": {
-    title: "Simple, Transparent Pricing",
-    description: "Start for free and upgrade when you need more. No hidden fees, cancel anytime.",
-    pill: "PRICING",
-  },
-  "/faq": {
-    title: "Frequently Asked Questions",
-    description: "Answers to common questions about {{appName}}, pricing, and trip sharing.",
-    pill: "FAQ",
-  },
-  "/share-unavailable": {
-    title: "Shared Trip Unavailable",
-    description: "The shared trip link is unavailable or expired.",
-  },
-};
-
-const LOCALIZED_PAGE_META: Record<string, Partial<Record<SupportedLocale, LocalizedPageDefinition>>> = {
-  "/": {
-    es: {
-      description: "Planifica viajes de forma más inteligente con línea de tiempo y mapa, y compártelos fácilmente.",
-    },
-    de: {
-      description: "Plane smartere Reisen mit Timeline und Karte und teile sie einfach.",
-    },
-    fr: {
-      description: "Planifiez des voyages plus malins avec timeline et carte, puis partagez-les facilement.",
-    },
-    it: {
-      description: "Pianifica viaggi migliori con timeline e mappa e condividili facilmente.",
-    },
-    ru: {
-      description: "Планируйте поездки умнее с таймлайном и картой и делитесь ими без лишних шагов.",
-    },
-    pt: {
-      description: "Plane viagens de forma mais inteligente com linha do tempo e mapa, e partilhe tudo com facilidade.",
-    },
-    pl: {
-      description: "Planuj podróże sprytniej dzięki osi czasu i mapie, a potem łatwo je udostępniaj.",
-    },
-  },
-  "/create-trip": {
-    es: {
-      title: "Crear viaje",
-      description: "Crea tu itinerario con paradas flexibles, rutas y planificación por línea de tiempo.",
-      pill: "PLANIFICADOR DE VIAJES",
-    },
-    de: {
-      title: "Reise erstellen",
-      description: "Erstelle deine Reiseroute mit flexiblen Stopps, Routen und Planung auf der Timeline.",
-      pill: "REISEPLANER",
-    },
-    fr: {
-      title: "Créer un voyage",
-      description: "Créez votre itinéraire avec des étapes flexibles, des routes et une planification sur la timeline.",
-      pill: "PLANIFICATEUR DE VOYAGE",
-    },
-    it: {
-      title: "Crea viaggio",
-      description: "Crea il tuo itinerario con tappe flessibili, percorsi e pianificazione su timeline.",
-      pill: "PIANIFICATORE VIAGGI",
-    },
-    ru: {
-      title: "Создать поездку",
-      description: "Соберите маршрут с гибкими остановками, продуманными путями и планированием по таймлайну.",
-      pill: "ПЛАНИРОВЩИК ПУТЕШЕСТВИЙ",
-    },
-    pt: {
-      title: "Criar viagem",
-      description: "Crie o seu itinerário com paragens flexíveis, rotas e planeamento em linha do tempo.",
-      pill: "PLANEADOR DE VIAGENS",
-    },
-    pl: {
-      title: "Utwórz podróż",
-      description: "Zbuduj plan podróży z elastycznymi przystankami, trasami i planowaniem na osi czasu.",
-      pill: "PLANER PODRÓŻY",
-    },
-  },
-  "/features": {
-    es: { title: "Funciones", description: "Descubre todo lo que {{appName}} ofrece para planificar y compartir mejores viajes." },
-    de: { title: "Funktionen", description: "Entdecke alle Funktionen von {{appName}} für bessere Reiseplanung." },
-    fr: { title: "Fonctionnalités", description: "Découvrez toutes les fonctionnalités de {{appName}} pour mieux planifier vos voyages." },
-    it: { title: "Funzionalità", description: "Scopri tutte le funzionalità di {{appName}} per pianificare viaggi migliori." },
-    ru: { title: "Возможности", description: "Узнайте, как {{appName}} помогает планировать поездки удобнее и быстрее." },
-    pt: { title: "Funcionalidades", description: "Descubra tudo o que o {{appName}} oferece para planear e partilhar melhores viagens." },
-    pl: { title: "Funkcje", description: "Sprawdź wszystko, co {{appName}} oferuje do lepszego planowania i udostępniania podróży." },
-  },
-  "/updates": {
-    es: { title: "Novedades del producto", description: "Sigue las últimas mejoras y funcionalidades lanzadas en {{appName}}." },
-    de: { title: "Neuigkeiten", description: "Alle neuen Verbesserungen und veröffentlichten Funktionen in {{appName}}." },
-    fr: { title: "Nouveautés", description: "Les dernières améliorations et fonctionnalités publiées dans {{appName}}." },
-    it: { title: "Novità", description: "Tutti gli ultimi miglioramenti e le funzionalità rilasciate in {{appName}}." },
-    ru: { title: "Новости и обновления", description: "Последние улучшения и новые функции {{appName}}." },
-    pt: { title: "Novidades do produto", description: "Acompanhe as melhorias mais recentes e as funcionalidades lançadas no {{appName}}." },
-    pl: { title: "Nowości produktu", description: "Sprawdź najnowsze usprawnienia i funkcje wdrożone w {{appName}}." },
-  },
-  "/blog": {
-    es: { title: "Blog", description: "Guías y consejos prácticos para planificar mejores viajes con {{appName}}." },
-    de: { title: "Blog", description: "Guides und Tipps für smartere Reiseplanung mit {{appName}}." },
-    fr: { title: "Blog", description: "Guides et conseils pratiques pour mieux planifier vos voyages avec {{appName}}." },
-    it: { title: "Blog", description: "Guide e consigli pratici per pianificare meglio i viaggi con {{appName}}." },
-    ru: { title: "Блог", description: "Гайды и советы по планированию поездок с {{appName}}." },
-    pt: { title: "Blog", description: "Guias e dicas práticas para planear viagens melhores com o {{appName}}." },
-    pl: { title: "Blog", description: "Poradniki i praktyczne wskazówki, które pomagają lepiej planować podróże z {{appName}}." },
-  },
-  "/pricing": {
-    es: { title: "Precios", description: "Empieza gratis y mejora cuando lo necesites. Transparente y sin costes ocultos." },
-    de: { title: "Preise", description: "Starte kostenlos und upgrade bei Bedarf. Transparent und ohne versteckte Kosten." },
-    fr: { title: "Tarifs", description: "Commencez gratuitement et passez a une offre superieure si besoin. Sans frais caches." },
-    it: { title: "Prezzi", description: "Inizia gratis e passa a un piano superiore quando serve. Nessun costo nascosto." },
-    ru: { title: "Тарифы", description: "Начните бесплатно и переходите на расширенный план при необходимости. Без скрытых платежей." },
-    pt: { title: "Preços", description: "Comece grátis e faça upgrade quando precisar. Transparente e sem custos escondidos." },
-    pl: { title: "Cennik", description: "Zacznij za darmo i przejdź na wyższy plan, gdy będzie potrzeba. Bez ukrytych opłat." },
-  },
-  "/faq": {
-    es: { title: "Preguntas frecuentes", description: "Respuestas a preguntas comunes sobre {{appName}}, precios y viajes compartidos." },
-    de: { title: "FAQ", description: "Antworten auf häufige Fragen zu {{appName}}, Preisen und Teilen von Reisen." },
-    fr: { title: "FAQ", description: "Réponses aux questions fréquentes sur {{appName}}, les tarifs et le partage de voyages." },
-    it: { title: "FAQ", description: "Risposte alle domande frequenti su {{appName}}, prezzi e condivisione dei viaggi." },
-    ru: { title: "FAQ", description: "Ответы на частые вопросы о {{appName}}, тарифах и совместном доступе к поездкам." },
-    pt: { title: "Perguntas frequentes", description: "Respostas às perguntas mais comuns sobre {{appName}}, preços e partilha de viagens." },
-    pl: { title: "Najczęściej zadawane pytania", description: "Odpowiedzi na najczęstsze pytania o {{appName}}, cennik i udostępnianie podróży." },
-  },
-  "/share-unavailable": {
-    es: { title: "Viaje compartido no disponible", description: "Este enlace de viaje compartido ya no está disponible o ha caducado." },
-    de: { title: "Geteilte Reise nicht verfügbar", description: "Dieser geteilte Reiselink ist nicht mehr verfügbar oder abgelaufen." },
-    fr: { title: "Voyage partagé indisponible", description: "Ce lien de voyage partagé n'est plus disponible ou a expiré." },
-    it: { title: "Viaggio condiviso non disponibile", description: "Questo link condiviso non è più disponibile o è scaduto." },
-    ru: { title: "Общий маршрут недоступен", description: "Ссылка на общий маршрут недоступна или истекла." },
-    pt: { title: "Viagem partilhada indisponível", description: "Este link de viagem partilhada não está disponível ou expirou." },
-    pl: { title: "Udostępniona podróż jest niedostępna", description: "Ten link do udostępnionej podróży jest niedostępny lub wygasł." },
-  },
-  "/login": {
-    es: { title: "Iniciar sesión", description: "Inicia sesión y sigue planificando tu próximo viaje en {{appName}}." },
-    de: { title: "Anmelden", description: "Melde dich an und plane deine nächste Reise in {{appName}} weiter." },
-    fr: { title: "Connexion", description: "Connectez-vous pour reprendre la planification de votre prochain voyage dans {{appName}}." },
-    it: { title: "Accedi", description: "Accedi e continua a pianificare il tuo prossimo viaggio in {{appName}}." },
-    ru: { title: "Вход", description: "Войдите, чтобы продолжить планирование следующей поездки в {{appName}}." },
-    pt: { title: "Iniciar sessão", description: "Inicie sessão e continue a planear a sua próxima viagem no {{appName}}." },
-    pl: { title: "Logowanie", description: "Zaloguj się i kontynuuj planowanie kolejnej podróży w {{appName}}." },
-  },
-  "/contact": {
-    es: { title: "Contacto", description: "Reporta errores de traducción o comparte feedback de localización sobre {{appName}}." },
-    de: { title: "Kontakt", description: "Melde Übersetzungsfehler oder Lokalisierungsfeedback zu {{appName}}." },
-    fr: { title: "Contact", description: "Signalez des erreurs de traduction ou vos retours de localisation pour {{appName}}." },
-    it: { title: "Contatti", description: "Segnala errori di traduzione o feedback sulla localizzazione di {{appName}}." },
-    ru: { title: "Контакты", description: "Сообщите об ошибках перевода или оставьте отзыв о локализации {{appName}}." },
-    pt: { title: "Contacto", description: "Reporte erros de tradução ou partilhe feedback de localização sobre o {{appName}}." },
-    pl: { title: "Kontakt", description: "Zgłoś błędy tłumaczenia lub prześlij opinię o lokalizacji {{appName}}." },
-  },
-  "/imprint": {
-    es: { title: "Aviso legal", description: "Información legal y corporativa sobre {{appName}}." },
-    de: { title: "Impressum", description: "Rechtliche Informationen und Unternehmensangaben zu {{appName}}." },
-    fr: { title: "Mentions légales", description: "Informations légales et sociétaires concernant {{appName}}." },
-    it: { title: "Note legali", description: "Informazioni legali e societarie su {{appName}}." },
-    ru: { title: "Реквизиты", description: "Юридическая и корпоративная информация о {{appName}}." },
-    pt: { title: "Aviso legal", description: "Informações legais e empresariais sobre o {{appName}}." },
-    pl: { title: "Informacje prawne", description: "Informacje prawne i firmowe dotyczące {{appName}}." },
-  },
-  "/privacy": {
-    es: { title: "Política de privacidad", description: "Descubre cómo {{appName}} trata los datos personales y protege la privacidad." },
-    de: { title: "Datenschutzerklärung", description: "Erfahre, wie {{appName}} personenbezogene Daten und Privatsphäre schützt." },
-    fr: { title: "Politique de confidentialité", description: "Découvrez comment {{appName}} traite les données personnelles et protège la vie privée." },
-    it: { title: "Informativa sulla privacy", description: "Scopri come {{appName}} gestisce i dati personali e protegge la privacy." },
-    ru: { title: "Политика конфиденциальности", description: "Узнайте, как {{appName}} обрабатывает персональные данные и защищает конфиденциальность." },
-    pt: { title: "Política de privacidade", description: "Saiba como o {{appName}} trata dados pessoais e protege a privacidade." },
-    pl: { title: "Polityka prywatności", description: "Sprawdź, jak {{appName}} przetwarza dane osobowe i chroni prywatność." },
-  },
-  "/terms": {
-    es: { title: "Términos del servicio", description: "Consulta los términos que regulan el uso de {{appName}}." },
-    de: { title: "Nutzungsbedingungen", description: "Lies die Bedingungen für die Nutzung von {{appName}}." },
-    fr: { title: "Conditions d'utilisation", description: "Consultez les conditions qui régissent l'utilisation de {{appName}}." },
-    it: { title: "Termini di servizio", description: "Leggi i termini che regolano l'uso di {{appName}}." },
-    ru: { title: "Условия использования", description: "Ознакомьтесь с условиями использования {{appName}}." },
-    pt: { title: "Termos de serviço", description: "Leia os termos que regem a utilização do {{appName}}." },
-    pl: { title: "Warunki korzystania z usługi", description: "Przeczytaj zasady korzystania z {{appName}}." },
-  },
-  "/cookies": {
-    es: { title: "Política de cookies", description: "Descubre cómo {{appName}} usa cookies y tecnologías similares." },
-    de: { title: "Cookie-Richtlinie", description: "Erfahre, wie {{appName}} Cookies und ähnliche Technologien verwendet." },
-    fr: { title: "Politique de cookies", description: "Comprenez comment {{appName}} utilise les cookies et technologies similaires." },
-    it: { title: "Informativa cookie", description: "Scopri come {{appName}} utilizza cookie e tecnologie simili." },
-    ru: { title: "Политика cookie", description: "Узнайте, как {{appName}} использует cookie и похожие технологии." },
-    pt: { title: "Política de cookies", description: "Saiba como o {{appName}} usa cookies e tecnologias semelhantes." },
-    pl: { title: "Polityka cookies", description: "Dowiedz się, jak {{appName}} używa plików cookie i podobnych technologii." },
-  },
-  "/inspirations": {
-    es: {
-      title: "¿A dónde viajarás después?",
-      description: "Explora ideas de viaje por temática, mes, país o festivales próximos.",
-      pill: "INSPIRACIÓN DE VIAJES",
-    },
-    de: {
-      title: "Wohin geht es als Nächstes?",
-      description: "Entdecke kuratierte Reiseideen nach Thema, Monat, Land oder kommenden Festivals.",
-      pill: "REISEINSPIRATIONEN",
-    },
-    fr: {
-      title: "Où partirez-vous ensuite ?",
-      description: "Explorez des idées de voyages par thème, mois, pays ou festivals à venir.",
-      pill: "INSPIRATIONS",
-    },
-    it: {
-      title: "Dove andrai la prossima volta?",
-      description: "Esplora idee di viaggio per tema, mese, paese o festival in arrivo.",
-      pill: "ISPIRAZIONI",
-    },
-    ru: {
-      title: "Куда поедете в следующий раз?",
-      description: "Смотрите идеи маршрутов по темам, месяцам, странам и ближайшим фестивалям.",
-      pill: "ИДЕИ ПУТЕШЕСТВИЙ",
-    },
-    pt: {
-      title: "Para onde vai a seguir?",
-      description: "Explore ideias de viagem por tema, mês, país ou festivais que estão a chegar.",
-      pill: "INSPIRAÇÃO DE VIAGENS",
-    },
-    pl: {
-      title: "Dokąd wybierzesz się następnym razem?",
-      description: "Przeglądaj pomysły na podróże według motywu, miesiąca, kraju lub nadchodzących festiwali.",
-      pill: "INSPIRACJE PODRÓŻNICZE",
-    },
-  },
-  "/inspirations/themes": {
-    es: { title: "Viajar por temática" },
-    de: { title: "Nach Reisethema planen" },
-    fr: { title: "Voyager par thème" },
-    it: { title: "Viaggia per tema" },
-    ru: { title: "Путешествия по темам" },
-    pt: { title: "Viajar por tema" },
-    pl: { title: "Podróże według motywu" },
-  },
-  "/inspirations/best-time-to-travel": {
-    es: { title: "Cuándo ir y a dónde" },
-    de: { title: "Wann du wohin reisen solltest" },
-    fr: { title: "Quand partir et où" },
-    it: { title: "Quando andare e dove" },
-    ru: { title: "Когда и куда ехать" },
-    pt: { title: "Quando ir e para onde" },
-    pl: { title: "Kiedy i dokąd jechać" },
-  },
-  "/inspirations/countries": {
-    es: { title: "Explorar destinos por país" },
-    de: { title: "Reiseziele nach Ländern entdecken" },
-    fr: { title: "Explorer les destinations par pays" },
-    it: { title: "Esplora destinazioni per paese" },
-    ru: { title: "Направления по странам" },
-    pt: { title: "Explorar destinos por país" },
-    pl: { title: "Odkrywaj kierunki według kraju" },
-  },
-  "/inspirations/events-and-festivals": {
-    es: { title: "Planear alrededor de un festival" },
-    de: { title: "Reise rund um Festivals planen" },
-    fr: { title: "Planifier autour d'un festival" },
-    it: { title: "Pianifica intorno a un festival" },
-    ru: { title: "Планируйте поездку вокруг фестиваля" },
-    pt: { title: "Planear à volta de um festival" },
-    pl: { title: "Zaplanuj podróż wokół festiwalu" },
-  },
-  "/inspirations/weekend-getaways": {
-    es: { title: "Escapadas rápidas para agendas ocupadas" },
-    de: { title: "Kurze Auszeiten für Vielbeschaftigte" },
-    fr: { title: "Escapades rapides pour voyageurs occupes" },
-    it: { title: "Fughe rapide per chi ha poco tempo" },
-    ru: { title: "Быстрые поездки для занятых" },
-    pt: { title: "Escapadinhas rápidas para quem tem pouco tempo" },
-    pl: { title: "Szybkie wypady dla zapracowanych" },
-  },
-};
-
-interface BlogMeta {
-  title: string;
-  description: string;
-  ogTitle?: string;
-  ogDescription?: string;
-}
-
-const BLOG_META: Record<string, BlogMeta> = {
-  "best-time-visit-japan": {
-    title: "The Best Time to Visit Japan — A Month-by-Month Guide",
-    description: "Japan transforms with every season. From cherry blossoms to powder snow, here's when to go.",
-    ogTitle: "Best Time to Visit Japan — Month by Month",
-    ogDescription: "Sakura, festivals, autumn foliage, and powder snow — find your perfect month to visit Japan.",
-  },
-  "budget-travel-europe": {
-    title: "Budget Travel Hacks for Europe",
-    description: "Smart timing, local habits, and a few practical tricks can cut your Europe costs in half.",
-    ogDescription: "Spend less, see more. Practical tips on timing, transport, and staying smart across Europe.",
-  },
-  "festival-travel-guide": {
-    title: "How to Plan a Trip Around a Festival",
-    description: "Festival-centered trips are some of the most memorable journeys. Here's how to plan one.",
-    ogDescription: "Build your next trip around a great event — from choosing the festival to planning the days around it.",
-  },
-  "how-to-plan-multi-city-trip": {
-    title: "How to Plan the Perfect Multi-City Trip",
-    description: "Practical advice on route planning, timing, and logistics for multi-destination travel.",
-    ogDescription: "Plan a smooth multi-stop itinerary with smart routing, realistic timing, and less stress.",
-  },
-  "weekend-getaway-tips": {
-    title: "Weekend Getaway Planning: From Idea to Boarding Pass",
-    description: "How to squeeze the most out of a 2–3 day trip without the stress.",
-    ogTitle: "Weekend Getaway Planning Made Simple",
-    ogDescription: "Make every hour count on a 2–3 day escape. Quick to plan, easy to enjoy.",
-  },
-};
-
-const BLOG_LOCALES_BY_SLUG: Record<string, SupportedLocale[]> = {
-  "best-time-visit-japan": ["en"],
-  "budget-travel-europe": ["en"],
-  "festival-travel-guide": ["en"],
-  "how-to-plan-multi-city-trip": ["en"],
-  "weekend-getaway-tips": ["en"],
-};
-
-const isSupportedLocale = (value?: string | null): value is SupportedLocale => {
-  if (!value) return false;
-  return SUPPORTED_LOCALES.includes(value as SupportedLocale);
-};
-
-const normalizePath = (pathname: string): string => {
-  const raw = pathname || "/";
-  const withLeadingSlash = raw.startsWith("/") ? raw : `/${raw}`;
-  const trimmed = withLeadingSlash.length > 1 && withLeadingSlash.endsWith("/")
-    ? withLeadingSlash.slice(0, -1)
-    : withLeadingSlash;
-  const segments = trimmed.split("/").filter(Boolean);
-
-  return trimmed;
-};
-
-const matchesPrefix = (pathname: string, prefix: string): boolean => {
-  return pathname === prefix || pathname.startsWith(`${prefix}/`);
-};
-
-const isToolBasePath = (pathname: string): boolean => {
-  return TOOL_PATH_PREFIXES.some((prefix) => matchesPrefix(pathname, prefix));
-};
-
-const shouldUseStrictToolHtmlCache = (pathname: string): boolean => {
-  return STRICT_TOOL_HTML_PREFIXES.some((prefix) => matchesPrefix(pathname, prefix));
-};
-
-const isLocalizedMarketingBasePath = (pathname: string): boolean => {
-  if (isToolBasePath(pathname)) return false;
-  return MARKETING_PATH_PATTERNS.some((pattern) => pattern.test(pathname));
-};
-
-const buildLocalizedPath = (basePath: string, locale: SupportedLocale): string => {
-  if (locale === DEFAULT_LOCALE) return basePath;
-  if (basePath === "/") return `/${locale}`;
-  return `/${locale}${basePath}`;
-};
-
-const pathToTitle = (pathname: string): string => {
-  if (pathname === "/") return SITE_NAME;
-  const leaf = pathname.split("/").filter(Boolean).slice(-1)[0] || "Page";
-  const words = leaf
-    .split(/[-_]+/)
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
-  return words.length > 0 ? words.join(" ") : "Page";
-};
-
-const finalizePageDefinition = (page: PageDefinition): PageDefinition => ({
-  ...page,
-  title: applyAppNameTemplate(page.title),
-  description: applyAppNameTemplate(page.description),
-  ogTitle: page.ogTitle ? applyAppNameTemplate(page.ogTitle) : undefined,
-  ogDescription: page.ogDescription ? applyAppNameTemplate(page.ogDescription) : undefined,
-  pill: page.pill ? applyAppNameTemplate(page.pill) : undefined,
-});
-
-const withLocaleOverrides = (
-  basePath: string,
-  locale: SupportedLocale,
-  page: PageDefinition,
-): PageDefinition => {
-  const localized = LOCALIZED_PAGE_META[basePath]?.[locale];
-  if (!localized) return finalizePageDefinition(page);
-  return finalizePageDefinition({
-    ...page,
-    ...localized,
-  });
-};
-
-const getCountryRouteMeta = (country: string, locale: SupportedLocale): PageDefinition => {
-  switch (locale) {
-    case "es":
-      return finalizePageDefinition({
-        title: `Viajar a ${country}`,
-        description: `Todo lo que necesitas para planificar tu viaje a ${country}: mejores meses, itinerarios populares y consejos útiles.`,
-        pill: "INSPIRACIÓN DE VIAJES",
-      });
-    case "de":
-      return finalizePageDefinition({
-        title: `Reise nach ${country}`,
-        description: `Plane deine Reise nach ${country} - beste Reisezeit, beliebte Routen und praktische Tipps.`,
-        pill: "REISEINSPIRATIONEN",
-      });
-    case "fr":
-      return finalizePageDefinition({
-        title: `Voyager en ${country}`,
-        description: `Tout pour planifier votre voyage en ${country} : meilleures periodes, itinéraires populaires et conseils utiles.`,
-        pill: "INSPIRATIONS",
-      });
-    case "it":
-      return finalizePageDefinition({
-        title: `Viaggia in ${country}`,
-        description: `Tutto ciò che serve per pianificare un viaggio in ${country}: periodi migliori, itinerari popolari e consigli utili.`,
-        pill: "ISPIRAZIONI",
-      });
-    case "ru":
-      return finalizePageDefinition({
-        title: `Путешествие в ${country}`,
-        description: `Все для планирования поездки в ${country}: лучшие месяцы, популярные маршруты и полезные советы.`,
-        pill: "ИДЕИ ПУТЕШЕСТВИЙ",
-      });
-    case "pt":
-      return finalizePageDefinition({
-        title: `Viajar para ${country}`,
-        description: `Tudo o que precisa para planear a sua viagem a ${country}: melhores meses, roteiros populares e dicas úteis.`,
-        pill: "INSPIRAÇÃO DE VIAGENS",
-      });
-    case "pl":
-      return finalizePageDefinition({
-        title: `Podróż do ${country}`,
-        description: `Wszystko, czego potrzebujesz, aby zaplanować podróż do ${country}: najlepsze miesiące, popularne trasy i praktyczne wskazówki.`,
-        pill: "INSPIRACJE PODRÓŻNICZE",
-      });
-    default:
-      return finalizePageDefinition({
-        title: `Travel to ${country}`,
-        description: `Plan your trip to ${country} - best months, itineraries, and tips.`,
-        pill: "TRIP INSPIRATIONS",
-      });
-  }
-};
-
-const getPageDefinition = (basePath: string, locale: SupportedLocale): PageDefinition => {
-  if (PAGE_META[basePath]) return withLocaleOverrides(basePath, locale, PAGE_META[basePath]);
-
-  if (basePath.startsWith("/admin")) {
-    return finalizePageDefinition({
-      title: "Admin Dashboard",
-      description: "Internal {{appName}} admin workspace.",
-      robots: "noindex,nofollow,max-image-preview:large",
-    });
-  }
-
-  const blogMatch = basePath.match(/^\/blog\/([^/]+)$/);
-  if (blogMatch) {
-    const slug = decodeURIComponent(blogMatch[1]);
-    const blog = BLOG_META[slug];
-    const media = getBlogImageMedia(slug, blog ? blog.title : pathToTitle(basePath));
-    return finalizePageDefinition({
-      title: blog ? blog.title : pathToTitle(basePath),
-      description: blog ? blog.description : "Read this article on the {{appName}} blog.",
-      ogTitle: blog?.ogTitle,
-      ogDescription: blog?.ogDescription,
-      pill: "BLOG",
-      blogOgImagePath: media.ogVertical.source,
-      blogAccentTint: DEFAULT_BLOG_OG_TINT,
-      blogTintIntensity: 60,
-    });
-  }
-
-  const countryMatch = basePath.match(/^\/inspirations\/country\/([^/]+)$/);
-  if (countryMatch) {
-    const country = decodeURIComponent(countryMatch[1])
-      .split(/[-_]+/)
-      .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
-      .join(" ");
-    return getCountryRouteMeta(country, locale);
-  }
-
-  if (basePath.startsWith("/inspirations")) {
-    return finalizePageDefinition({
-      title: pathToTitle(basePath),
-      description: "Explore curated trip ideas and travel inspiration on {{appName}}.",
-      pill: "TRIP INSPIRATIONS",
-    });
-  }
-
-  return finalizePageDefinition({
-    title: pathToTitle(basePath),
-    description: DEFAULT_DESCRIPTION,
-  });
-};
-
-const stripSeoTags = (html: string): string => {
-  const patterns = [
-    /<title>[\s\S]*?<\/title>/gi,
-    /<meta[^>]+name=["']description["'][^>]*>/gi,
-    /<meta[^>]+name=["']robots["'][^>]*>/gi,
-    /<meta[^>]+property=["']og:[^"']+["'][^>]*>/gi,
-    /<meta[^>]+name=["']twitter:[^"']+["'][^>]*>/gi,
-    /<meta[^>]+http-equiv=["']content-language["'][^>]*>/gi,
-    /<link[^>]+rel=["']canonical["'][^>]*>/gi,
-    /<link[^>]+rel=["']alternate["'][^>]+hreflang=["'][^"']+["'][^>]*>/gi,
-  ];
-  return patterns.reduce((acc, regex) => acc.replace(regex, ""), html);
-};
-
-const setHtmlLangAttributes = (html: string, lang: string, dir: "ltr" | "rtl"): string => {
-  const safeLang = escapeHtml(lang);
-  const safeDir = escapeHtml(dir);
-
-  return html.replace(/<html\b([^>]*)>/i, (_full, attrs: string) => {
-    let nextAttrs = attrs;
-
-    if (/\slang\s*=\s*["'][^"']*["']/i.test(nextAttrs)) {
-      nextAttrs = nextAttrs.replace(/(\slang\s*=\s*["'])[^"']*(["'])/i, `$1${safeLang}$2`);
-    } else {
-      nextAttrs += ` lang="${safeLang}"`;
-    }
-
-    if (/\sdir\s*=\s*["'][^"']*["']/i.test(nextAttrs)) {
-      nextAttrs = nextAttrs.replace(/(\sdir\s*=\s*["'])[^"']*(["'])/i, `$1${safeDir}$2`);
-    } else {
-      nextAttrs += ` dir="${safeDir}"`;
-    }
-
-    return `<html${nextAttrs}>`;
-  });
-};
-
-const buildMetaTags = (meta: Metadata): string => {
-  const title = escapeHtml(meta.pageTitle);
-  const description = escapeHtml(meta.description);
-  const ogTitle = escapeHtml(meta.ogTitle);
-  const ogDescription = escapeHtml(meta.ogDescription);
-  const canonicalUrl = escapeHtml(meta.canonicalUrl);
-  const ogImageUrl = escapeHtml(meta.ogImageUrl);
-  const ogLogoUrl = escapeHtml(meta.ogLogoUrl);
-  const robots = escapeHtml(meta.robots);
-  const contentLanguage = escapeHtml(meta.htmlLang);
-
-  const alternateTags = meta.alternateLinks.map((link) => {
-    const hreflang = escapeHtml(link.hreflang);
-    const href = escapeHtml(link.href);
-    return `<link rel="alternate" hreflang="${hreflang}" href="${href}" />`;
+const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    setTimeout(() => {
+      reject(new Error("site-og-manifest-timeout"));
+    }, timeoutMs);
   });
 
-  return [
-    `<title>${title}</title>`,
-    `<meta name="description" content="${description}" />`,
-    `<link rel="canonical" href="${canonicalUrl}" />`,
-    ...alternateTags,
-    `<meta http-equiv="content-language" content="${contentLanguage}" />`,
-    `<meta name="robots" content="${robots}" />`,
-    `<meta property="og:type" content="website" />`,
-    `<meta property="og:site_name" content="${SITE_NAME}" />`,
-    `<meta property="og:title" content="${ogTitle}" />`,
-    `<meta property="og:description" content="${ogDescription}" />`,
-    `<meta property="og:url" content="${canonicalUrl}" />`,
-    `<meta property="og:image" content="${ogImageUrl}" />`,
-    `<meta property="og:image:width" content="1200" />`,
-    `<meta property="og:image:height" content="630" />`,
-    `<meta property="og:image:alt" content="${ogTitle}" />`,
-    `<meta property="og:logo" content="${ogLogoUrl}" />`,
-    `<meta name="twitter:card" content="summary_large_image" />`,
-    `<meta name="twitter:title" content="${ogTitle}" />`,
-    `<meta name="twitter:description" content="${ogDescription}" />`,
-    `<meta name="twitter:image" content="${ogImageUrl}" />`,
-  ].join("\n");
+  return Promise.race([promise, timeoutPromise]);
 };
 
-const collapseBlankLines = (html: string): string => html.replace(/(\n\s*){3,}/g, "\n\n");
-
-const injectMetaTags = (html: string, meta: Metadata): string => {
-  if (!/<head[^>]*>/i.test(html) || !/<\/head>/i.test(html)) {
-    return html;
+const loadStaticManifest = async (origin: string): Promise<SiteOgStaticManifest | null> => {
+  const now = Date.now();
+  if (manifestCache && now - manifestCache.fetchedAt < SITE_OG_STATIC_MANIFEST_TTL_MS) {
+    return manifestCache.manifest;
   }
-  const cleaned = collapseBlankLines(stripSeoTags(html));
-  const htmlTagged = setHtmlLangAttributes(cleaned, meta.htmlLang, meta.htmlDir);
-  return htmlTagged.replace(/(<head[^>]*>)/i, `$1\n${buildMetaTags(meta)}`);
-};
 
-const buildCanonicalSearch = (url: URL): string => {
-  const params = new URLSearchParams(url.search);
-  const dropKeys = new Set([
-    "prefill",
-    "debug",
-    "utm_source",
-    "utm_medium",
-    "utm_campaign",
-    "utm_term",
-    "utm_content",
-    "gclid",
-    "fbclid",
-  ]);
+  const manifestUrl = new URL(SITE_OG_STATIC_MANIFEST_PATH, origin).toString();
 
-  for (const key of Array.from(params.keys())) {
-    if (dropKeys.has(key) || key.startsWith("utm_")) {
-      params.delete(key);
+  try {
+    const response = await withTimeout(fetch(manifestUrl, {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+      },
+    }), SITE_OG_STATIC_MANIFEST_TIMEOUT_MS);
+
+    if (!response.ok) {
+      manifestCache = { fetchedAt: now, manifest: null };
+      return null;
     }
-  }
 
-  const qs = params.toString();
-  return qs ? `?${qs}` : "";
-};
-
-const parsePathInfo = (pathname: string): {
-  normalizedPath: string;
-  localeFromPath: SupportedLocale | null;
-  basePath: string;
-  isLocalizedMarketing: boolean;
-} => {
-  const normalizedPath = normalizePath(pathname);
-  const segments = normalizedPath.split("/").filter(Boolean);
-
-  const maybeLocale = segments[0] || null;
-  const localeFromPath = isSupportedLocale(maybeLocale) ? maybeLocale : null;
-  const basePath = localeFromPath
-    ? normalizePath(`/${segments.slice(1).join("/") || ""}`)
-    : normalizedPath;
-
-  return {
-    normalizedPath,
-    localeFromPath,
-    basePath,
-    isLocalizedMarketing: isLocalizedMarketingBasePath(basePath),
-  };
-};
-
-const getBlogLocales = (basePath: string): SupportedLocale[] | null => {
-  const match = basePath.match(/^\/blog\/([^/]+)$/);
-  if (!match) return null;
-  const slug = decodeURIComponent(match[1]);
-  return BLOG_LOCALES_BY_SLUG[slug] ?? [DEFAULT_LOCALE];
-};
-
-const buildAlternateLinks = (origin: string, basePath: string, locales: SupportedLocale[]): AlternateLink[] => {
-  const links: AlternateLink[] = locales.map((locale) => ({
-    hreflang: locale,
-    href: new URL(buildLocalizedPath(basePath, locale), origin).toString(),
-  }));
-
-  const xDefaultLocale = locales.includes(DEFAULT_LOCALE)
-    ? DEFAULT_LOCALE
-    : locales[0] ?? DEFAULT_LOCALE;
-
-  links.push({
-    hreflang: "x-default",
-    href: new URL(buildLocalizedPath(basePath, xDefaultLocale), origin).toString(),
-  });
-
-  return links;
-};
-
-const buildMetadata = (url: URL): Metadata => {
-  const pathInfo = parsePathInfo(url.pathname);
-  const canonicalSearch = buildCanonicalSearch(url);
-  const blogLocales = getBlogLocales(pathInfo.basePath);
-
-  let effectiveLocale: SupportedLocale = DEFAULT_LOCALE;
-  let basePathForMeta = pathInfo.basePath;
-  let canonicalPath = pathInfo.normalizedPath;
-  let alternateLinks: AlternateLink[] = [];
-
-  if (pathInfo.isLocalizedMarketing) {
-    effectiveLocale = pathInfo.localeFromPath ?? DEFAULT_LOCALE;
-
-    const missingLocalizedBlogVariant = Boolean(
-      blogLocales && !blogLocales.includes(effectiveLocale),
-    );
-
-    if (missingLocalizedBlogVariant) {
-      // Keep locale-specific UI on the current path, but canonicalize
-      // to the source article locale to avoid duplicate-indexing fallback URLs.
-      canonicalPath = buildLocalizedPath(pathInfo.basePath, DEFAULT_LOCALE);
-      alternateLinks = buildAlternateLinks(url.origin, pathInfo.basePath, blogLocales ?? [DEFAULT_LOCALE]);
-    } else {
-      canonicalPath = buildLocalizedPath(pathInfo.basePath, effectiveLocale);
-      alternateLinks = buildAlternateLinks(
-        url.origin,
-        pathInfo.basePath,
-        blogLocales ?? SUPPORTED_LOCALES.slice(),
-      );
+    const parsed = await response.json();
+    if (!isSiteOgStaticManifest(parsed)) {
+      manifestCache = { fetchedAt: now, manifest: null };
+      return null;
     }
-  } else if (pathInfo.localeFromPath && isToolBasePath(pathInfo.basePath)) {
-    if (pathInfo.basePath === "/create-trip") {
-      effectiveLocale = pathInfo.localeFromPath;
-      canonicalPath = buildLocalizedPath(pathInfo.basePath, effectiveLocale);
-      alternateLinks = buildAlternateLinks(url.origin, pathInfo.basePath, SUPPORTED_LOCALES.slice());
-    } else {
-      canonicalPath = pathInfo.basePath;
+
+    manifestCache = { fetchedAt: now, manifest: parsed };
+    return parsed;
+  } catch {
+    manifestCache = { fetchedAt: now, manifest: null };
+    return null;
+  }
+};
+
+const toStaticOgImageUrl = (origin: string, path: string): string | null => {
+  if (!path.startsWith("/images/og/site/generated/")) return null;
+  if (!path.endsWith(".png")) return null;
+  return new URL(path, origin).toString();
+};
+
+const resolveOgImageUrl = async (
+  origin: string,
+  metadata: SiteOgMetadata,
+): Promise<{ ogImageUrl: string; source: "static" | "dynamic" }> => {
+  const manifest = await loadStaticManifest(origin);
+  const manifestEntry = manifest?.entries?.[metadata.routeKey];
+
+  if (manifestEntry) {
+    const staticUrl = toStaticOgImageUrl(origin, manifestEntry.path);
+    if (staticUrl) {
+      return {
+        ogImageUrl: staticUrl,
+        source: "static",
+      };
     }
-  }
-
-  const page = getPageDefinition(basePathForMeta, effectiveLocale);
-  const title = page.title === SITE_NAME ? SITE_NAME : `${page.title} | ${SITE_NAME}`;
-  const canonicalUrl = new URL(canonicalPath + canonicalSearch, url.origin).toString();
-
-  const ogTitleRaw = page.ogTitle || page.title;
-  const ogDescriptionRaw = page.ogDescription || page.description;
-  const ogTitleFull = ogTitleRaw === SITE_NAME ? SITE_NAME : `${ogTitleRaw} | ${SITE_NAME}`;
-
-  const ogImage = new URL("/api/og/site", url.origin);
-  ogImage.searchParams.set("title", ogTitleRaw);
-  ogImage.searchParams.set("description", ogDescriptionRaw);
-  ogImage.searchParams.set("path", canonicalPath + canonicalSearch);
-  if (page.pill) {
-    ogImage.searchParams.set("pill", page.pill);
-  }
-  if (page.blogOgImagePath) {
-    ogImage.searchParams.set("blog_image", page.blogOgImagePath);
-    ogImage.searchParams.set("blog_rev", BLOG_OG_IMAGE_REVISION);
-    ogImage.searchParams.set("blog_tint", page.blogAccentTint || DEFAULT_BLOG_OG_TINT);
-    ogImage.searchParams.set("blog_tint_intensity", String(page.blogTintIntensity ?? 60));
   }
 
   return {
-    pageTitle: title,
-    description: page.description,
-    ogTitle: ogTitleFull,
-    ogDescription: ogDescriptionRaw,
-    canonicalUrl,
-    ogImageUrl: ogImage.toString(),
-    ogLogoUrl: new URL("/favicon.svg", url.origin).toString(),
-    robots: page.robots || "index,follow,max-image-preview:large",
-    alternateLinks,
-    htmlLang: effectiveLocale,
-    htmlDir: "ltr",
+    ogImageUrl: buildDynamicSiteOgImageUrl(origin, metadata.ogImageParams),
+    source: "dynamic",
   };
 };
 
@@ -888,6 +105,7 @@ const fetchSpaHtmlFallback = async (origin: string): Promise<Response | null> =>
         accept: "text/html,application/xhtml+xml",
       },
     });
+
     const contentType = response.headers.get("content-type") || "";
     if (!response.ok || !contentType.includes("text/html")) return null;
     return response;
@@ -906,8 +124,8 @@ export default async (request: Request, context: { next: () => Promise<Response>
     baseResponse = await context.next();
     fallbackResponse = baseResponse.clone();
   } catch {
-    // Availability first: if the routed lookup fails in edge middleware, load
-    // the SPA shell directly so we avoid returning a 502 crash page.
+    // Availability first: if routed lookup fails in middleware, serve the SPA
+    // shell directly so users do not see the edge crash page.
     baseResponse = await fetchSpaHtmlFallback(url.origin);
     if (baseResponse) {
       fallbackResponse = baseResponse.clone();
@@ -929,15 +147,21 @@ export default async (request: Request, context: { next: () => Promise<Response>
   if (!contentType.includes("text/html")) return baseResponse;
 
   try {
-    const metadata = buildMetadata(url);
+    const metadata = buildSiteOgMetadata(url);
+    const { ogImageUrl, source } = await resolveOgImageUrl(url.origin, metadata);
     const html = await baseResponse.text();
-    const rewrittenHtml = injectMetaTags(html, metadata);
+    const rewrittenHtml = injectMetaTags(html, {
+      ...metadata,
+      ogImageUrl,
+    });
+
     const headers = new Headers(baseResponse.headers);
     headers.set("content-type", "text/html; charset=utf-8");
     headers.set(
       "cache-control",
       shouldUseStrictToolHtmlCache(url.pathname) ? TOOL_APP_CACHE_CONTROL : SITE_CACHE_CONTROL,
     );
+    headers.set("x-travelflow-og-source", source);
     if (usedSpaFallback) {
       headers.set("x-travelflow-edge-fallback", "spa-index");
     }

--- a/netlify/edge-lib/site-og-metadata.ts
+++ b/netlify/edge-lib/site-og-metadata.ts
@@ -1,0 +1,1022 @@
+import { escapeHtml } from "./trip-og-data.ts";
+import { BLOG_OG_IMAGE_REVISION, getBlogImageMedia } from "../../data/blogImageMedia.ts";
+import { getExampleTripCardByTemplateId, getLocalizedExampleTripCard } from "../../data/exampleTripCards.ts";
+import { APP_DEFAULT_DESCRIPTION, APP_NAME, applyAppNameTemplate } from "../../config/appGlobals.ts";
+
+export const SITE_NAME = APP_NAME;
+export const DEFAULT_DESCRIPTION = APP_DEFAULT_DESCRIPTION;
+export const SITE_CACHE_CONTROL = "public, max-age=0, s-maxage=900, stale-while-revalidate=86400";
+export const TOOL_APP_CACHE_CONTROL = "public, max-age=0, s-maxage=60, stale-while-revalidate=60, must-revalidate";
+const DEFAULT_BLOG_OG_TINT = "#6366f1";
+export const SUPPORTED_LOCALES = ["en", "es", "de", "fr", "pt", "ru", "it", "pl", "ko"] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+export const DEFAULT_LOCALE: SupportedLocale = "en";
+
+export interface AlternateLink {
+  hreflang: string;
+  href: string;
+}
+
+export interface SiteOgImageParams {
+  title: string;
+  description: string;
+  path: string;
+  pill?: string;
+  blog_image?: string;
+  blog_rev?: string;
+  blog_tint?: string;
+  blog_tint_intensity?: string;
+}
+
+export interface SiteOgMetadata {
+  routeKey: string;
+  canonicalPath: string;
+  canonicalSearch: string;
+  pageTitle: string;
+  description: string;
+  ogTitle: string;
+  ogDescription: string;
+  canonicalUrl: string;
+  ogImageUrl: string;
+  ogImageParams: SiteOgImageParams;
+  ogLogoUrl: string;
+  robots: string;
+  alternateLinks: AlternateLink[];
+  htmlLang: string;
+  htmlDir: "ltr" | "rtl";
+}
+
+interface PageDefinition {
+  title: string;
+  description: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  robots?: string;
+  pill?: string;
+  blogOgImagePath?: string;
+  blogAccentTint?: string;
+  blogTintIntensity?: number;
+}
+
+type LocalizedPageDefinition = Partial<
+  Pick<PageDefinition, "title" | "description" | "ogTitle" | "ogDescription" | "pill">
+>;
+
+const MARKETING_PATH_PATTERNS: RegExp[] = [
+  /^\/$/,
+  /^\/features$/,
+  /^\/inspirations$/,
+  /^\/inspirations\/themes$/,
+  /^\/inspirations\/best-time-to-travel$/,
+  /^\/inspirations\/countries$/,
+  /^\/inspirations\/events-and-festivals$/,
+  /^\/inspirations\/weekend-getaways$/,
+  /^\/inspirations\/country\/[^/]+$/,
+  /^\/updates$/,
+  /^\/blog$/,
+  /^\/blog\/[^/]+$/,
+  /^\/pricing$/,
+  /^\/faq$/,
+  /^\/share-unavailable$/,
+  /^\/login$/,
+  /^\/contact$/,
+  /^\/imprint$/,
+  /^\/privacy$/,
+  /^\/terms$/,
+  /^\/cookies$/,
+];
+
+const TOOL_PATH_PREFIXES = ["/create-trip", "/trip", "/s", "/example", "/admin", "/api"];
+const STRICT_TOOL_HTML_PREFIXES = ["/create-trip", "/admin", "/example"];
+
+const PAGE_META: Record<string, PageDefinition> = {
+  "/": {
+    title: "{{appName}}",
+    description: "Plan smarter trips with timeline + map routing and share them beautifully.",
+    pill: "{{appName}}",
+  },
+  "/create-trip": {
+    title: "Create Trip",
+    description: "Build your itinerary with flexible stops, routes, and timeline planning.",
+    pill: "TRIP PLANNER",
+  },
+  "/features": {
+    title: "Features",
+    description: "See everything {{appName}} offers for planning and sharing better adventures.",
+    pill: "FEATURES",
+  },
+  "/updates": {
+    title: "Product Updates",
+    description: "Catch the latest {{appName}} improvements and recently shipped features.",
+    pill: "PRODUCT UPDATES",
+  },
+  "/blog": {
+    title: "{{appName}} Blog",
+    description: "Guides, trip-planning ideas, and practical workflow tips from the {{appName}} team.",
+    pill: "BLOG",
+  },
+  "/login": {
+    title: "Login",
+    description: "Sign in and continue planning your next trip in {{appName}}.",
+  },
+  "/contact": {
+    title: "Contact",
+    description: "Reach out to report translation issues or localization feedback for {{appName}}.",
+  },
+  "/imprint": {
+    title: "Imprint",
+    description: "Legal notice and provider identification for {{appName}}.",
+  },
+  "/privacy": {
+    title: "Privacy Policy",
+    description: "Learn how {{appName}} handles personal data and privacy protection.",
+  },
+  "/terms": {
+    title: "Terms of Service",
+    description: "Read the terms that govern the use of {{appName}}.",
+  },
+  "/cookies": {
+    title: "Cookie Policy",
+    description: "Understand how {{appName}} uses cookies and similar technologies.",
+  },
+  "/inspirations": {
+    title: "Where Will You Go Next?",
+    description: "Browse curated trip ideas by theme, month, country, or upcoming festivals.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/inspirations/themes": {
+    title: "Travel by Theme",
+    description: "Find curated trip ideas that match your travel style — adventure, food, photography, and more.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/inspirations/best-time-to-travel": {
+    title: "When to Go Where",
+    description: "Month-by-month guide to the best time to visit destinations around the world.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/inspirations/countries": {
+    title: "Explore by Country",
+    description: "Country-specific travel guides with best-month picks, top cities, and local tips.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/inspirations/events-and-festivals": {
+    title: "Plan Around a Festival",
+    description: "Discover upcoming festivals and build your itinerary around the event.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/inspirations/weekend-getaways": {
+    title: "Quick Escapes for Busy Travelers",
+    description: "2–3 day getaway ideas for spontaneous adventurers — pack light and make the most of a long weekend.",
+    pill: "TRIP INSPIRATIONS",
+  },
+  "/pricing": {
+    title: "Simple, Transparent Pricing",
+    description: "Start for free and upgrade when you need more. No hidden fees, cancel anytime.",
+    pill: "PRICING",
+  },
+  "/faq": {
+    title: "Frequently Asked Questions",
+    description: "Answers to common questions about {{appName}}, pricing, and trip sharing.",
+    pill: "FAQ",
+  },
+  "/share-unavailable": {
+    title: "Shared Trip Unavailable",
+    description: "The shared trip link is unavailable or expired.",
+  },
+};
+
+const LOCALIZED_PAGE_META: Record<string, Partial<Record<SupportedLocale, LocalizedPageDefinition>>> = {
+  "/": {
+    es: {
+      description: "Planifica viajes de forma más inteligente con línea de tiempo y mapa, y compártelos fácilmente.",
+    },
+    de: {
+      description: "Plane smartere Reisen mit Timeline und Karte und teile sie einfach.",
+    },
+    fr: {
+      description: "Planifiez des voyages plus malins avec timeline et carte, puis partagez-les facilement.",
+    },
+    it: {
+      description: "Pianifica viaggi migliori con timeline e mappa e condividili facilmente.",
+    },
+    ru: {
+      description: "Планируйте поездки умнее с таймлайном и картой и делитесь ими без лишних шагов.",
+    },
+    pt: {
+      description: "Plane viagens de forma mais inteligente com linha do tempo e mapa, e partilhe tudo com facilidade.",
+    },
+    pl: {
+      description: "Planuj podróże sprytniej dzięki osi czasu i mapie, a potem łatwo je udostępniaj.",
+    },
+  },
+  "/create-trip": {
+    es: {
+      title: "Crear viaje",
+      description: "Crea tu itinerario con paradas flexibles, rutas y planificación por línea de tiempo.",
+      pill: "PLANIFICADOR DE VIAJES",
+    },
+    de: {
+      title: "Reise erstellen",
+      description: "Erstelle deine Reiseroute mit flexiblen Stopps, Routen und Planung auf der Timeline.",
+      pill: "REISEPLANER",
+    },
+    fr: {
+      title: "Créer un voyage",
+      description: "Créez votre itinéraire avec des étapes flexibles, des routes et une planification sur la timeline.",
+      pill: "PLANIFICATEUR DE VOYAGE",
+    },
+    it: {
+      title: "Crea viaggio",
+      description: "Crea il tuo itinerario con tappe flessibili, percorsi e pianificazione su timeline.",
+      pill: "PIANIFICATORE VIAGGI",
+    },
+    ru: {
+      title: "Создать поездку",
+      description: "Соберите маршрут с гибкими остановками, продуманными путями и планированием по таймлайну.",
+      pill: "ПЛАНИРОВЩИК ПУТЕШЕСТВИЙ",
+    },
+    pt: {
+      title: "Criar viagem",
+      description: "Crie o seu itinerário com paragens flexíveis, rotas e planeamento em linha do tempo.",
+      pill: "PLANEADOR DE VIAGENS",
+    },
+    pl: {
+      title: "Utwórz podróż",
+      description: "Zbuduj plan podróży z elastycznymi przystankami, trasami i planowaniem na osi czasu.",
+      pill: "PLANER PODRÓŻY",
+    },
+  },
+  "/features": {
+    es: { title: "Funciones", description: "Descubre todo lo que {{appName}} ofrece para planificar y compartir mejores viajes." },
+    de: { title: "Funktionen", description: "Entdecke alle Funktionen von {{appName}} für bessere Reiseplanung." },
+    fr: { title: "Fonctionnalités", description: "Découvrez toutes les fonctionnalités de {{appName}} pour mieux planifier vos voyages." },
+    it: { title: "Funzionalità", description: "Scopri tutte le funzionalità di {{appName}} per pianificare viaggi migliori." },
+    ru: { title: "Возможности", description: "Узнайте, как {{appName}} помогает планировать поездки удобнее и быстрее." },
+    pt: { title: "Funcionalidades", description: "Descubra tudo o que o {{appName}} oferece para planear e partilhar melhores viagens." },
+    pl: { title: "Funkcje", description: "Sprawdź wszystko, co {{appName}} oferuje do lepszego planowania i udostępniania podróży." },
+  },
+  "/updates": {
+    es: { title: "Novedades del producto", description: "Sigue las últimas mejoras y funcionalidades lanzadas en {{appName}}." },
+    de: { title: "Neuigkeiten", description: "Alle neuen Verbesserungen und veröffentlichten Funktionen in {{appName}}." },
+    fr: { title: "Nouveautés", description: "Les dernières améliorations et fonctionnalités publiées dans {{appName}}." },
+    it: { title: "Novità", description: "Tutti gli ultimi miglioramenti e le funzionalità rilasciate in {{appName}}." },
+    ru: { title: "Новости и обновления", description: "Последние улучшения и новые функции {{appName}}." },
+    pt: { title: "Novidades do produto", description: "Acompanhe as melhorias mais recentes e as funcionalidades lançadas no {{appName}}." },
+    pl: { title: "Nowości produktu", description: "Sprawdź najnowsze usprawnienia i funkcje wdrożone w {{appName}}." },
+  },
+  "/blog": {
+    es: { title: "Blog", description: "Guías y consejos prácticos para planificar mejores viajes con {{appName}}." },
+    de: { title: "Blog", description: "Guides und Tipps für smartere Reiseplanung mit {{appName}}." },
+    fr: { title: "Blog", description: "Guides et conseils pratiques pour mieux planifier vos voyages avec {{appName}}." },
+    it: { title: "Blog", description: "Guide e consigli pratici per pianificare meglio i viaggi con {{appName}}." },
+    ru: { title: "Блог", description: "Гайды и советы по планированию поездок с {{appName}}." },
+    pt: { title: "Blog", description: "Guias e dicas práticas para planear viagens melhores com o {{appName}}." },
+    pl: { title: "Blog", description: "Poradniki i praktyczne wskazówki, które pomagają lepiej planować podróże z {{appName}}." },
+  },
+  "/pricing": {
+    es: { title: "Precios", description: "Empieza gratis y mejora cuando lo necesites. Transparente y sin costes ocultos." },
+    de: { title: "Preise", description: "Starte kostenlos und upgrade bei Bedarf. Transparent und ohne versteckte Kosten." },
+    fr: { title: "Tarifs", description: "Commencez gratuitement et passez a une offre superieure si besoin. Sans frais caches." },
+    it: { title: "Prezzi", description: "Inizia gratis e passa a un piano superiore quando serve. Nessun costo nascosto." },
+    ru: { title: "Тарифы", description: "Начните бесплатно и переходите на расширенный план при необходимости. Без скрытых платежей." },
+    pt: { title: "Preços", description: "Comece grátis e faça upgrade quando precisar. Transparente e sem custos escondidos." },
+    pl: { title: "Cennik", description: "Zacznij za darmo i przejdź na wyższy plan, gdy będzie potrzeba. Bez ukrytych opłat." },
+  },
+  "/faq": {
+    es: { title: "Preguntas frecuentes", description: "Respuestas a preguntas comunes sobre {{appName}}, precios y viajes compartidos." },
+    de: { title: "FAQ", description: "Antworten auf häufige Fragen zu {{appName}}, Preisen und Teilen von Reisen." },
+    fr: { title: "FAQ", description: "Réponses aux questions fréquentes sur {{appName}}, les tarifs et le partage de voyages." },
+    it: { title: "FAQ", description: "Risposte alle domande frequenti su {{appName}}, prezzi e condivisione dei viaggi." },
+    ru: { title: "FAQ", description: "Ответы на частые вопросы о {{appName}}, тарифах и совместном доступе к поездкам." },
+    pt: { title: "Perguntas frequentes", description: "Respostas às perguntas mais comuns sobre {{appName}}, preços e partilha de viagens." },
+    pl: { title: "Najczęściej zadawane pytania", description: "Odpowiedzi na najczęstsze pytania o {{appName}}, cennik i udostępnianie podróży." },
+  },
+  "/share-unavailable": {
+    es: { title: "Viaje compartido no disponible", description: "Este enlace de viaje compartido ya no está disponible o ha caducado." },
+    de: { title: "Geteilte Reise nicht verfügbar", description: "Dieser geteilte Reiselink ist nicht mehr verfügbar oder abgelaufen." },
+    fr: { title: "Voyage partagé indisponible", description: "Ce lien de voyage partagé n'est plus disponible ou a expiré." },
+    it: { title: "Viaggio condiviso non disponibile", description: "Questo link condiviso non è più disponibile o è scaduto." },
+    ru: { title: "Общий маршрут недоступен", description: "Ссылка на общий маршрут недоступна или истекла." },
+    pt: { title: "Viagem partilhada indisponível", description: "Este link de viagem partilhada não está disponível ou expirou." },
+    pl: { title: "Udostępniona podróż jest niedostępna", description: "Ten link do udostępnionej podróży jest niedostępny lub wygasł." },
+  },
+  "/login": {
+    es: { title: "Iniciar sesión", description: "Inicia sesión y sigue planificando tu próximo viaje en {{appName}}." },
+    de: { title: "Anmelden", description: "Melde dich an und plane deine nächste Reise in {{appName}} weiter." },
+    fr: { title: "Connexion", description: "Connectez-vous pour reprendre la planification de votre prochain voyage dans {{appName}}." },
+    it: { title: "Accedi", description: "Accedi e continua a pianificare il tuo prossimo viaggio in {{appName}}." },
+    ru: { title: "Вход", description: "Войдите, чтобы продолжить планирование следующей поездки в {{appName}}." },
+    pt: { title: "Iniciar sessão", description: "Inicie sessão e continue a planear a sua próxima viagem no {{appName}}." },
+    pl: { title: "Logowanie", description: "Zaloguj się i kontynuuj planowanie kolejnej podróży w {{appName}}." },
+  },
+  "/contact": {
+    es: { title: "Contacto", description: "Reporta errores de traducción o comparte feedback de localización sobre {{appName}}." },
+    de: { title: "Kontakt", description: "Melde Übersetzungsfehler oder Lokalisierungsfeedback zu {{appName}}." },
+    fr: { title: "Contact", description: "Signalez des erreurs de traduction ou vos retours de localisation pour {{appName}}." },
+    it: { title: "Contatti", description: "Segnala errori di traduzione o feedback sulla localizzazione di {{appName}}." },
+    ru: { title: "Контакты", description: "Сообщите об ошибках перевода или оставьте отзыв о локализации {{appName}}." },
+    pt: { title: "Contacto", description: "Reporte erros de tradução ou partilhe feedback de localização sobre o {{appName}}." },
+    pl: { title: "Kontakt", description: "Zgłoś błędy tłumaczenia lub prześlij opinię o lokalizacji {{appName}}." },
+  },
+  "/imprint": {
+    es: { title: "Aviso legal", description: "Información legal y corporativa sobre {{appName}}." },
+    de: { title: "Impressum", description: "Rechtliche Informationen und Unternehmensangaben zu {{appName}}." },
+    fr: { title: "Mentions légales", description: "Informations légales et sociétaires concernant {{appName}}." },
+    it: { title: "Note legali", description: "Informazioni legali e societarie su {{appName}}." },
+    ru: { title: "Реквизиты", description: "Юридическая и корпоративная информация о {{appName}}." },
+    pt: { title: "Aviso legal", description: "Informações legais e empresariais sobre o {{appName}}." },
+    pl: { title: "Informacje prawne", description: "Informacje prawne i firmowe dotyczące {{appName}}." },
+  },
+  "/privacy": {
+    es: { title: "Política de privacidad", description: "Descubre cómo {{appName}} trata los datos personales y protege la privacidad." },
+    de: { title: "Datenschutzerklärung", description: "Erfahre, wie {{appName}} personenbezogene Daten und Privatsphäre schützt." },
+    fr: { title: "Politique de confidentialité", description: "Découvrez comment {{appName}} traite les données personnelles et protège la vie privée." },
+    it: { title: "Informativa sulla privacy", description: "Scopri come {{appName}} gestisce i dati personali e protegge la privacy." },
+    ru: { title: "Политика конфиденциальности", description: "Узнайте, как {{appName}} обрабатывает персональные данные и защищает конфиденциальность." },
+    pt: { title: "Política de privacidade", description: "Saiba como o {{appName}} trata dados pessoais e protege a privacidade." },
+    pl: { title: "Polityka prywatności", description: "Sprawdź, jak {{appName}} przetwarza dane osobowe i chroni prywatność." },
+  },
+  "/terms": {
+    es: { title: "Términos del servicio", description: "Consulta los términos que regulan el uso de {{appName}}." },
+    de: { title: "Nutzungsbedingungen", description: "Lies die Bedingungen für die Nutzung von {{appName}}." },
+    fr: { title: "Conditions d'utilisation", description: "Consultez les conditions qui régissent l'utilisation de {{appName}}." },
+    it: { title: "Termini di servizio", description: "Leggi i termini che regolano l'uso di {{appName}}." },
+    ru: { title: "Условия использования", description: "Ознакомьтесь с условиями использования {{appName}}." },
+    pt: { title: "Termos de serviço", description: "Leia os termos que regem a utilização do {{appName}}." },
+    pl: { title: "Warunki korzystania z usługi", description: "Przeczytaj zasady korzystania z {{appName}}." },
+  },
+  "/cookies": {
+    es: { title: "Política de cookies", description: "Descubre cómo {{appName}} usa cookies y tecnologías similares." },
+    de: { title: "Cookie-Richtlinie", description: "Erfahre, wie {{appName}} Cookies und ähnliche Technologien verwendet." },
+    fr: { title: "Politique de cookies", description: "Comprenez comment {{appName}} utilise les cookies et technologies similaires." },
+    it: { title: "Informativa cookie", description: "Scopri come {{appName}} utilizza cookie e tecnologie simili." },
+    ru: { title: "Политика cookie", description: "Узнайте, как {{appName}} использует cookie и похожие технологии." },
+    pt: { title: "Política de cookies", description: "Saiba como o {{appName}} usa cookies e tecnologias semelhantes." },
+    pl: { title: "Polityka cookies", description: "Dowiedz się, jak {{appName}} używa plików cookie i podobnych technologii." },
+  },
+  "/inspirations": {
+    es: {
+      title: "¿A dónde viajarás después?",
+      description: "Explora ideas de viaje por temática, mes, país o festivales próximos.",
+      pill: "INSPIRACIÓN DE VIAJES",
+    },
+    de: {
+      title: "Wohin geht es als Nächstes?",
+      description: "Entdecke kuratierte Reiseideen nach Thema, Monat, Land oder kommenden Festivals.",
+      pill: "REISEINSPIRATIONEN",
+    },
+    fr: {
+      title: "Où partirez-vous ensuite ?",
+      description: "Explorez des idées de voyages par thème, mois, pays ou festivals à venir.",
+      pill: "INSPIRATIONS",
+    },
+    it: {
+      title: "Dove andrai la prossima volta?",
+      description: "Esplora idee di viaggio per tema, mese, paese o festival in arrivo.",
+      pill: "ISPIRAZIONI",
+    },
+    ru: {
+      title: "Куда поедете в следующий раз?",
+      description: "Смотрите идеи маршрутов по темам, месяцам, странам и ближайшим фестивалям.",
+      pill: "ИДЕИ ПУТЕШЕСТВИЙ",
+    },
+    pt: {
+      title: "Para onde vai a seguir?",
+      description: "Explore ideias de viagem por tema, mês, país ou festivais que estão a chegar.",
+      pill: "INSPIRAÇÃO DE VIAGENS",
+    },
+    pl: {
+      title: "Dokąd wybierzesz się następnym razem?",
+      description: "Przeglądaj pomysły na podróże według motywu, miesiąca, kraju lub nadchodzących festiwali.",
+      pill: "INSPIRACJE PODRÓŻNICZE",
+    },
+  },
+  "/inspirations/themes": {
+    es: { title: "Viajar por temática" },
+    de: { title: "Nach Reisethema planen" },
+    fr: { title: "Voyager par thème" },
+    it: { title: "Viaggia per tema" },
+    ru: { title: "Путешествия по темам" },
+    pt: { title: "Viajar por tema" },
+    pl: { title: "Podróże według motywu" },
+  },
+  "/inspirations/best-time-to-travel": {
+    es: { title: "Cuándo ir y a dónde" },
+    de: { title: "Wann du wohin reisen solltest" },
+    fr: { title: "Quand partir et où" },
+    it: { title: "Quando andare e dove" },
+    ru: { title: "Когда и куда ехать" },
+    pt: { title: "Quando ir e para onde" },
+    pl: { title: "Kiedy i dokąd jechać" },
+  },
+  "/inspirations/countries": {
+    es: { title: "Explorar destinos por país" },
+    de: { title: "Reiseziele nach Ländern entdecken" },
+    fr: { title: "Explorer les destinations par pays" },
+    it: { title: "Esplora destinazioni per paese" },
+    ru: { title: "Направления по странам" },
+    pt: { title: "Explorar destinos por país" },
+    pl: { title: "Odkrywaj kierunki według kraju" },
+  },
+  "/inspirations/events-and-festivals": {
+    es: { title: "Planear alrededor de un festival" },
+    de: { title: "Reise rund um Festivals planen" },
+    fr: { title: "Planifier autour d'un festival" },
+    it: { title: "Pianifica intorno a un festival" },
+    ru: { title: "Планируйте поездку вокруг фестиваля" },
+    pt: { title: "Planear à volta de um festival" },
+    pl: { title: "Zaplanuj podróż wokół festiwalu" },
+  },
+  "/inspirations/weekend-getaways": {
+    es: { title: "Escapadas rápidas para agendas ocupadas" },
+    de: { title: "Kurze Auszeiten für Vielbeschaftigte" },
+    fr: { title: "Escapades rapides pour voyageurs occupes" },
+    it: { title: "Fughe rapide per chi ha poco tempo" },
+    ru: { title: "Быстрые поездки для занятых" },
+    pt: { title: "Escapadinhas rápidas para quem tem pouco tempo" },
+    pl: { title: "Szybkie wypady dla zapracowanych" },
+  },
+};
+
+interface BlogMeta {
+  title: string;
+  description: string;
+  ogTitle?: string;
+  ogDescription?: string;
+}
+
+const BLOG_META: Record<string, BlogMeta> = {
+  "best-time-visit-japan": {
+    title: "The Best Time to Visit Japan — A Month-by-Month Guide",
+    description: "Japan transforms with every season. From cherry blossoms to powder snow, here's when to go.",
+    ogTitle: "Best Time to Visit Japan — Month by Month",
+    ogDescription: "Sakura, festivals, autumn foliage, and powder snow — find your perfect month to visit Japan.",
+  },
+  "budget-travel-europe": {
+    title: "Budget Travel Hacks for Europe",
+    description: "Smart timing, local habits, and a few practical tricks can cut your Europe costs in half.",
+    ogDescription: "Spend less, see more. Practical tips on timing, transport, and staying smart across Europe.",
+  },
+  "festival-travel-guide": {
+    title: "How to Plan a Trip Around a Festival",
+    description: "Festival-centered trips are some of the most memorable journeys. Here's how to plan one.",
+    ogDescription: "Build your next trip around a great event — from choosing the festival to planning the days around it.",
+  },
+  "how-to-plan-multi-city-trip": {
+    title: "How to Plan the Perfect Multi-City Trip",
+    description: "Practical advice on route planning, timing, and logistics for multi-destination travel.",
+    ogDescription: "Plan a smooth multi-stop itinerary with smart routing, realistic timing, and less stress.",
+  },
+  "weekend-getaway-tips": {
+    title: "Weekend Getaway Planning: From Idea to Boarding Pass",
+    description: "How to squeeze the most out of a 2–3 day trip without the stress.",
+    ogTitle: "Weekend Getaway Planning Made Simple",
+    ogDescription: "Make every hour count on a 2–3 day escape. Quick to plan, easy to enjoy.",
+  },
+};
+
+const BLOG_LOCALES_BY_SLUG: Record<string, SupportedLocale[]> = {
+  "best-time-visit-japan": ["en"],
+  "budget-travel-europe": ["en"],
+  "festival-travel-guide": ["en"],
+  "how-to-plan-multi-city-trip": ["en"],
+  "weekend-getaway-tips": ["en"],
+};
+
+const isSupportedLocale = (value?: string | null): value is SupportedLocale => {
+  if (!value) return false;
+  return SUPPORTED_LOCALES.includes(value as SupportedLocale);
+};
+
+const normalizePath = (pathname: string): string => {
+  const raw = pathname || "/";
+  const withLeadingSlash = raw.startsWith("/") ? raw : `/${raw}`;
+  const trimmed = withLeadingSlash.length > 1 && withLeadingSlash.endsWith("/")
+    ? withLeadingSlash.slice(0, -1)
+    : withLeadingSlash;
+  const segments = trimmed.split("/").filter(Boolean);
+
+  return trimmed;
+};
+
+const matchesPrefix = (pathname: string, prefix: string): boolean => {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+};
+
+const isToolBasePath = (pathname: string): boolean => {
+  return TOOL_PATH_PREFIXES.some((prefix) => matchesPrefix(pathname, prefix));
+};
+
+export const shouldUseStrictToolHtmlCache = (pathname: string): boolean => {
+  return STRICT_TOOL_HTML_PREFIXES.some((prefix) => matchesPrefix(pathname, prefix));
+};
+
+const isLocalizedMarketingBasePath = (pathname: string): boolean => {
+  if (isToolBasePath(pathname)) return false;
+  return MARKETING_PATH_PATTERNS.some((pattern) => pattern.test(pathname));
+};
+
+const buildLocalizedPath = (basePath: string, locale: SupportedLocale): string => {
+  if (locale === DEFAULT_LOCALE) return basePath;
+  if (basePath === "/") return `/${locale}`;
+  return `/${locale}${basePath}`;
+};
+
+const pathToTitle = (pathname: string): string => {
+  if (pathname === "/") return SITE_NAME;
+  const leaf = pathname.split("/").filter(Boolean).slice(-1)[0] || "Page";
+  const words = leaf
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+  return words.length > 0 ? words.join(" ") : "Page";
+};
+
+const finalizePageDefinition = (page: PageDefinition): PageDefinition => ({
+  ...page,
+  title: applyAppNameTemplate(page.title),
+  description: applyAppNameTemplate(page.description),
+  ogTitle: page.ogTitle ? applyAppNameTemplate(page.ogTitle) : undefined,
+  ogDescription: page.ogDescription ? applyAppNameTemplate(page.ogDescription) : undefined,
+  pill: page.pill ? applyAppNameTemplate(page.pill) : undefined,
+});
+
+const withLocaleOverrides = (
+  basePath: string,
+  locale: SupportedLocale,
+  page: PageDefinition,
+): PageDefinition => {
+  const localized = LOCALIZED_PAGE_META[basePath]?.[locale];
+  if (!localized) return finalizePageDefinition(page);
+  return finalizePageDefinition({
+    ...page,
+    ...localized,
+  });
+};
+
+const getCountryRouteMeta = (country: string, locale: SupportedLocale): PageDefinition => {
+  switch (locale) {
+    case "es":
+      return finalizePageDefinition({
+        title: `Viajar a ${country}`,
+        description: `Todo lo que necesitas para planificar tu viaje a ${country}: mejores meses, itinerarios populares y consejos útiles.`,
+        pill: "INSPIRACIÓN DE VIAJES",
+      });
+    case "de":
+      return finalizePageDefinition({
+        title: `Reise nach ${country}`,
+        description: `Plane deine Reise nach ${country} - beste Reisezeit, beliebte Routen und praktische Tipps.`,
+        pill: "REISEINSPIRATIONEN",
+      });
+    case "fr":
+      return finalizePageDefinition({
+        title: `Voyager en ${country}`,
+        description: `Tout pour planifier votre voyage en ${country} : meilleures periodes, itinéraires populaires et conseils utiles.`,
+        pill: "INSPIRATIONS",
+      });
+    case "it":
+      return finalizePageDefinition({
+        title: `Viaggia in ${country}`,
+        description: `Tutto ciò che serve per pianificare un viaggio in ${country}: periodi migliori, itinerari popolari e consigli utili.`,
+        pill: "ISPIRAZIONI",
+      });
+    case "ru":
+      return finalizePageDefinition({
+        title: `Путешествие в ${country}`,
+        description: `Все для планирования поездки в ${country}: лучшие месяцы, популярные маршруты и полезные советы.`,
+        pill: "ИДЕИ ПУТЕШЕСТВИЙ",
+      });
+    case "pt":
+      return finalizePageDefinition({
+        title: `Viajar para ${country}`,
+        description: `Tudo o que precisa para planear a sua viagem a ${country}: melhores meses, roteiros populares e dicas úteis.`,
+        pill: "INSPIRAÇÃO DE VIAGENS",
+      });
+    case "pl":
+      return finalizePageDefinition({
+        title: `Podróż do ${country}`,
+        description: `Wszystko, czego potrzebujesz, aby zaplanować podróż do ${country}: najlepsze miesiące, popularne trasy i praktyczne wskazówki.`,
+        pill: "INSPIRACJE PODRÓŻNICZE",
+      });
+    default:
+      return finalizePageDefinition({
+        title: `Travel to ${country}`,
+        description: `Plan your trip to ${country} - best months, itineraries, and tips.`,
+        pill: "TRIP INSPIRATIONS",
+      });
+  }
+};
+
+const getPageDefinition = (basePath: string, locale: SupportedLocale): PageDefinition => {
+  if (PAGE_META[basePath]) return withLocaleOverrides(basePath, locale, PAGE_META[basePath]);
+
+  if (basePath.startsWith("/admin")) {
+    return finalizePageDefinition({
+      title: "Admin Dashboard",
+      description: "Internal {{appName}} admin workspace.",
+      robots: "noindex,nofollow,max-image-preview:large",
+    });
+  }
+
+  const exampleMatch = basePath.match(/^\/example\/([^/]+)$/);
+  if (exampleMatch) {
+    const templateId = decodeURIComponent(exampleMatch[1]);
+    const card = getExampleTripCardByTemplateId(templateId);
+    if (card) {
+      const localized = getLocalizedExampleTripCard(
+        card,
+        locale,
+        card.countries.map((country) => country.name),
+      );
+      const title = localized.title || card.title;
+      const countryList = card.countries.map((country) => country.name).filter(Boolean);
+      const countryLabel = countryList.slice(0, 3).join(", ");
+      return finalizePageDefinition({
+        title,
+        description: countryLabel
+          ? `Preview this sample itinerary across ${countryLabel} and personalize it in {{appName}}.`
+          : "Preview this sample itinerary and personalize it in {{appName}}.",
+        ogDescription: `Open the ${title} example trip template and customize your own itinerary in {{appName}}.`,
+        pill: "EXAMPLE TRIP",
+        robots: "index,follow,max-image-preview:large",
+      });
+    }
+  }
+
+  const blogMatch = basePath.match(/^\/blog\/([^/]+)$/);
+  if (blogMatch) {
+    const slug = decodeURIComponent(blogMatch[1]);
+    const blog = BLOG_META[slug];
+    const media = getBlogImageMedia(slug, blog ? blog.title : pathToTitle(basePath));
+    return finalizePageDefinition({
+      title: blog ? blog.title : pathToTitle(basePath),
+      description: blog ? blog.description : "Read this article on the {{appName}} blog.",
+      ogTitle: blog?.ogTitle,
+      ogDescription: blog?.ogDescription,
+      pill: "BLOG",
+      blogOgImagePath: media.ogVertical.source,
+      blogAccentTint: DEFAULT_BLOG_OG_TINT,
+      blogTintIntensity: 60,
+    });
+  }
+
+  const countryMatch = basePath.match(/^\/inspirations\/country\/([^/]+)$/);
+  if (countryMatch) {
+    const country = decodeURIComponent(countryMatch[1])
+      .split(/[-_]+/)
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+      .join(" ");
+    return getCountryRouteMeta(country, locale);
+  }
+
+  if (basePath.startsWith("/inspirations")) {
+    return finalizePageDefinition({
+      title: pathToTitle(basePath),
+      description: "Explore curated trip ideas and travel inspiration on {{appName}}.",
+      pill: "TRIP INSPIRATIONS",
+    });
+  }
+
+  return finalizePageDefinition({
+    title: pathToTitle(basePath),
+    description: DEFAULT_DESCRIPTION,
+  });
+};
+
+const stripSeoTags = (html: string): string => {
+  const patterns = [
+    /<title>[\s\S]*?<\/title>/gi,
+    /<meta[^>]+name=["']description["'][^>]*>/gi,
+    /<meta[^>]+name=["']robots["'][^>]*>/gi,
+    /<meta[^>]+property=["']og:[^"']+["'][^>]*>/gi,
+    /<meta[^>]+name=["']twitter:[^"']+["'][^>]*>/gi,
+    /<meta[^>]+http-equiv=["']content-language["'][^>]*>/gi,
+    /<link[^>]+rel=["']canonical["'][^>]*>/gi,
+    /<link[^>]+rel=["']alternate["'][^>]+hreflang=["'][^"']+["'][^>]*>/gi,
+  ];
+  return patterns.reduce((acc, regex) => acc.replace(regex, ""), html);
+};
+
+const setHtmlLangAttributes = (html: string, lang: string, dir: "ltr" | "rtl"): string => {
+  const safeLang = escapeHtml(lang);
+  const safeDir = escapeHtml(dir);
+
+  return html.replace(/<html\b([^>]*)>/i, (_full, attrs: string) => {
+    let nextAttrs = attrs;
+
+    if (/\slang\s*=\s*["'][^"']*["']/i.test(nextAttrs)) {
+      nextAttrs = nextAttrs.replace(/(\slang\s*=\s*["'])[^"']*(["'])/i, `$1${safeLang}$2`);
+    } else {
+      nextAttrs += ` lang="${safeLang}"`;
+    }
+
+    if (/\sdir\s*=\s*["'][^"']*["']/i.test(nextAttrs)) {
+      nextAttrs = nextAttrs.replace(/(\sdir\s*=\s*["'])[^"']*(["'])/i, `$1${safeDir}$2`);
+    } else {
+      nextAttrs += ` dir="${safeDir}"`;
+    }
+
+    return `<html${nextAttrs}>`;
+  });
+};
+
+export const buildMetaTags = (meta: SiteOgMetadata): string => {
+  const title = escapeHtml(meta.pageTitle);
+  const description = escapeHtml(meta.description);
+  const ogTitle = escapeHtml(meta.ogTitle);
+  const ogDescription = escapeHtml(meta.ogDescription);
+  const canonicalUrl = escapeHtml(meta.canonicalUrl);
+  const ogImageUrl = escapeHtml(meta.ogImageUrl);
+  const ogLogoUrl = escapeHtml(meta.ogLogoUrl);
+  const robots = escapeHtml(meta.robots);
+  const contentLanguage = escapeHtml(meta.htmlLang);
+
+  const alternateTags = meta.alternateLinks.map((link) => {
+    const hreflang = escapeHtml(link.hreflang);
+    const href = escapeHtml(link.href);
+    return `<link rel="alternate" hreflang="${hreflang}" href="${href}" />`;
+  });
+
+  return [
+    `<title>${title}</title>`,
+    `<meta name="description" content="${description}" />`,
+    `<link rel="canonical" href="${canonicalUrl}" />`,
+    ...alternateTags,
+    `<meta http-equiv="content-language" content="${contentLanguage}" />`,
+    `<meta name="robots" content="${robots}" />`,
+    `<meta property="og:type" content="website" />`,
+    `<meta property="og:site_name" content="${SITE_NAME}" />`,
+    `<meta property="og:title" content="${ogTitle}" />`,
+    `<meta property="og:description" content="${ogDescription}" />`,
+    `<meta property="og:url" content="${canonicalUrl}" />`,
+    `<meta property="og:image" content="${ogImageUrl}" />`,
+    `<meta property="og:image:width" content="1200" />`,
+    `<meta property="og:image:height" content="630" />`,
+    `<meta property="og:image:alt" content="${ogTitle}" />`,
+    `<meta property="og:logo" content="${ogLogoUrl}" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${ogTitle}" />`,
+    `<meta name="twitter:description" content="${ogDescription}" />`,
+    `<meta name="twitter:image" content="${ogImageUrl}" />`,
+  ].join("\n");
+};
+
+const collapseBlankLines = (html: string): string => html.replace(/(\n\s*){3,}/g, "\n\n");
+
+export const injectMetaTags = (html: string, meta: SiteOgMetadata): string => {
+  if (!/<head[^>]*>/i.test(html) || !/<\/head>/i.test(html)) {
+    return html;
+  }
+  const cleaned = collapseBlankLines(stripSeoTags(html));
+  const htmlTagged = setHtmlLangAttributes(cleaned, meta.htmlLang, meta.htmlDir);
+  return htmlTagged.replace(/(<head[^>]*>)/i, `$1\n${buildMetaTags(meta)}`);
+};
+
+export const buildCanonicalSearch = (url: URL): string => {
+  const params = new URLSearchParams(url.search);
+  const dropKeys = new Set([
+    "prefill",
+    "debug",
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "gclid",
+    "fbclid",
+  ]);
+
+  for (const key of Array.from(params.keys())) {
+    if (dropKeys.has(key) || key.startsWith("utm_")) {
+      params.delete(key);
+    }
+  }
+
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+};
+
+const sanitizeRouteKeySegment = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    || "root";
+
+export const buildSiteOgRouteKey = (canonicalPath: string, canonicalSearch: string): string => {
+  const joined = `${canonicalPath}${canonicalSearch}`;
+  if (joined === "/" || joined === "") return "root";
+  const normalized = joined.startsWith("/") ? joined.slice(1) : joined;
+  return sanitizeRouteKeySegment(normalized);
+};
+
+export const buildDynamicSiteOgImageUrl = (origin: string, params: SiteOgImageParams): string => {
+  const ogImage = new URL("/api/og/site", origin);
+  ogImage.searchParams.set("title", params.title);
+  ogImage.searchParams.set("description", params.description);
+  ogImage.searchParams.set("path", params.path);
+  if (params.pill) ogImage.searchParams.set("pill", params.pill);
+  if (params.blog_image) ogImage.searchParams.set("blog_image", params.blog_image);
+  if (params.blog_rev) ogImage.searchParams.set("blog_rev", params.blog_rev);
+  if (params.blog_tint) ogImage.searchParams.set("blog_tint", params.blog_tint);
+  if (params.blog_tint_intensity) ogImage.searchParams.set("blog_tint_intensity", params.blog_tint_intensity);
+  return ogImage.toString();
+};
+
+const parsePathInfo = (pathname: string): {
+  normalizedPath: string;
+  localeFromPath: SupportedLocale | null;
+  basePath: string;
+  isLocalizedMarketing: boolean;
+} => {
+  const normalizedPath = normalizePath(pathname);
+  const segments = normalizedPath.split("/").filter(Boolean);
+
+  const maybeLocale = segments[0] || null;
+  const localeFromPath = isSupportedLocale(maybeLocale) ? maybeLocale : null;
+  const basePath = localeFromPath
+    ? normalizePath(`/${segments.slice(1).join("/") || ""}`)
+    : normalizedPath;
+
+  return {
+    normalizedPath,
+    localeFromPath,
+    basePath,
+    isLocalizedMarketing: isLocalizedMarketingBasePath(basePath),
+  };
+};
+
+const getBlogLocales = (basePath: string): SupportedLocale[] | null => {
+  const match = basePath.match(/^\/blog\/([^/]+)$/);
+  if (!match) return null;
+  const slug = decodeURIComponent(match[1]);
+  return BLOG_LOCALES_BY_SLUG[slug] ?? [DEFAULT_LOCALE];
+};
+
+const buildAlternateLinks = (origin: string, basePath: string, locales: SupportedLocale[]): AlternateLink[] => {
+  const links: AlternateLink[] = locales.map((locale) => ({
+    hreflang: locale,
+    href: new URL(buildLocalizedPath(basePath, locale), origin).toString(),
+  }));
+
+  const xDefaultLocale = locales.includes(DEFAULT_LOCALE)
+    ? DEFAULT_LOCALE
+    : locales[0] ?? DEFAULT_LOCALE;
+
+  links.push({
+    hreflang: "x-default",
+    href: new URL(buildLocalizedPath(basePath, xDefaultLocale), origin).toString(),
+  });
+
+  return links;
+};
+
+export const buildSiteOgMetadata = (url: URL): SiteOgMetadata => {
+  const pathInfo = parsePathInfo(url.pathname);
+  const canonicalSearch = buildCanonicalSearch(url);
+  const blogLocales = getBlogLocales(pathInfo.basePath);
+
+  let effectiveLocale: SupportedLocale = DEFAULT_LOCALE;
+  let basePathForMeta = pathInfo.basePath;
+  let canonicalPath = pathInfo.normalizedPath;
+  let alternateLinks: AlternateLink[] = [];
+
+  if (pathInfo.isLocalizedMarketing) {
+    effectiveLocale = pathInfo.localeFromPath ?? DEFAULT_LOCALE;
+
+    const missingLocalizedBlogVariant = Boolean(
+      blogLocales && !blogLocales.includes(effectiveLocale),
+    );
+
+    if (missingLocalizedBlogVariant) {
+      // Keep locale-specific UI on the current path, but canonicalize
+      // to the source article locale to avoid duplicate-indexing fallback URLs.
+      canonicalPath = buildLocalizedPath(pathInfo.basePath, DEFAULT_LOCALE);
+      alternateLinks = buildAlternateLinks(url.origin, pathInfo.basePath, blogLocales ?? [DEFAULT_LOCALE]);
+    } else {
+      canonicalPath = buildLocalizedPath(pathInfo.basePath, effectiveLocale);
+      alternateLinks = buildAlternateLinks(
+        url.origin,
+        pathInfo.basePath,
+        blogLocales ?? SUPPORTED_LOCALES.slice(),
+      );
+    }
+  } else if (pathInfo.localeFromPath && isToolBasePath(pathInfo.basePath)) {
+    if (pathInfo.basePath === "/create-trip") {
+      effectiveLocale = pathInfo.localeFromPath;
+      canonicalPath = buildLocalizedPath(pathInfo.basePath, effectiveLocale);
+      alternateLinks = buildAlternateLinks(url.origin, pathInfo.basePath, SUPPORTED_LOCALES.slice());
+    } else {
+      canonicalPath = pathInfo.basePath;
+    }
+  }
+
+  const page = getPageDefinition(basePathForMeta, effectiveLocale);
+  const title = page.title === SITE_NAME ? SITE_NAME : `${page.title} | ${SITE_NAME}`;
+  const canonicalUrl = new URL(canonicalPath + canonicalSearch, url.origin).toString();
+
+  const ogTitleRaw = page.ogTitle || page.title;
+  const ogDescriptionRaw = page.ogDescription || page.description;
+  const ogTitleFull = ogTitleRaw === SITE_NAME ? SITE_NAME : `${ogTitleRaw} | ${SITE_NAME}`;
+
+  const ogImageParams: SiteOgImageParams = {
+    title: ogTitleRaw,
+    description: ogDescriptionRaw,
+    path: canonicalPath + canonicalSearch,
+  };
+  if (page.pill) ogImageParams.pill = page.pill;
+  if (page.blogOgImagePath) {
+    ogImageParams.blog_image = page.blogOgImagePath;
+    ogImageParams.blog_rev = BLOG_OG_IMAGE_REVISION;
+    ogImageParams.blog_tint = page.blogAccentTint || DEFAULT_BLOG_OG_TINT;
+    ogImageParams.blog_tint_intensity = String(page.blogTintIntensity ?? 60);
+  }
+  const routeKey = buildSiteOgRouteKey(canonicalPath, canonicalSearch);
+
+  return {
+    routeKey,
+    canonicalPath,
+    canonicalSearch,
+    pageTitle: title,
+    description: page.description,
+    ogTitle: ogTitleFull,
+    ogDescription: ogDescriptionRaw,
+    canonicalUrl,
+    ogImageUrl: buildDynamicSiteOgImageUrl(url.origin, ogImageParams),
+    ogImageParams,
+    ogLogoUrl: new URL("/favicon.svg", url.origin).toString(),
+    robots: page.robots || "index,follow,max-image-preview:large",
+    alternateLinks,
+    htmlLang: effectiveLocale,
+    htmlDir: "ltr",
+  };
+};
+
+const STATIC_MARKETING_BASE_PATHS: readonly string[] = [
+  "/",
+  "/features",
+  "/inspirations",
+  "/inspirations/themes",
+  "/inspirations/best-time-to-travel",
+  "/inspirations/countries",
+  "/inspirations/events-and-festivals",
+  "/inspirations/weekend-getaways",
+  "/updates",
+  "/blog",
+  "/pricing",
+  "/faq",
+  "/share-unavailable",
+  "/login",
+  "/contact",
+  "/imprint",
+  "/privacy",
+  "/terms",
+  "/cookies",
+];
+
+export interface SiteOgPathEnumerationInput {
+  blogSlugs: string[];
+  countryNames: string[];
+  exampleTemplateIds: string[];
+}
+
+const localizeStaticPath = (basePath: string, locale: SupportedLocale): string => {
+  if (locale === DEFAULT_LOCALE) return basePath;
+  if (basePath === "/") return `/${locale}`;
+  return `/${locale}${basePath}`;
+};
+
+export const enumerateSiteOgPathnames = (
+  input: SiteOgPathEnumerationInput,
+): string[] => {
+  const paths = new Set<string>();
+
+  const addLocalized = (basePath: string) => {
+    for (const locale of SUPPORTED_LOCALES) {
+      paths.add(localizeStaticPath(basePath, locale));
+    }
+  };
+
+  for (const basePath of STATIC_MARKETING_BASE_PATHS) addLocalized(basePath);
+  addLocalized("/create-trip");
+
+  for (const slug of input.blogSlugs) {
+    const normalizedSlug = slug.trim();
+    if (!normalizedSlug) continue;
+    addLocalized(`/blog/${encodeURIComponent(normalizedSlug)}`);
+  }
+
+  for (const countryName of input.countryNames) {
+    const normalizedCountryName = countryName.trim();
+    if (!normalizedCountryName) continue;
+    addLocalized(`/inspirations/country/${encodeURIComponent(normalizedCountryName)}`);
+  }
+
+  for (const templateId of input.exampleTemplateIds) {
+    const normalizedTemplateId = templateId.trim();
+    if (!normalizedTemplateId) continue;
+    paths.add(`/example/${encodeURIComponent(normalizedTemplateId)}`);
+  }
+
+  return Array.from(paths);
+};

--- a/netlify/edge-lib/site-og-static-manifest.ts
+++ b/netlify/edge-lib/site-og-static-manifest.ts
@@ -1,0 +1,27 @@
+export interface SiteOgStaticManifestEntry {
+  path: string;
+  hash: string;
+}
+
+export interface SiteOgStaticManifest {
+  generatedAt: string;
+  revision: string;
+  entries: Record<string, SiteOgStaticManifestEntry>;
+}
+
+export const isSiteOgStaticManifest = (value: unknown): value is SiteOgStaticManifest => {
+  if (!value || typeof value !== "object") return false;
+  const payload = value as Partial<SiteOgStaticManifest>;
+  if (typeof payload.generatedAt !== "string") return false;
+  if (typeof payload.revision !== "string") return false;
+  if (!payload.entries || typeof payload.entries !== "object") return false;
+
+  for (const entry of Object.values(payload.entries)) {
+    if (!entry || typeof entry !== "object") return false;
+    const candidate = entry as Partial<SiteOgStaticManifestEntry>;
+    if (typeof candidate.path !== "string") return false;
+    if (typeof candidate.hash !== "string") return false;
+  }
+
+  return true;
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "updates:next-version": "node scripts/next-release-version.mjs",
     "blog:validate": "node scripts/validate-blog.mjs",
     "edge:validate": "node scripts/validate-edge-functions.mjs",
+    "og:site:build": "tsx scripts/build-site-og-static-images.ts",
+    "og:site:validate": "tsx scripts/validate-site-og-static-manifest.ts",
     "sitemap:generate": "node scripts/generate-sitemap.mjs",
     "inspirations:images:jobs": "tsx scripts/build-inspiration-image-batch.ts",
     "build:images": "tsx scripts/build-inspiration-images.ts",
@@ -29,7 +31,7 @@
     "test:core": "vitest run --coverage --reporter=default",
     "test:e2e": "playwright test",
     "release:prepare": "pnpm build:blog-images && pnpm build",
-    "build": "pnpm test:core && pnpm inspirations:images:optimize && pnpm blog:images:optimize && pnpm build:image-placeholders && pnpm i18n:validate && pnpm plans:validate-sync && pnpm updates:validate && pnpm storage:validate && pnpm blog:validate && pnpm edge:validate && pnpm sitemap:generate && vite build",
+    "build": "pnpm test:core && pnpm inspirations:images:optimize && pnpm blog:images:optimize && pnpm build:image-placeholders && pnpm og:site:build && pnpm og:site:validate && pnpm i18n:validate && pnpm plans:validate-sync && pnpm updates:validate && pnpm storage:validate && pnpm blog:validate && pnpm edge:validate && pnpm sitemap:generate && vite build",
     "preview": "vite preview",
     "maps:generate": "tsx scripts/generate-trip-maps.ts"
   },

--- a/scripts/build-site-og-static-images.ts
+++ b/scripts/build-site-og-static-images.ts
@@ -1,0 +1,90 @@
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import sharp from "sharp";
+import type { SiteOgStaticManifest } from "../netlify/edge-lib/site-og-static-manifest.ts";
+import {
+  SITE_OG_STATIC_DIR_RELATIVE,
+  SITE_OG_STATIC_MANIFEST_FILE_NAME,
+  SITE_OG_STATIC_PUBLIC_PREFIX,
+  buildSiteOgManifestRevision,
+  buildSiteOgStaticFileName,
+  buildSiteOgStaticRenderPayload,
+  collectSiteOgStaticTargets,
+  computeSiteOgStaticPayloadHash,
+  renderSiteOgStaticSvg,
+} from "./site-og-static-shared.ts";
+
+const ROOT_DIR = process.cwd();
+const OUTPUT_DIR = path.join(ROOT_DIR, SITE_OG_STATIC_DIR_RELATIVE);
+const MANIFEST_PATH = path.join(OUTPUT_DIR, SITE_OG_STATIC_MANIFEST_FILE_NAME);
+
+const sortRecord = <T>(entries: Record<string, T>): Record<string, T> =>
+  Object.fromEntries(
+    Object.entries(entries).sort(([left], [right]) => left.localeCompare(right)),
+  );
+
+const writePngFromSvg = async (svg: string, outputPath: string): Promise<void> => {
+  await sharp(Buffer.from(svg)).png({
+    compressionLevel: 9,
+    effort: 10,
+    palette: true,
+    quality: 78,
+  }).toFile(outputPath);
+};
+
+const main = async (): Promise<void> => {
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const targets = collectSiteOgStaticTargets();
+  const manifestEntries: SiteOgStaticManifest["entries"] = {};
+  const expectedFiles = new Set<string>([SITE_OG_STATIC_MANIFEST_FILE_NAME]);
+
+  let written = 0;
+  let reused = 0;
+
+  for (const target of targets) {
+    const payload = buildSiteOgStaticRenderPayload(target.metadata);
+    const hash = computeSiteOgStaticPayloadHash(payload);
+    const fileName = buildSiteOgStaticFileName(target.routeKey, hash);
+    const outputPath = path.join(OUTPUT_DIR, fileName);
+
+    expectedFiles.add(fileName);
+
+    if (existsSync(outputPath)) {
+      reused += 1;
+    } else {
+      const svg = renderSiteOgStaticSvg(payload);
+      await writePngFromSvg(svg, outputPath);
+      written += 1;
+    }
+
+    manifestEntries[target.routeKey] = {
+      path: `${SITE_OG_STATIC_PUBLIC_PREFIX}/${fileName}`,
+      hash,
+    };
+  }
+
+  for (const fileName of readdirSync(OUTPUT_DIR)) {
+    if (!fileName.endsWith(".png")) continue;
+    if (expectedFiles.has(fileName)) continue;
+    rmSync(path.join(OUTPUT_DIR, fileName), { force: true });
+  }
+
+  const sortedEntries = sortRecord(manifestEntries);
+  const manifest: SiteOgStaticManifest = {
+    generatedAt: new Date().toISOString(),
+    revision: buildSiteOgManifestRevision(sortedEntries),
+    entries: sortedEntries,
+  };
+
+  writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  process.stdout.write(
+    `[site-og-static] targets=${targets.length} wrote=${written} reused=${reused} manifest=${SITE_OG_STATIC_DIR_RELATIVE}/${SITE_OG_STATIC_MANIFEST_FILE_NAME}\n`,
+  );
+};
+
+void main().catch((error) => {
+  process.stderr.write(`[site-og-static] ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/scripts/edge-validation-utils.mjs
+++ b/scripts/edge-validation-utils.mjs
@@ -23,25 +23,59 @@ export const parseEdgeFunctionEntries = (toml) => {
 export const findCatchAllEdgeEntries = (entries) =>
   entries.filter((entry) => entry.path.trim() === "/*");
 
-const SITE_OG_META_ALLOWED_PATHS = new Set([
+const SITE_OG_META_LOCALES = ["es", "de", "fr", "pt", "ru", "it", "pl", "ko"];
+
+const SITE_OG_META_BASE_ALLOWED_PATHS = [
+  "/",
+  "/features",
+  "/inspirations",
+  "/inspirations/*",
+  "/updates",
   "/blog",
   "/blog/*",
-  "/es/blog",
-  "/es/blog/*",
-  "/de/blog",
-  "/de/blog/*",
-  "/fr/blog",
-  "/fr/blog/*",
-  "/pt/blog",
-  "/pt/blog/*",
-  "/ru/blog",
-  "/ru/blog/*",
-  "/it/blog",
-  "/it/blog/*",
-  "/pl/blog",
-  "/pl/blog/*",
-  "/ko/blog",
-  "/ko/blog/*",
+  "/pricing",
+  "/faq",
+  "/share-unavailable",
+  "/login",
+  "/contact",
+  "/imprint",
+  "/privacy",
+  "/terms",
+  "/cookies",
+  "/create-trip",
+  "/example/*",
+];
+
+const SITE_OG_META_LOCALIZED_ALLOWED_PATHS = [
+  "/",
+  "/features",
+  "/inspirations",
+  "/inspirations/*",
+  "/updates",
+  "/blog",
+  "/blog/*",
+  "/pricing",
+  "/faq",
+  "/share-unavailable",
+  "/login",
+  "/contact",
+  "/imprint",
+  "/privacy",
+  "/terms",
+  "/cookies",
+  "/create-trip",
+];
+
+const localizePath = (path, locale) => {
+  if (path === "/") return `/${locale}`;
+  return `/${locale}${path}`;
+};
+
+const SITE_OG_META_ALLOWED_PATHS = new Set([
+  ...SITE_OG_META_BASE_ALLOWED_PATHS,
+  ...SITE_OG_META_LOCALES.flatMap((locale) =>
+    SITE_OG_META_LOCALIZED_ALLOWED_PATHS.map((path) => localizePath(path, locale))
+  ),
 ]);
 
 export const findSiteOgMetaScopeViolations = (entries) =>
@@ -50,5 +84,5 @@ export const findSiteOgMetaScopeViolations = (entries) =>
     .filter((entry) => !SITE_OG_META_ALLOWED_PATHS.has(entry.path.trim()))
     .map((entry) => ({
       ...entry,
-      reason: `site-og-meta must only be mapped to blog routes. Found disallowed path "${entry.path}".`,
+      reason: `site-og-meta must only be mapped to approved static/example route allowlists. Found disallowed path "${entry.path}".`,
     }));

--- a/scripts/site-og-static-shared.ts
+++ b/scripts/site-og-static-shared.ts
@@ -1,0 +1,256 @@
+import { createHash } from "node:crypto";
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import { COUNTRY_TRAVEL_DATA } from "../data/countryTravelData.ts";
+import { exampleTripCards } from "../data/exampleTripCards.ts";
+import { buildSiteOgMetadata, enumerateSiteOgPathnames, type SiteOgMetadata } from "../netlify/edge-lib/site-og-metadata.ts";
+
+export const SITE_OG_IMAGE_WIDTH = 1200;
+export const SITE_OG_IMAGE_HEIGHT = 630;
+export const SITE_OG_STATIC_DIR_RELATIVE = "public/images/og/site/generated";
+export const SITE_OG_STATIC_PUBLIC_PREFIX = "/images/og/site/generated";
+export const SITE_OG_STATIC_MANIFEST_FILE_NAME = "manifest.json";
+export const SITE_OG_STATIC_MANIFEST_RELATIVE_PATH = `${SITE_OG_STATIC_DIR_RELATIVE}/${SITE_OG_STATIC_MANIFEST_FILE_NAME}`;
+export const SITE_OG_BUILD_ORIGIN = "https://travelflowapp.netlify.app";
+
+export interface SiteOgStaticTarget {
+  pathname: string;
+  routeKey: string;
+  metadata: SiteOgMetadata;
+}
+
+export interface SiteOgStaticRenderPayload {
+  routeKey: string;
+  title: string;
+  description: string;
+  path: string;
+  pill: string;
+  blogImage: string;
+  blogRevision: string;
+  blogTint: string;
+  blogTintIntensity: string;
+}
+
+const truncateText = (value: string, max: number): string => {
+  if (value.length <= max) return value;
+  return `${value.slice(0, Math.max(1, max - 1))}…`;
+};
+
+const wrapText = (value: string, maxChars: number, maxLines: number): string[] => {
+  const words = value
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+  if (words.length === 0) return [value];
+
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (candidate.length <= maxChars) {
+      current = candidate;
+      continue;
+    }
+
+    if (current) {
+      lines.push(current);
+      current = word;
+    } else {
+      lines.push(word.slice(0, maxChars));
+      current = word.slice(maxChars);
+    }
+
+    if (lines.length >= maxLines) break;
+  }
+
+  if (lines.length < maxLines && current) {
+    lines.push(current);
+  }
+
+  if (lines.length > maxLines) {
+    lines.length = maxLines;
+  }
+
+  if (lines.length === maxLines) {
+    const joined = lines.join(" ");
+    if (joined.length < value.length) {
+      const last = lines[maxLines - 1].replace(/…+$/g, "");
+      lines[maxLines - 1] = truncateText(last, maxChars);
+    }
+  }
+
+  return lines;
+};
+
+const escapeSvgText = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const toSlug = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    || "route";
+
+const collectBlogSlugs = (): string[] => {
+  const contentDir = path.join(process.cwd(), "content", "blog");
+
+  const slugs = readdirSync(contentDir)
+    .filter((fileName) => fileName.endsWith(".md"))
+    .map((fileName) => fileName.replace(/\.md$/i, "").trim())
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
+
+  return slugs;
+};
+
+const collectCountryNames = (): string[] => {
+  const names = COUNTRY_TRAVEL_DATA.countries
+    .map((country) => country.countryName.trim())
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
+
+  return Array.from(new Set(names));
+};
+
+const collectExampleTemplateIds = (): string[] => {
+  const ids = exampleTripCards
+    .map((card) => card.templateId?.trim() || "")
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
+
+  return Array.from(new Set(ids));
+};
+
+export const collectSiteOgPathnames = (): string[] => {
+  const pathnames = enumerateSiteOgPathnames({
+    blogSlugs: collectBlogSlugs(),
+    countryNames: collectCountryNames(),
+    exampleTemplateIds: collectExampleTemplateIds(),
+  });
+
+  return Array.from(new Set(pathnames)).sort((left, right) => left.localeCompare(right));
+};
+
+export const collectSiteOgStaticTargets = (origin = SITE_OG_BUILD_ORIGIN): SiteOgStaticTarget[] => {
+  const pathnames = collectSiteOgPathnames();
+  const targetsByRouteKey = new Map<string, SiteOgStaticTarget>();
+
+  for (const pathname of pathnames) {
+    const metadata = buildSiteOgMetadata(new URL(pathname, origin));
+
+    if (!targetsByRouteKey.has(metadata.routeKey)) {
+      targetsByRouteKey.set(metadata.routeKey, {
+        pathname,
+        routeKey: metadata.routeKey,
+        metadata,
+      });
+    }
+  }
+
+  return Array.from(targetsByRouteKey.values()).sort((left, right) => left.routeKey.localeCompare(right.routeKey));
+};
+
+export const buildSiteOgStaticRenderPayload = (metadata: SiteOgMetadata): SiteOgStaticRenderPayload => ({
+  routeKey: metadata.routeKey,
+  title: metadata.ogImageParams.title,
+  description: metadata.ogImageParams.description,
+  path: metadata.ogImageParams.path,
+  pill: metadata.ogImageParams.pill || "",
+  blogImage: metadata.ogImageParams.blog_image || "",
+  blogRevision: metadata.ogImageParams.blog_rev || "",
+  blogTint: metadata.ogImageParams.blog_tint || "",
+  blogTintIntensity: metadata.ogImageParams.blog_tint_intensity || "",
+});
+
+export const computeSiteOgStaticPayloadHash = (payload: SiteOgStaticRenderPayload): string =>
+  createHash("sha256")
+    .update(JSON.stringify(payload))
+    .digest("hex")
+    .slice(0, 16);
+
+export const buildSiteOgStaticFileName = (routeKey: string, hash: string): string =>
+  `${toSlug(routeKey)}-${hash}.png`;
+
+const buildSvgTextLine = (value: string, x: number, y: number, className: string): string =>
+  `<text x="${x}" y="${y}" class="${className}">${escapeSvgText(value)}</text>`;
+
+export const renderSiteOgStaticSvg = (payload: SiteOgStaticRenderPayload): string => {
+  const titleLines = wrapText(payload.title, 30, 3);
+  const descriptionLines = wrapText(payload.description, 56, 3);
+  const pill = payload.pill || "TRAVELFLOW";
+  const displayPath = truncateText(payload.path || "/", 56);
+
+  const titleText = titleLines
+    .map((line, index) => buildSvgTextLine(line, 92, 194 + (index * 62), "title"))
+    .join("\n");
+
+  const descriptionText = descriptionLines
+    .map((line, index) => buildSvgTextLine(line, 92, 382 + (index * 38), "description"))
+    .join("\n");
+
+  const tint = payload.blogTint && /^#[0-9a-f]{6}$/i.test(payload.blogTint)
+    ? payload.blogTint.toLowerCase()
+    : "#4f46e5";
+  const tintStrength = Number.parseInt(payload.blogTintIntensity || "60", 10);
+  const normalizedStrength = Number.isFinite(tintStrength)
+    ? Math.max(0, Math.min(100, tintStrength))
+    : 60;
+  const overlayOpacity = (normalizedStrength / 100) * 0.45;
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${SITE_OG_IMAGE_WIDTH}" height="${SITE_OG_IMAGE_HEIGHT}" viewBox="0 0 ${SITE_OG_IMAGE_WIDTH} ${SITE_OG_IMAGE_HEIGHT}">`,
+    "  <defs>",
+    "    <linearGradient id=\"bg\" x1=\"0%\" y1=\"0%\" x2=\"100%\" y2=\"100%\">",
+    "      <stop offset=\"0%\" stop-color=\"#f8fafc\" />",
+    "      <stop offset=\"52%\" stop-color=\"#e5e7eb\" />",
+    "      <stop offset=\"100%\" stop-color=\"#e0e7ff\" />",
+    "    </linearGradient>",
+    "    <linearGradient id=\"rightPanel\" x1=\"0%\" y1=\"0%\" x2=\"100%\" y2=\"100%\">",
+    "      <stop offset=\"0%\" stop-color=\"#312e81\" />",
+    "      <stop offset=\"100%\" stop-color=\"#4f46e5\" />",
+    "    </linearGradient>",
+    "    <style>",
+    "      .pill { fill: #ffffff; font-size: 28px; font-weight: 700; letter-spacing: 0.5px; font-family: 'Bricolage Grotesque', 'Segoe UI', 'Arial', sans-serif; }",
+    "      .title { fill: #111827; font-size: 58px; font-weight: 800; letter-spacing: -1.2px; font-family: 'Bricolage Grotesque', 'Segoe UI', 'Arial', sans-serif; }",
+    "      .description { fill: #334155; font-size: 34px; font-weight: 500; font-family: 'Bricolage Grotesque', 'Segoe UI', 'Arial', sans-serif; }",
+    "      .site { fill: #111827; font-size: 30px; font-weight: 700; font-family: 'Bricolage Grotesque', 'Segoe UI', 'Arial', sans-serif; }",
+    "      .path { fill: #475569; font-size: 21px; font-weight: 500; font-family: 'Bricolage Grotesque', 'Segoe UI', 'Arial', sans-serif; }",
+    "      .accent { fill: #c7d2fe; font-size: 20px; font-weight: 700; letter-spacing: 1px; font-family: 'Bricolage Grotesque', 'Segoe UI', 'Arial', sans-serif; }",
+    "    </style>",
+    "  </defs>",
+    "  <rect x=\"0\" y=\"0\" width=\"1200\" height=\"630\" fill=\"url(#bg)\" />",
+    "  <rect x=\"44\" y=\"38\" width=\"762\" height=\"554\" rx=\"28\" fill=\"rgba(255,255,255,0.9)\" stroke=\"rgba(148,163,184,0.28)\" />",
+    "  <rect x=\"828\" y=\"38\" width=\"328\" height=\"554\" rx=\"28\" fill=\"url(#rightPanel)\" />",
+    `  <rect x=\"828\" y=\"38\" width=\"328\" height=\"554\" rx=\"28\" fill=\"${tint}\" opacity=\"${overlayOpacity.toFixed(3)}\" />`,
+    "  <rect x=\"92\" y=\"76\" width=\"256\" height=\"58\" rx=\"29\" fill=\"#4f46e5\" />",
+    `  ${buildSvgTextLine(pill, 114, 113, "pill")}`,
+    `  ${titleText}`,
+    `  ${descriptionText}`,
+    "  <rect x=\"92\" y=\"518\" width=\"670\" height=\"1\" fill=\"rgba(148,163,184,0.42)\" />",
+    `  ${buildSvgTextLine("TravelFlow", 92, 560, "site")}`,
+    `  ${buildSvgTextLine(displayPath, 324, 560, "path")}`,
+    "  <circle cx=\"992\" cy=\"128\" r=\"38\" fill=\"rgba(199,210,254,0.28)\" />",
+    "  <circle cx=\"1092\" cy=\"212\" r=\"22\" fill=\"rgba(199,210,254,0.2)\" />",
+    "  <circle cx=\"936\" cy=\"258\" r=\"14\" fill=\"rgba(199,210,254,0.32)\" />",
+    `  ${buildSvgTextLine(payload.blogImage ? "BLOG PREVIEW" : "SITE PREVIEW", 884, 560, "accent")}`,
+    "</svg>",
+  ].join("\n");
+};
+
+export const buildSiteOgManifestRevision = (entries: Record<string, { path: string; hash: string }>): string => {
+  const payload = JSON.stringify(
+    Object.entries(entries)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([routeKey, value]) => [routeKey, value.path, value.hash]),
+  );
+
+  return createHash("sha256").update(payload).digest("hex").slice(0, 12);
+};

--- a/scripts/validate-site-og-static-manifest.ts
+++ b/scripts/validate-site-og-static-manifest.ts
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { isSiteOgStaticManifest, type SiteOgStaticManifest } from "../netlify/edge-lib/site-og-static-manifest.ts";
+import {
+  SITE_OG_STATIC_DIR_RELATIVE,
+  SITE_OG_STATIC_MANIFEST_FILE_NAME,
+  SITE_OG_STATIC_PUBLIC_PREFIX,
+  buildSiteOgStaticFileName,
+  buildSiteOgStaticRenderPayload,
+  collectSiteOgStaticTargets,
+  computeSiteOgStaticPayloadHash,
+} from "./site-og-static-shared.ts";
+
+const ROOT_DIR = process.cwd();
+const OUTPUT_DIR = path.join(ROOT_DIR, SITE_OG_STATIC_DIR_RELATIVE);
+const MANIFEST_PATH = path.join(OUTPUT_DIR, SITE_OG_STATIC_MANIFEST_FILE_NAME);
+
+const fail = (message: string): never => {
+  process.stderr.write(`[site-og-static:validate] ${message}\n`);
+  process.exit(1);
+};
+
+const main = (): void => {
+  if (!existsSync(MANIFEST_PATH)) {
+    fail(`Missing manifest: ${SITE_OG_STATIC_DIR_RELATIVE}/${SITE_OG_STATIC_MANIFEST_FILE_NAME}. Run pnpm og:site:build first.`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  } catch (error) {
+    fail(`Manifest is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (!isSiteOgStaticManifest(parsed)) {
+    fail("Manifest shape is invalid.");
+  }
+
+  const manifest = parsed as SiteOgStaticManifest;
+  const targets = collectSiteOgStaticTargets();
+  const expectedRouteKeys = new Set(targets.map((target) => target.routeKey));
+  const manifestRouteKeys = new Set(Object.keys(manifest.entries));
+
+  const missingRouteKeys = Array.from(expectedRouteKeys).filter((routeKey) => !manifestRouteKeys.has(routeKey));
+  if (missingRouteKeys.length > 0) {
+    fail(`Manifest is missing route keys: ${missingRouteKeys.slice(0, 8).join(", ")}${missingRouteKeys.length > 8 ? "..." : ""}`);
+  }
+
+  const unexpectedRouteKeys = Array.from(manifestRouteKeys).filter((routeKey) => !expectedRouteKeys.has(routeKey));
+  if (unexpectedRouteKeys.length > 0) {
+    fail(`Manifest contains unexpected route keys: ${unexpectedRouteKeys.slice(0, 8).join(", ")}${unexpectedRouteKeys.length > 8 ? "..." : ""}`);
+  }
+
+  for (const target of targets) {
+    const entry = manifest.entries[target.routeKey];
+    if (!entry) {
+      fail(`Manifest entry missing for route key ${target.routeKey}`);
+    }
+
+    if (!entry.path.startsWith(`${SITE_OG_STATIC_PUBLIC_PREFIX}/`)) {
+      fail(`Manifest entry for ${target.routeKey} has invalid path prefix: ${entry.path}`);
+    }
+
+    const payload = buildSiteOgStaticRenderPayload(target.metadata);
+    const expectedHash = computeSiteOgStaticPayloadHash(payload);
+    const expectedFileName = buildSiteOgStaticFileName(target.routeKey, expectedHash);
+    const expectedPath = `${SITE_OG_STATIC_PUBLIC_PREFIX}/${expectedFileName}`;
+
+    if (entry.hash !== expectedHash) {
+      fail(`Manifest hash mismatch for ${target.routeKey}: expected ${expectedHash}, got ${entry.hash}`);
+    }
+
+    if (entry.path !== expectedPath) {
+      fail(`Manifest path mismatch for ${target.routeKey}: expected ${expectedPath}, got ${entry.path}`);
+    }
+
+    const absoluteAssetPath = path.join(ROOT_DIR, "public", entry.path.replace(/^\//, ""));
+    if (!existsSync(absoluteAssetPath)) {
+      fail(`Manifest asset is missing on disk for ${target.routeKey}: ${entry.path}`);
+    }
+  }
+
+  process.stdout.write(`[site-og-static:validate] validated ${targets.length} route entries\n`);
+};
+
+main();

--- a/tests/unit/edgeValidationUtils.test.ts
+++ b/tests/unit/edgeValidationUtils.test.ts
@@ -40,9 +40,9 @@ describe('edge validation utils', () => {
 
   it('detects disallowed site-og-meta route scope', () => {
     const entries = [
-      { path: '/blog', functionName: 'site-og-meta' },
-      { path: '/de/blog/*', functionName: 'site-og-meta' },
       { path: '/', functionName: 'site-og-meta' },
+      { path: '/example/*', functionName: 'site-og-meta' },
+      { path: '/de/features', functionName: 'site-og-meta' },
       { path: '/de/*', functionName: 'site-og-meta' },
       { path: '/trip/*', functionName: 'trip-og-meta' },
     ];
@@ -50,15 +50,26 @@ describe('edge validation utils', () => {
     const violations = findSiteOgMetaScopeViolations(entries);
     expect(violations).toEqual([
       {
-        path: '/',
-        functionName: 'site-og-meta',
-        reason: 'site-og-meta must only be mapped to blog routes. Found disallowed path "/".',
-      },
-      {
         path: '/de/*',
         functionName: 'site-og-meta',
-        reason: 'site-og-meta must only be mapped to blog routes. Found disallowed path "/de/*".',
+        reason: 'site-og-meta must only be mapped to approved static/example route allowlists. Found disallowed path "/de/*".',
       },
     ]);
+  });
+
+  it('passes approved site-og-meta allowlist routes', () => {
+    const entries = [
+      { path: '/', functionName: 'site-og-meta' },
+      { path: '/inspirations/*', functionName: 'site-og-meta' },
+      { path: '/blog/*', functionName: 'site-og-meta' },
+      { path: '/example/*', functionName: 'site-og-meta' },
+      { path: '/de', functionName: 'site-og-meta' },
+      { path: '/de/inspirations/*', functionName: 'site-og-meta' },
+      { path: '/de/blog/*', functionName: 'site-og-meta' },
+      { path: '/de/create-trip', functionName: 'site-og-meta' },
+      { path: '/trip/*', functionName: 'trip-og-meta' },
+    ];
+
+    expect(findSiteOgMetaScopeViolations(entries)).toEqual([]);
   });
 });

--- a/tests/unit/siteOgMetadata.test.ts
+++ b/tests/unit/siteOgMetadata.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSiteOgMetadata,
+  enumerateSiteOgPathnames,
+} from '../../netlify/edge-lib/site-og-metadata.ts';
+import {
+  buildSiteOgStaticRenderPayload,
+  collectSiteOgStaticTargets,
+  computeSiteOgStaticPayloadHash,
+} from '../../scripts/site-og-static-shared.ts';
+
+const ORIGIN = 'https://travelflowapp.netlify.app';
+
+const getMetadata = (pathname: string) => buildSiteOgMetadata(new URL(pathname, ORIGIN));
+
+describe('site OG metadata resolver', () => {
+  it('resolves homepage metadata', () => {
+    const metadata = getMetadata('/');
+
+    expect(metadata.routeKey).toBe('root');
+    expect(metadata.canonicalPath).toBe('/');
+    expect(metadata.canonicalUrl).toBe(`${ORIGIN}/`);
+    expect(metadata.ogImageParams.path).toBe('/');
+  });
+
+  it('resolves localized static route metadata', () => {
+    const metadata = getMetadata('/de/features');
+
+    expect(metadata.canonicalPath).toBe('/de/features');
+    expect(metadata.htmlLang).toBe('de');
+    expect(metadata.alternateLinks.some((link) => link.hreflang === 'de')).toBe(true);
+    expect(metadata.ogImageParams.path).toBe('/de/features');
+  });
+
+  it('resolves blog, country detail, and example route metadata', () => {
+    const blogMeta = getMetadata('/blog/how-to-plan-multi-city-trip');
+    expect(blogMeta.ogImageParams.blog_image).toContain('/images/blog/how-to-plan-multi-city-trip-og-vertical.jpg');
+    expect(blogMeta.ogImageParams.path).toBe('/blog/how-to-plan-multi-city-trip');
+
+    const countryMeta = getMetadata('/inspirations/country/New%20Zealand');
+    expect(countryMeta.pageTitle.toLowerCase()).toContain('new zealand');
+    expect(countryMeta.canonicalPath).toBe('/inspirations/country/New%20Zealand');
+
+    const exampleMeta = getMetadata('/example/thailand-islands');
+    expect(exampleMeta.canonicalPath).toBe('/example/thailand-islands');
+    expect(exampleMeta.pageTitle).toContain('Temples');
+    expect(exampleMeta.ogDescription).toContain('example trip template');
+  });
+});
+
+describe('site OG static generation helpers', () => {
+  it('enumerates route pathnames for static OG generation', () => {
+    const pathnames = enumerateSiteOgPathnames({
+      blogSlugs: ['how-to-plan-multi-city-trip'],
+      countryNames: ['Japan'],
+      exampleTemplateIds: ['thailand-islands'],
+    });
+
+    expect(pathnames).toContain('/');
+    expect(pathnames).toContain('/de/features');
+    expect(pathnames).toContain('/blog/how-to-plan-multi-city-trip');
+    expect(pathnames).toContain('/inspirations/country/Japan');
+    expect(pathnames).toContain('/example/thailand-islands');
+  });
+
+  it('builds deterministic payload hashes and unique target route keys', () => {
+    const metadata = getMetadata('/example/thailand-islands');
+    const payload = buildSiteOgStaticRenderPayload(metadata);
+    const hashA = computeSiteOgStaticPayloadHash(payload);
+    const hashB = computeSiteOgStaticPayloadHash(payload);
+
+    expect(hashA).toBe(hashB);
+    expect(hashA).toMatch(/^[a-f0-9]{16}$/);
+
+    const allTargets = collectSiteOgStaticTargets();
+    expect(allTargets.length).toBeGreaterThan(0);
+
+    const routeKeySet = new Set(allTargets.map((target) => target.routeKey));
+    expect(routeKeySet.size).toBe(allTargets.length);
+
+    const exampleTarget = allTargets.find((target) => target.pathname === '/example/thailand-islands');
+    expect(exampleTarget).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- extract site OG metadata + route logic into a shared resolver module used by build/runtime
- generate static OG PNG assets at build-time with deterministic hashed filenames + manifest validation
- switch `site-og-meta` to static-first OG image resolution with dynamic `/api/og/site` fallback and add `x-travelflow-og-source` tracing
- restore explicit safe edge bindings for static/localized/example routes while keeping catch-all forbidden
- expand validator/test/docs/release-note coverage for the new static OG policy

## Validation
- `pnpm og:site:build`
- `pnpm og:site:validate`
- `pnpm edge:validate`
- `pnpm updates:validate`
- `pnpm test:core`
- `pnpm vitest run tests/unit/siteOgMetadata.test.ts tests/unit/edgeValidationUtils.test.ts`
