### PR TITLE
hotfix: harden OG edge rendering and document recurrence

### DIFF
--- a/content/updates/2026-02-24-edge-availability-hotfix.md
+++ b/content/updates/2026-02-24-edge-availability-hotfix.md
@@ -14,6 +14,8 @@ summary: "Stabilizes edge availability and restores reliable custom social previ
 - [x] [Fixed] 🛟 Restored reliable page and asset loading during intermittent edge timeout spikes.
 - [x] [Fixed] 🖼️ Restored custom social previews for static pages, localized blog entries, and example trip pages.
 - [x] [Improved] ⚡ Switched static-page preview images to pre-generated assets for faster, more stable social-card delivery.
+- [x] [Fixed] 🧯 Hardened social-image rendering so temporary third-party font-network slowdowns no longer break OG image endpoints.
 - [ ] [Internal] 🧱 Added build-time static OG asset generation with deterministic hashed filenames plus manifest validation.
 - [ ] [Internal] 🛡️ Added explicit safe-route policy enforcement for metadata middleware and kept catch-all edge bindings blocked in CI.
 - [ ] [Internal] 🧭 Added static-first OG image lookup with dynamic image fallback and response tracing header (`x-travelflow-og-source`).
+- [ ] [Internal] 🌐 Removed external font-CDN fallback dependencies from OG edge image functions and enforced short font-fetch timeouts.

--- a/docs/EDGE_FUNCTIONS.md
+++ b/docs/EDGE_FUNCTIONS.md
@@ -108,7 +108,12 @@ Set required keys in **Netlify > Site settings > Environment variables**. Key na
 |---|---|---|
 | `https://esm.sh/react@18.3.1` | `site-og-image.tsx`, `trip-og-image.tsx` | 18.3.1 |
 | `https://deno.land/x/og_edge/mod.ts` | `site-og-image.tsx`, `trip-og-image.tsx` | latest (unpinned) |
-| Space Grotesk font via `cdn.jsdelivr.net` | `site-og-image.tsx`, `trip-og-image.tsx` | — |
+
+### OG font dependency policy
+
+- OG image functions must load heading fonts from local assets only (`/fonts/bricolage-grotesque/*`).
+- Do not add remote CDN font fallbacks in edge image functions.
+- Font fetch operations must stay short-lived (timeout bounded) so upstream slowness does not turn into edge 502s.
 
 ## Caching strategies
 

--- a/netlify/edge-functions/site-og-image.tsx
+++ b/netlify/edge-functions/site-og-image.tsx
@@ -1,41 +1,12 @@
 import React from "https://esm.sh/react@18.3.1";
 import { ImageResponse } from "https://deno.land/x/og_edge/mod.ts";
 import { APP_NAME } from "../../config/appGlobals.ts";
+import { buildLocalHeadingFontUrls, type BaseHeadingFontWeight } from "../edge-lib/og-font-utils.ts";
 
 const IMAGE_WIDTH = 1200;
 const IMAGE_HEIGHT = 630;
 const SITE_NAME = APP_NAME;
 const HEADLINE_FONT_FAMILY = "Bricolage Grotesque";
-const LOCAL_HEADLINE_FONT_400_LATIN_EXT_WOFF_PATH =
-  "/fonts/bricolage-grotesque/bricolage-grotesque-latin-ext-400-normal.woff";
-const LOCAL_HEADLINE_FONT_400_WOFF_PATH =
-  "/fonts/bricolage-grotesque/bricolage-grotesque-latin-400-normal.woff";
-const LOCAL_HEADLINE_FONT_700_LATIN_EXT_WOFF_PATH =
-  "/fonts/bricolage-grotesque/bricolage-grotesque-latin-ext-700-normal.woff";
-const LOCAL_HEADLINE_FONT_700_WOFF_PATH =
-  "/fonts/bricolage-grotesque/bricolage-grotesque-latin-700-normal.woff";
-const CDN_HEADLINE_FONT_400_LATIN_EXT_WOFF_URL =
-  "https://unpkg.com/@fontsource/bricolage-grotesque@5.2.10/files/bricolage-grotesque-latin-ext-400-normal.woff";
-const CDN_HEADLINE_FONT_400_WOFF_URL =
-  "https://unpkg.com/@fontsource/bricolage-grotesque@5.2.10/files/bricolage-grotesque-latin-400-normal.woff";
-const GOOGLE_HEADLINE_FONT_400_WOFF_URL =
-  "https://fonts.gstatic.com/l/font?kit=3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvRviyM4&skey=7f69194495102d00&v=v9";
-const CDN_HEADLINE_FONT_700_LATIN_EXT_WOFF_URL =
-  "https://unpkg.com/@fontsource/bricolage-grotesque@5.2.10/files/bricolage-grotesque-latin-ext-700-normal.woff";
-const CDN_HEADLINE_FONT_700_WOFF_URL =
-  "https://unpkg.com/@fontsource/bricolage-grotesque@5.2.10/files/bricolage-grotesque-latin-700-normal.woff";
-const GOOGLE_HEADLINE_FONT_700_WOFF_URL =
-  "https://fonts.gstatic.com/l/font?kit=3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvfzlyM4&skey=7f69194495102d00&v=v9";
-const LOCAL_HEADLINE_FONT_800_LATIN_EXT_WOFF_PATH =
-  "/fonts/bricolage-grotesque/bricolage-grotesque-latin-ext-800-normal.woff";
-const LOCAL_HEADLINE_FONT_800_WOFF_PATH =
-  "/fonts/bricolage-grotesque/bricolage-grotesque-latin-800-normal.woff";
-const CDN_HEADLINE_FONT_800_LATIN_EXT_WOFF_URL =
-  "https://unpkg.com/@fontsource/bricolage-grotesque@5.2.10/files/bricolage-grotesque-latin-ext-800-normal.woff";
-const CDN_HEADLINE_FONT_800_WOFF_URL =
-  "https://unpkg.com/@fontsource/bricolage-grotesque@5.2.10/files/bricolage-grotesque-latin-800-normal.woff";
-const GOOGLE_HEADLINE_FONT_800_WOFF_URL =
-  "https://fonts.gstatic.com/l/font?kit=3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvZvlyM4&skey=7f69194495102d00&v=v9";
 
 const DEFAULT_TITLE = APP_NAME;
 const DEFAULT_SUBLINE = "Plan and share travel routes with timeline and map previews.";
@@ -51,7 +22,6 @@ type LoadedHeadingFont = {
   weight: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
 };
 
-type BaseHeadingFontWeight = 400 | 700 | 800;
 type OgHeadingFontWeight = LoadedHeadingFont["weight"];
 const BASE_HEADING_FONT_WEIGHTS: readonly BaseHeadingFontWeight[] = [400, 700, 800];
 const OG_HEADING_FONT_WEIGHTS: readonly OgHeadingFontWeight[] = [100, 200, 300, 400, 500, 600, 700, 800, 900];
@@ -61,10 +31,19 @@ const WOFF_SIGNATURE = "wOFF";
 const WOFF2_SIGNATURE = "wOF2";
 const OTF_SIGNATURE = "OTTO";
 const TTC_SIGNATURE = "ttcf";
+const FONT_FETCH_TIMEOUT_MS = 900;
+
+const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    setTimeout(() => reject(new Error("font-fetch-timeout")), timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]);
+};
 
 const fetchFontArrayBuffer = async (fontUrl: string): Promise<ArrayBuffer | null> => {
   try {
-    const response = await fetch(fontUrl);
+    const response = await withTimeout(fetch(fontUrl), FONT_FETCH_TIMEOUT_MS);
     if (!response.ok) return null;
     return await response.arrayBuffer();
   } catch {
@@ -75,46 +54,7 @@ const fetchFontArrayBuffer = async (fontUrl: string): Promise<ArrayBuffer | null
 // og_edge picks the first matching font per weight and does not merge unicode-range subsets.
 // Keep full latin files first so ASCII headlines do not fall back to system fonts.
 const buildHeadingFontUrls = (requestUrl: URL, weight: BaseHeadingFontWeight): string[] => {
-  const local400LatinExt = new URL(LOCAL_HEADLINE_FONT_400_LATIN_EXT_WOFF_PATH, requestUrl.origin).toString();
-  const local400 = new URL(LOCAL_HEADLINE_FONT_400_WOFF_PATH, requestUrl.origin).toString();
-  const local700LatinExt = new URL(LOCAL_HEADLINE_FONT_700_LATIN_EXT_WOFF_PATH, requestUrl.origin).toString();
-  const local700 = new URL(LOCAL_HEADLINE_FONT_700_WOFF_PATH, requestUrl.origin).toString();
-  const cdn400LatinExt = CDN_HEADLINE_FONT_400_LATIN_EXT_WOFF_URL;
-  const cdn400 = CDN_HEADLINE_FONT_400_WOFF_URL;
-  const cdn700LatinExt = CDN_HEADLINE_FONT_700_LATIN_EXT_WOFF_URL;
-  const local800 = new URL(LOCAL_HEADLINE_FONT_800_WOFF_PATH, requestUrl.origin).toString();
-  const local800LatinExt = new URL(LOCAL_HEADLINE_FONT_800_LATIN_EXT_WOFF_PATH, requestUrl.origin).toString();
-  const cdn700 = CDN_HEADLINE_FONT_700_WOFF_URL;
-  const cdn800LatinExt = CDN_HEADLINE_FONT_800_LATIN_EXT_WOFF_URL;
-  const cdn800 = CDN_HEADLINE_FONT_800_WOFF_URL;
-
-  if (weight === 800) {
-    return [
-      local800,
-      local800LatinExt,
-      GOOGLE_HEADLINE_FONT_800_WOFF_URL,
-      cdn800,
-      cdn800LatinExt,
-    ];
-  }
-
-  if (weight === 700) {
-    return [
-      local700,
-      local700LatinExt,
-      GOOGLE_HEADLINE_FONT_700_WOFF_URL,
-      cdn700,
-      cdn700LatinExt,
-    ];
-  }
-
-  return [
-    local400,
-    local400LatinExt,
-    GOOGLE_HEADLINE_FONT_400_WOFF_URL,
-    cdn400,
-    cdn400LatinExt,
-  ];
+  return buildLocalHeadingFontUrls(requestUrl.origin, weight);
 };
 
 const isSupportedOgFont = (fontData: ArrayBuffer): boolean => {

--- a/netlify/edge-lib/og-font-utils.ts
+++ b/netlify/edge-lib/og-font-utils.ts
@@ -1,0 +1,20 @@
+export type BaseHeadingFontWeight = 400 | 700 | 800;
+
+const LOCAL_HEADLINE_FONT_PATHS: Record<BaseHeadingFontWeight, string[]> = {
+  400: [
+    "/fonts/bricolage-grotesque/bricolage-grotesque-latin-400-normal.woff",
+    "/fonts/bricolage-grotesque/bricolage-grotesque-latin-ext-400-normal.woff",
+  ],
+  700: [
+    "/fonts/bricolage-grotesque/bricolage-grotesque-latin-700-normal.woff",
+    "/fonts/bricolage-grotesque/bricolage-grotesque-latin-ext-700-normal.woff",
+  ],
+  800: [
+    "/fonts/bricolage-grotesque/bricolage-grotesque-latin-800-normal.woff",
+    "/fonts/bricolage-grotesque/bricolage-grotesque-latin-ext-800-normal.woff",
+  ],
+};
+
+export const buildLocalHeadingFontUrls = (origin: string, weight: BaseHeadingFontWeight): string[] => {
+  return LOCAL_HEADLINE_FONT_PATHS[weight].map((path) => new URL(path, origin).toString());
+};

--- a/tests/unit/ogFontUtils.test.ts
+++ b/tests/unit/ogFontUtils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { buildLocalHeadingFontUrls } from '../../netlify/edge-lib/og-font-utils.ts';
+
+describe('og font utils', () => {
+  it('builds local-only font URLs for each supported weight', () => {
+    const origin = 'https://travelflowapp.netlify.app';
+
+    const urls400 = buildLocalHeadingFontUrls(origin, 400);
+    const urls700 = buildLocalHeadingFontUrls(origin, 700);
+    const urls800 = buildLocalHeadingFontUrls(origin, 800);
+
+    for (const urls of [urls400, urls700, urls800]) {
+      expect(urls).toHaveLength(2);
+      for (const url of urls) {
+        expect(url.startsWith(`${origin}/fonts/bricolage-grotesque/`)).toBe(true);
+        expect(url.includes('unpkg.com')).toBe(false);
+        expect(url.includes('fonts.gstatic.com')).toBe(false);
+      }
+    }
+
+    expect(urls400[0]).toContain('latin-400-normal.woff');
+    expect(urls700[0]).toContain('latin-700-normal.woff');
+    expect(urls800[0]).toContain('latin-800-normal.woff');
+  });
+});


### PR DESCRIPTION
## Investigation summary
- I validated production directly and repeatedly: `/`, `/api/og/playground`, and `/api/og/site?...` currently return `200` from this session.
- I could not reproduce the outage at investigation time, but your reported symptoms match edge upstream timeout behavior.
- The strongest remaining risk path in code was external font CDN fallback inside OG image generators (`site-og-image`, `trip-og-image`), which can stall edge render requests on upstream network issues.

## What this PR changes
- remove external font CDN fallback dependencies from OG image functions (`unpkg`, `fonts.gstatic.com`)
- keep OG font loading local-only from `/fonts/bricolage-grotesque/*`
- enforce short fetch timeouts for font reads to fail fast instead of waiting on slow upstreams
- add unit coverage for local-only OG font URL resolution
- update incident postmortem with recurrence + this mitigation
- update edge docs and release draft notes

## Validation
- `pnpm test:core`
- `pnpm edge:validate`
- `pnpm updates:validate`
- `pnpm vitest run tests/unit/ogFontUtils.test.ts`
