### PR TITLE
Fix Perplexity/Qwen OpenRouter response-format compatibility

### DIFF
--- a/content/updates/2026-02-11-ai-backend-target-architecture.md
+++ b/content/updates/2026-02-11-ai-backend-target-architecture.md
@@ -98,3 +98,4 @@ summary: "Implemented the first operational benchmark stack with persisted sessi
 - [ ] [Internal] 🧰 Added quick `Activate all` / `Deactivate all` target actions in `/admin/ai-benchmark` so benchmark model pools can be toggled in one click.
 - [ ] [Internal] 🧯 Fixed edge bundling regression by switching benchmark model-catalog provider metadata import to explicit `.ts` extension for Deno-compatible module resolution.
 - [ ] [Internal] 🛠️ Updated Qwen benchmark/runtime model IDs to valid OpenRouter slugs (`qwen3.5-plus-02-15`, `qwen3.5-397b-a17b`) and added legacy-ID aliasing to keep older saved target payloads working.
+- [ ] [Internal] 🔧 Switched OpenRouter benchmark `response_format` to provider-compatible text mode so Perplexity and Qwen routes no longer fail on unsupported `json_object` schema validation.

--- a/netlify/edge-lib/ai-provider-runtime.ts
+++ b/netlify/edge-lib/ai-provider-runtime.ts
@@ -1051,7 +1051,7 @@ const generateWithOpenRouter = async (
             model,
             max_tokens: maxOutputTokens,
             temperature: 0.2,
-            response_format: { type: "json_object" },
+            response_format: { type: "text" },
             messages: [
               {
                 role: "system",

--- a/tests/unit/aiProviderRuntime.test.ts
+++ b/tests/unit/aiProviderRuntime.test.ts
@@ -344,9 +344,14 @@ describe('netlify/edge-lib/ai-provider-runtime', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect((fetchMock.mock.calls[0] as [string])[0]).toBe('https://openrouter.ai/api/v1/chat/completions');
     expect((fetchMock.mock.calls[1] as [string])[0]).toBe('https://openrouter.ai/api/v1/chat/completions');
+    const perplexityRequest = (fetchMock.mock.calls[0] as [string, RequestInit])[1];
+    const perplexityBody = JSON.parse(String(perplexityRequest.body));
+    expect(perplexityBody.model).toBe('perplexity/sonar');
+    expect(perplexityBody.response_format?.type).toBe('text');
     const qwenRequest = (fetchMock.mock.calls[1] as [string, RequestInit])[1];
     const qwenBody = JSON.parse(String(qwenRequest.body));
     expect(qwenBody.model).toBe('qwen/qwen3.5-plus-02-15');
+    expect(qwenBody.response_format?.type).toBe('text');
 
     expect(perplexityResult.ok).toBe(true);
     if (perplexityResult.ok) {


### PR DESCRIPTION
## Summary
- switch OpenRouter benchmark/runtime calls from `response_format: { type: "json_object" }` to `response_format: { type: "text" }` for provider compatibility
- keep strict JSON output via system prompt + existing parse/strict-retry logic
- extend runtime regression coverage to assert Perplexity/Qwen OpenRouter request payloads now use `response_format.type = "text"`

## Validation
- `pnpm vitest run tests/unit/aiProviderRuntime.test.ts`
- `pnpm test:core`
- `pnpm updates:validate`
- OpenRouter model availability check:
  - `perplexity/sonar`
  - `perplexity/sonar-pro`
  - `qwen/qwen3.5-plus-02-15`
  - `qwen/qwen3.5-397b-a17b`
