### PR TITLE
Fix Qwen benchmark model IDs for OpenRouter

### DIFF
--- a/config/aiModelCatalog.ts
+++ b/config/aiModelCatalog.ts
@@ -227,9 +227,9 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
         costNote: 'Requires OPENROUTER_API_KEY on server. Perplexity benchmark calls are routed via OpenRouter for unified execution.',
     },
     {
-        id: 'qwen:qwen/qwen-3.5-plus',
+        id: 'qwen:qwen/qwen3.5-plus-02-15',
         provider: 'qwen',
-        model: 'qwen/qwen-3.5-plus',
+        model: 'qwen/qwen3.5-plus-02-15',
         label: 'Qwen 3.5 Plus',
         availability: 'active',
         releasedAt: '2026-02-22',
@@ -238,9 +238,9 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
         costNote: 'Requires OPENROUTER_API_KEY on server. Qwen benchmark calls are routed via OpenRouter for unified execution.',
     },
     {
-        id: 'qwen:qwen/qwen-3.5',
+        id: 'qwen:qwen/qwen3.5-397b-a17b',
         provider: 'qwen',
-        model: 'qwen/qwen-3.5',
+        model: 'qwen/qwen3.5-397b-a17b',
         label: 'Qwen 3.5',
         availability: 'active',
         releasedAt: '2026-02-22',

--- a/content/updates/2026-02-11-ai-backend-target-architecture.md
+++ b/content/updates/2026-02-11-ai-backend-target-architecture.md
@@ -97,3 +97,4 @@ summary: "Implemented the first operational benchmark stack with persisted sessi
 - [ ] [Internal] 🎚️ Added per-pill benchmark target controls to temporarily deactivate models for `Test all` and trigger a single-model run directly from the target chip.
 - [ ] [Internal] 🧰 Added quick `Activate all` / `Deactivate all` target actions in `/admin/ai-benchmark` so benchmark model pools can be toggled in one click.
 - [ ] [Internal] 🧯 Fixed edge bundling regression by switching benchmark model-catalog provider metadata import to explicit `.ts` extension for Deno-compatible module resolution.
+- [ ] [Internal] 🛠️ Updated Qwen benchmark/runtime model IDs to valid OpenRouter slugs (`qwen3.5-plus-02-15`, `qwen3.5-397b-a17b`) and added legacy-ID aliasing to keep older saved target payloads working.

--- a/netlify/edge-lib/ai-provider-runtime.ts
+++ b/netlify/edge-lib/ai-provider-runtime.ts
@@ -75,9 +75,16 @@ export const PROVIDER_ALLOWLIST: Record<string, Set<string>> = {
     "perplexity/sonar-pro",
   ]),
   qwen: new Set([
-    "qwen/qwen-3.5-plus",
-    "qwen/qwen-3.5",
+    "qwen/qwen3.5-plus-02-15",
+    "qwen/qwen3.5-397b-a17b",
   ]),
+};
+
+const PROVIDER_MODEL_ALIASES: Record<string, Record<string, string>> = {
+  qwen: {
+    "qwen/qwen-3.5-plus": "qwen/qwen3.5-plus-02-15",
+    "qwen/qwen-3.5": "qwen/qwen3.5-397b-a17b",
+  },
 };
 
 export const GEMINI_DEFAULT_MODEL = "gemini-3-pro-preview";
@@ -386,7 +393,9 @@ export const ensureModelAllowed = (
     };
   }
 
-  if (!allowlist.has(model)) {
+  const resolvedModel = PROVIDER_MODEL_ALIASES[provider]?.[model] ?? model;
+
+  if (!allowlist.has(resolvedModel)) {
     return {
       error: `Model '${model}' is not enabled for provider '${provider}'.`,
       code: "MODEL_NOT_ALLOWED",
@@ -1180,7 +1189,8 @@ export const generateProviderItinerary = async (
   options: ProviderGenerationOptions,
 ): Promise<ProviderGenerationResult> => {
   const provider = options.provider.trim().toLowerCase();
-  const model = options.model.trim();
+  const requestedModel = options.model.trim();
+  const model = PROVIDER_MODEL_ALIASES[provider]?.[requestedModel] ?? requestedModel;
   const maxOutputTokens = resolveOutputTokenBudget(options.maxOutputTokens);
 
   const allowlistError = ensureModelAllowed(provider, model);

--- a/services/aiBenchmarkPreferencesService.ts
+++ b/services/aiBenchmarkPreferencesService.ts
@@ -44,7 +44,7 @@ export const BENCHMARK_DEFAULT_MODEL_IDS = [
     'openai:gpt-5.2-pro',
     'anthropic:claude-sonnet-4.6',
     'perplexity:perplexity/sonar',
-    'qwen:qwen/qwen-3.5-plus',
+    'qwen:qwen/qwen3.5-plus-02-15',
 ];
 
 export const DEFAULT_BENCHMARK_MASK_SCENARIO: BenchmarkMaskScenario = {

--- a/tests/unit/aiBenchmarkTargets.test.ts
+++ b/tests/unit/aiBenchmarkTargets.test.ts
@@ -30,14 +30,14 @@ describe('utils/aiBenchmarkTargets', () => {
     const selectedTargets: AiBenchmarkTargetModel[] = [
       { id: 'a', provider: 'openai', model: 'openai/gpt-5-mini', label: 'GPT 5 mini' },
       { id: 'b', provider: 'perplexity', model: 'perplexity/sonar', label: 'Sonnar' },
-      { id: 'c', provider: 'qwen', model: 'qwen/qwen-3.5-plus', label: 'Qwen 3.5 Plus' },
+      { id: 'c', provider: 'qwen', model: 'qwen/qwen3.5-plus-02-15', label: 'Qwen 3.5 Plus' },
     ];
 
     const runnable = buildRunnableBenchmarkTargets(selectedTargets, ['b']);
 
     expect(runnable).toEqual([
       { provider: 'openai', model: 'openai/gpt-5-mini', label: 'GPT 5 mini' },
-      { provider: 'qwen', model: 'qwen/qwen-3.5-plus', label: 'Qwen 3.5 Plus' },
+      { provider: 'qwen', model: 'qwen/qwen3.5-plus-02-15', label: 'Qwen 3.5 Plus' },
     ]);
   });
 

--- a/tests/unit/aiModelCatalog.test.ts
+++ b/tests/unit/aiModelCatalog.test.ts
@@ -23,8 +23,8 @@ describe('config/aiModelCatalog', () => {
     expect(modelIds.has('openrouter:moonshotai/kimi-k2.5')).toBe(true);
     expect(modelIds.has('perplexity:perplexity/sonar')).toBe(true);
     expect(modelIds.has('perplexity:perplexity/sonar-pro')).toBe(true);
-    expect(modelIds.has('qwen:qwen/qwen-3.5-plus')).toBe(true);
-    expect(modelIds.has('qwen:qwen/qwen-3.5')).toBe(true);
+    expect(modelIds.has('qwen:qwen/qwen3.5-plus-02-15')).toBe(true);
+    expect(modelIds.has('qwen:qwen/qwen3.5-397b-a17b')).toBe(true);
   });
 
   it('keeps runtime/default model wiring intact', () => {

--- a/tests/unit/aiProviderRuntime.test.ts
+++ b/tests/unit/aiProviderRuntime.test.ts
@@ -36,6 +36,7 @@ describe('netlify/edge-lib/ai-provider-runtime', () => {
     expect(ensureModelAllowed('openrouter', 'z-ai/glm-5')).toBeNull();
     expect(ensureModelAllowed('anthropic', 'claude-sonnet-4.6')).toBeNull();
     expect(ensureModelAllowed('perplexity', 'perplexity/sonar')).toBeNull();
+    expect(ensureModelAllowed('qwen', 'qwen/qwen3.5-plus-02-15')).toBeNull();
     expect(ensureModelAllowed('qwen', 'qwen/qwen-3.5-plus')).toBeNull();
     expect(ensureModelAllowed('openrouter', 'missing-model')?.code).toBe('MODEL_NOT_ALLOWED');
     expect(ensureModelAllowed('unknown-provider', 'x')?.code).toBe('PROVIDER_NOT_SUPPORTED');
@@ -321,7 +322,7 @@ describe('netlify/edge-lib/ai-provider-runtime', () => {
       )
       .mockResolvedValueOnce(
         jsonResponse({
-          model: 'qwen/qwen-3.5-plus',
+          model: 'qwen/qwen3.5-plus-02-15',
           choices: [{ message: { content: '{"title":"Qwen"}' } }],
           usage: { prompt_tokens: 4, completion_tokens: 5, total_tokens: 9 },
         }),
@@ -343,6 +344,9 @@ describe('netlify/edge-lib/ai-provider-runtime', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect((fetchMock.mock.calls[0] as [string])[0]).toBe('https://openrouter.ai/api/v1/chat/completions');
     expect((fetchMock.mock.calls[1] as [string])[0]).toBe('https://openrouter.ai/api/v1/chat/completions');
+    const qwenRequest = (fetchMock.mock.calls[1] as [string, RequestInit])[1];
+    const qwenBody = JSON.parse(String(qwenRequest.body));
+    expect(qwenBody.model).toBe('qwen/qwen3.5-plus-02-15');
 
     expect(perplexityResult.ok).toBe(true);
     if (perplexityResult.ok) {
@@ -353,7 +357,7 @@ describe('netlify/edge-lib/ai-provider-runtime', () => {
     expect(qwenResult.ok).toBe(true);
     if (qwenResult.ok) {
       expect(qwenResult.value.meta.provider).toBe('qwen');
-      expect(qwenResult.value.meta.model).toBe('qwen/qwen-3.5-plus');
+      expect(qwenResult.value.meta.model).toBe('qwen/qwen3.5-plus-02-15');
     }
   });
 


### PR DESCRIPTION
## Summary
- replace invalid Qwen benchmark model IDs with current OpenRouter model slugs
- update benchmark defaults so new sessions select the valid Qwen 3.5 Plus target
- add legacy alias mapping in provider runtime so older saved payloads using `qwen/qwen-3.5` or `qwen/qwen-3.5-plus` still execute
- update/add regression coverage for catalog IDs, target filtering, and runtime alias routing

## Validation
- `pnpm vitest run tests/unit/aiModelCatalog.test.ts tests/unit/aiProviderRuntime.test.ts tests/unit/aiBenchmarkTargets.test.ts tests/unit/aiBenchmarkPreferencesService.test.ts`
- `pnpm test:core`
- `pnpm build`
