### PR TITLE
Telemetry: provider logos in charts and full month daily cost history

### DIFF
--- a/content/updates/2026-02-11-ai-backend-target-architecture.md
+++ b/content/updates/2026-02-11-ai-backend-target-architecture.md
@@ -99,3 +99,5 @@ summary: "Implemented the first operational benchmark stack with persisted sessi
 - [ ] [Internal] 🧯 Fixed edge bundling regression by switching benchmark model-catalog provider metadata import to explicit `.ts` extension for Deno-compatible module resolution.
 - [ ] [Internal] 🛠️ Updated Qwen benchmark/runtime model IDs to valid OpenRouter slugs (`qwen3.5-plus-02-15`, `qwen3.5-397b-a17b`) and added legacy-ID aliasing to keep older saved target payloads working.
 - [ ] [Internal] 🔧 Switched OpenRouter benchmark `response_format` to provider-compatible text mode so Perplexity and Qwen routes no longer fail on unsupported `json_object` schema validation.
+- [ ] [Internal] 🏷️ Added provider-logo labels in telemetry model bar charts plus provider-logo custom tooltips for Tremor provider charts (`Provider breakdown`, `Provider success rate`, `Provider cost per success`) where custom rendering is supported.
+- [ ] [Internal] 📅 Expanded `Total cost per day (Current Month)` to render full day-by-day month history (including zero-cost days) instead of only returned aggregate days.

--- a/tests/unit/adminAiTelemetryChartData.test.ts
+++ b/tests/unit/adminAiTelemetryChartData.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildCurrentMonthDailyCostHistory,
   buildFailureCodeBarListData,
   buildProviderCostPerSuccessChartData,
   buildProviderDonutEntries,
@@ -156,5 +157,24 @@ describe('services/adminAiTelemetryChartData', () => {
     expect(barListRows).toHaveLength(2);
     expect(barListRows[0]).toMatchObject({ key: 'OPENAI_REQUEST_FAILED', value: 2 });
     expect(barListRows[1]).toMatchObject({ key: 'UNKNOWN_ERROR', value: 2 });
+  });
+
+  it('builds current-month daily cost history with missing days filled as zero', () => {
+    const rows = [
+      { date: '2026-02-01', cost: 0.5 },
+      { date: '2026-02-03', cost: 0.2 },
+      { date: '2026-02-03', cost: 0.1 },
+      { date: '2026-01-31', cost: 9.99 },
+      { date: 'invalid', cost: 3 },
+    ];
+
+    const series = buildCurrentMonthDailyCostHistory(rows, new Date('2026-02-05T11:30:00Z'));
+    expect(series).toEqual([
+      { date: '2026-02-01', cost: 0.5 },
+      { date: '2026-02-02', cost: 0 },
+      { date: '2026-02-03', cost: 0.3 },
+      { date: '2026-02-04', cost: 0 },
+      { date: '2026-02-05', cost: 0 },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add provider-logo labels in telemetry model bar charts (Top models by speed/cost/value/success-rate and Model call volume)
- add custom Tremor tooltips with provider logos for provider comparison charts:
  - Provider breakdown
  - Provider success rate
  - Provider cost per success
- expand current-month cost chart data to always include day-by-day history from month start through today (zero-filled for missing days)
- add regression coverage for monthly daily cost-history normalization/fill behavior

## Validation
- `pnpm vitest run tests/unit/adminAiTelemetryChartData.test.ts`
- `pnpm test:core`
- `pnpm exec vite build`
- `pnpm updates:validate`
