### PR TITLE
fix: use trip-style OG previews for example templates

### DIFF
--- a/content/updates/2026-02-24-edge-availability-hotfix.md
+++ b/content/updates/2026-02-24-edge-availability-hotfix.md
@@ -15,7 +15,9 @@ summary: "Stabilizes edge availability and restores reliable custom social previ
 - [x] [Fixed] 🖼️ Restored custom social previews for static pages, localized blog entries, and example trip pages.
 - [x] [Improved] ⚡ Switched static-page preview images to pre-generated assets for faster, more stable social-card delivery.
 - [x] [Fixed] 🧯 Hardened social-image rendering so temporary third-party font-network slowdowns no longer break OG image endpoints.
+- [x] [Fixed] 🧭 Updated example template social previews to use the same trip-card style as shared trip previews.
 - [ ] [Internal] 🧱 Added build-time static OG asset generation with deterministic hashed filenames plus manifest validation.
 - [ ] [Internal] 🛡️ Added explicit safe-route policy enforcement for metadata middleware and kept catch-all edge bindings blocked in CI.
 - [ ] [Internal] 🧭 Added static-first OG image lookup with dynamic image fallback and response tracing header (`x-travelflow-og-source`).
 - [ ] [Internal] 🌐 Removed external font-CDN fallback dependencies from OG edge image functions and enforced short font-fetch timeouts.
+- [ ] [Internal] 🗺️ Routed `/example/*` OG images through trip-style renderer overrides while preserving static-site OG coverage for other marketing paths.

--- a/docs/EDGE_FUNCTIONS.md
+++ b/docs/EDGE_FUNCTIONS.md
@@ -31,6 +31,10 @@ Blog pages ──▶ site-og-meta.ts ──context.next()──▶ SPA index.htm
                          │
                          └─▶ fallback OG URL (`/api/og/site?...`) when no static match
 
+Example template pages (`/example/*`) ──▶ site-og-meta.ts ──▶ force dynamic OG (`/api/og/trip?...`)
+                         │
+                         └─▶ skips static-site manifest so example previews match trip/share card layout
+
 Trip/share pages ──▶ trip-og-meta.ts ──context.next()──▶ SPA index.html
                          │
                          ▼ (OG image URL points to)

--- a/docs/incidents/2026-02-24-edge-timeout-site-outage.md
+++ b/docs/incidents/2026-02-24-edge-timeout-site-outage.md
@@ -35,6 +35,8 @@ The primary blast radius came from a catch-all edge middleware route (`[[edge_fu
 - 2026-02-24 ~19:xx UTC: remediation narrowed `site-og-meta` to blog-only routes and added edge fallback logic for upstream lookup failures.
 - 2026-02-24 ~19:38 UTC: follow-up reports showed intermittent `Upstream lookup timed out` on OG endpoints (`/api/og/site`, `/api/og/playground`) during the static OG rollout window.
 - 2026-02-24 ~19:xx UTC: additional hardening removed remote font-CDN fallback dependencies in OG image functions and enforced short font-fetch timeouts to avoid long edge waits on third-party upstreams.
+- 2026-02-24 ~20:xx UTC: follow-up QA reported degraded `/example/*` OG card quality (layout mismatch versus trip/share previews) because static-site renderer output was being used for example routes.
+- 2026-02-24 ~20:xx UTC: remediation switched `/example/*` OG images to trip-card rendering (`/api/og/trip` with template overrides), bypassing static-site image usage for those routes.
 
 ## Root Cause
 The production site had a catch-all edge middleware route:
@@ -58,6 +60,7 @@ When upstream edge lookups timed out, this catch-all interception turned localiz
 ## What Did Not Work
 - Detection was user-driven, not monitor-driven.
 - The edge routing policy allowed a high blast-radius config in production.
+- Static site-style OG rendering for example templates did not match expected trip preview quality.
 
 ## Corrective Actions
 
@@ -73,6 +76,7 @@ When upstream edge lookups timed out, this catch-all interception turned localiz
 - Added build validation to guarantee manifest/asset coverage for all static OG route keys.
 - Removed remote font-CDN fallbacks from `/api/og/site` and `/api/og/trip` image rendering and limited font fetch waits with request-level timeouts.
 - Added regression test coverage for OG font URL resolution to ensure only local font assets are used.
+- Updated `/example/*` OG behavior to use trip-style OG rendering so example templates match trip/share social card presentation.
 
 ### Planned follow-ups (high priority)
 - Add synthetic monitoring checks (every 1 minute):

--- a/netlify/edge-functions/site-og-meta.ts
+++ b/netlify/edge-functions/site-og-meta.ts
@@ -1,7 +1,6 @@
 import {
   SITE_CACHE_CONTROL,
   TOOL_APP_CACHE_CONTROL,
-  buildDynamicSiteOgImageUrl,
   buildSiteOgMetadata,
   injectMetaTags,
   shouldUseStrictToolHtmlCache,
@@ -78,6 +77,14 @@ const resolveOgImageUrl = async (
   origin: string,
   metadata: SiteOgMetadata,
 ): Promise<{ ogImageUrl: string; source: "static" | "dynamic" }> => {
+  const prefersDynamicTripCard = metadata.canonicalPath.startsWith("/example/");
+  if (prefersDynamicTripCard) {
+    return {
+      ogImageUrl: metadata.ogImageUrl,
+      source: "dynamic",
+    };
+  }
+
   const manifest = await loadStaticManifest(origin);
   const manifestEntry = manifest?.entries?.[metadata.routeKey];
 
@@ -92,7 +99,7 @@ const resolveOgImageUrl = async (
   }
 
   return {
-    ogImageUrl: buildDynamicSiteOgImageUrl(origin, metadata.ogImageParams),
+    ogImageUrl: metadata.ogImageUrl,
     source: "dynamic",
   };
 };

--- a/tests/unit/siteOgMetadata.test.ts
+++ b/tests/unit/siteOgMetadata.test.ts
@@ -45,6 +45,9 @@ describe('site OG metadata resolver', () => {
     expect(exampleMeta.canonicalPath).toBe('/example/thailand-islands');
     expect(exampleMeta.pageTitle).toContain('Temples');
     expect(exampleMeta.ogDescription).toContain('example trip template');
+    expect(exampleMeta.ogImageUrl).toContain('/api/og/trip?');
+    expect(exampleMeta.ogImageUrl).toContain('title=26D+Temples+%26+Beaches');
+    expect(exampleMeta.ogImageUrl).toContain('map=https%3A%2F%2Ftravelflowapp.netlify.app%2Fimages%2Ftrip-maps%2Fthailand-islands.png');
   });
 });
 


### PR DESCRIPTION
## What changed
- route `/example/*` OG images to trip-style renderer output (`/api/og/trip` overrides) instead of static site-card assets
- keep static OG for other static marketing routes
- update incident postmortem/docs/release draft for this regression + fix
- extend site OG metadata tests to assert example routes now resolve trip-style OG URL

## Why
- the static site-card renderer made example previews look broken/misaligned vs trip/share cards
- example templates should visually match trip preview cards with map panel

## Validation
- `pnpm test:core`
- `pnpm edge:validate`
- `pnpm updates:validate`
- `pnpm vitest run tests/unit/siteOgMetadata.test.ts tests/unit/ogFontUtils.test.ts tests/unit/edgeValidationUtils.test.ts`

## Investigation note
- production was healthy at investigation time (no reproducible 5xx), so this PR only targets the example-card visual mismatch and leaves the prior font-timeout hardening in place.
