### PR TITLE
Fix static OG cache persistence across failed builds

### DIFF
--- a/content/updates/2026-02-24-edge-availability-hotfix.md
+++ b/content/updates/2026-02-24-edge-availability-hotfix.md
@@ -23,6 +23,7 @@ summary: "Stabilizes edge availability and restores reliable custom social previ
 - [ ] [Internal] 🌐 Removed external font-CDN fallback dependencies from OG edge image functions and enforced short font-fetch timeouts.
 - [ ] [Internal] 🗺️ Routed `/example/*` OG images through trip-style renderer overrides while preserving static-site OG coverage for other marketing paths.
 - [ ] [Internal] ♻️ Added Netlify build-cache restore/save for static OG assets so unchanged generated social-preview images can be reused across CI deploys.
+- [ ] [Internal] 🧰 Hardened static OG cache persistence by saving cache artifacts on failed Netlify builds too, preventing repeated full regenerations after unrelated build errors.
 - [ ] [Internal] 🧪 Added Netlify secret-scan guardrails for public browser key prefixes used in client-side map integrations, including disabling enhanced smart detection to prevent repeated preview deploy false positives.
 - [ ] [Internal] 🛠️ Added `/admin/og-tools` with a same-origin OG inspector showing canonical/OG/Twitter tags plus static-vs-dynamic source detection.
 - [ ] [Internal] 🧭 Added filtered static OG command builder support (`--locales`, include/exclude paths/prefixes) with documented release-safe full validation flow.


### PR DESCRIPTION
## Summary
- persist static OG cache even on failed Netlify builds (`onError`) to avoid repeated full OG regeneration on the next successful build
- ensure cache directory exists before restore/save operations for safer plugin behavior
- add regression coverage for `onError` cache save and directory creation helper

## Validation
- `pnpm vitest run tests/unit/siteOgBuildCachePlugin.test.ts`
- `pnpm test:core`
- `pnpm updates:validate`
