### PR TITLE
Fix edge bundling for ai provider catalog import

### DIFF
--- a/config/aiModelCatalog.ts
+++ b/config/aiModelCatalog.ts
@@ -2,7 +2,7 @@ import {
     type AiProviderId,
     getAiProviderMetadata,
     getAiProviderSortOrder,
-} from './aiProviderCatalog';
+} from './aiProviderCatalog.ts';
 
 export type AiModelAvailability = 'active' | 'planned';
 

--- a/content/updates/2026-02-11-ai-backend-target-architecture.md
+++ b/content/updates/2026-02-11-ai-backend-target-architecture.md
@@ -96,3 +96,4 @@ summary: "Implemented the first operational benchmark stack with persisted sessi
 - [ ] [Internal] 🏷️ Added Perplexity/Qwen benchmark provider families (`Sonnar`, `Sonnar Pro`, `Qwen 3.5 Plus`, `Qwen 3.5`) with short-name metadata plus bundled brand-logo assets (provider + routed model vendors) across admin benchmark and telemetry model surfaces.
 - [ ] [Internal] 🎚️ Added per-pill benchmark target controls to temporarily deactivate models for `Test all` and trigger a single-model run directly from the target chip.
 - [ ] [Internal] 🧰 Added quick `Activate all` / `Deactivate all` target actions in `/admin/ai-benchmark` so benchmark model pools can be toggled in one click.
+- [ ] [Internal] 🧯 Fixed edge bundling regression by switching benchmark model-catalog provider metadata import to explicit `.ts` extension for Deno-compatible module resolution.


### PR DESCRIPTION
## Summary
- fix Netlify Edge bundling failure by making the provider catalog import in `config/aiModelCatalog.ts` explicitly Deno-resolvable (`./aiProviderCatalog.ts`)
- add internal release-note entry documenting the edge bundling regression fix

## Validation
- `pnpm updates:validate`
- `pnpm vitest run tests/unit/aiModelCatalog.test.ts tests/unit/aiProviderCatalog.test.ts tests/unit/aiProviderRuntime.test.ts`
- `pnpm test:core`
- `npx netlify build` (local; confirms `Edge Functions bundling completed`)

## Checklist
- [x] New module guard completed
- [x] Existing tests cover touched config import graph:
  - `tests/unit/aiModelCatalog.test.ts`
  - `tests/unit/aiProviderCatalog.test.ts`
  - `tests/unit/aiProviderRuntime.test.ts`
