### PR TITLE
chore(release): publish trip generation background feedback v0.60.0

### DIFF
--- a/content/updates/2026-02-24-trip-generation-background-feedback.md
+++ b/content/updates/2026-02-24-trip-generation-background-feedback.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-02-24-trip-generation-background-feedback
-version: v0.59.0
+version: v0.60.0
 title: "Trip generation background feedback"
 date: 2026-02-24
-published_at: 2026-02-24T21:40:00Z
-status: draft
+published_at: 2026-02-24T20:21:10Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Adds background progress and completion signals so long-running trip generation stays clear even when users switch tabs."


### PR DESCRIPTION
## Summary
- publish the release note entry for the merged Issue #145 feature
- switch `content/updates/2026-02-24-trip-generation-background-feedback.md` from `draft` to `published`
- set `published_at` to the actual merge timestamp (`2026-02-24T20:21:10Z`)
- bump version to canonical next published version (`v0.60.0`)

## Related Issues
- Refs #145
- Closes #145

## Validation
- [x] `pnpm test:core`
- [x] `pnpm build`
- [x] `pnpm storage:validate`

## New Module Guard
- [x] New module guard completed
- [x] If I added files under `services/` or `config/`, I listed matching `tests/**` paths below.

### Matching `tests/**` Entries (required when adding `services/` or `config/` files)
- `tests/...` (not applicable; no `services/` or `config/` files added)
