### PR TITLE
Fix static OG footer host for pre-generated images

### DIFF
--- a/content/updates/2026-02-25-site-og-build-reliability-hotfix.md
+++ b/content/updates/2026-02-25-site-og-build-reliability-hotfix.md
@@ -12,6 +12,7 @@ summary: "Production builds now use a more resilient static OG rendering pass to
 
 ## Changes
 - [x] [Fixed] 🛠️ Social preview generation is now more resilient during production deploys, reducing the chance of failed releases caused by transient rendering errors.
+- [x] [Fixed] 🌐 Pre-generated social previews now consistently render the canonical public domain in the footer instead of local build host addresses.
 - [x] [Improved] ⚡ Static social preview generation now focuses on high-impact pages first, cutting production build workload while keeping dynamic fallback previews for all other routes.
 - [ ] [Internal] 🧱 Added retry + safe fallback rendering in the static OG Deno batch pass and tuned default renderer concurrency for faster, steadier CI execution.
 - [ ] [Internal] 📋 Added full-scope override commands (`pnpm og:site:build:full` + `pnpm og:site:validate:full`) plus updated admin/docs guidance so teams can intentionally widen pre-generation coverage when needed.

--- a/docs/EDGE_FUNCTIONS.md
+++ b/docs/EDGE_FUNCTIONS.md
@@ -84,6 +84,7 @@ The CI validator (`scripts/validate-edge-functions.mjs`) enforces this rule at b
   - All non-default pages fall back to dynamic OG image URLs (`/api/og/site` or `/api/og/trip`) with edge caching.
   - Writes hashed PNG assets to `public/images/og/site/generated/`.
   - Writes `public/images/og/site/generated/manifest.json`.
+  - Injects `display_host` from `SITE_OG_BUILD_ORIGIN` so static OG footer URLs always show the canonical public domain (not local build hosts).
   - Full-scope override: run `pnpm og:site:build:full` to generate every supported static path (marketing/legal/create-trip/blog detail/inspirations detail).
   - Supports optional route filters:
     - `--locales=en,de`

--- a/netlify/edge-functions/site-og-image.tsx
+++ b/netlify/edge-functions/site-og-image.tsx
@@ -168,6 +168,20 @@ const normalizePath = (value: string | null): string => {
   return `/${trimmed}`;
 };
 
+const normalizeDisplayHost = (value: string | null, fallbackHost: string): string => {
+  if (!value) return fallbackHost;
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return fallbackHost;
+
+  try {
+    const parsed = new URL(`https://${trimmed}`);
+    if (parsed.host !== trimmed) return fallbackHost;
+    return parsed.host;
+  } catch {
+    return fallbackHost;
+  }
+};
+
 const BLOG_IMAGE_PATH_REGEX = /^\/images\/blog\/[a-z0-9-]+-og-vertical\.(png|jpe?g)$/;
 
 const normalizeBlogImagePath = (value: string | null): string | null => {
@@ -331,7 +345,8 @@ export default async (request: Request): Promise<Response> => {
     const subline = sanitizeText(getSearchParam(url, "description"), 160) || DEFAULT_SUBLINE;
     const pillText = sanitizeText(getSearchParam(url, "pill"), 30) || SITE_NAME;
     const pagePath = normalizePath(getSearchParam(url, "path"));
-    const displayUrl = truncateText(`${url.host}${pagePath}`, 62);
+    const displayHost = normalizeDisplayHost(getSearchParam(url, "display_host"), url.host);
+    const displayUrl = truncateText(`${displayHost}${pagePath}`, 62);
     const blogImagePath = normalizeBlogImagePath(getSearchParam(url, "blog_image"));
     const blogTint = normalizeOptionalHexColor(getSearchParam(url, "blog_tint"));
     const blogTintIntensity = normalizeTintIntensity(getSearchParam(url, "blog_tint_intensity"), 60);

--- a/scripts/build-site-og-static-images.ts
+++ b/scripts/build-site-og-static-images.ts
@@ -9,6 +9,7 @@ import type { SiteOgMetadata } from "../netlify/edge-lib/site-og-metadata.ts";
 import {
   SITE_OG_BUILD_ORIGIN,
   SITE_OG_STATIC_DIR_RELATIVE,
+  SITE_OG_STATIC_DISPLAY_HOST,
   SITE_OG_STATIC_MANIFEST_FILE_NAME,
   SITE_OG_STATIC_PUBLIC_PREFIX,
   buildSiteOgManifestRevision,
@@ -129,6 +130,8 @@ const buildQueryFromMetadata = (metadata: SiteOgMetadata): Record<string, string
     if (!value) continue;
     query[key] = value;
   }
+
+  query.display_host = SITE_OG_STATIC_DISPLAY_HOST;
 
   return query;
 };

--- a/scripts/site-og-static-shared.ts
+++ b/scripts/site-og-static-shared.ts
@@ -21,7 +21,8 @@ export const SITE_OG_STATIC_PUBLIC_PREFIX = "/images/og/site/generated";
 export const SITE_OG_STATIC_MANIFEST_FILE_NAME = "manifest.json";
 export const SITE_OG_STATIC_MANIFEST_RELATIVE_PATH = `${SITE_OG_STATIC_DIR_RELATIVE}/${SITE_OG_STATIC_MANIFEST_FILE_NAME}`;
 export const SITE_OG_BUILD_ORIGIN = "https://travelflowapp.netlify.app";
-export const SITE_OG_STATIC_TEMPLATE_REVISION = "2026-02-25-site-og-single-renderer-v5";
+export const SITE_OG_STATIC_DISPLAY_HOST = new URL(SITE_OG_BUILD_ORIGIN).host;
+export const SITE_OG_STATIC_TEMPLATE_REVISION = "2026-02-25-site-og-single-renderer-v6";
 export const SITE_OG_STATIC_TARGET_SCOPE_ENV = "SITE_OG_STATIC_TARGET_SCOPE";
 
 export interface SiteOgStaticTarget {
@@ -35,6 +36,7 @@ export interface SiteOgStaticRenderPayload {
   title: string;
   description: string;
   path: string;
+  displayHost: string;
   pill: string;
   blogImage: string;
   blogRevision: string;
@@ -259,6 +261,7 @@ export const buildSiteOgStaticRenderPayload = (metadata: SiteOgMetadata): SiteOg
   title: metadata.ogImageParams.title,
   description: metadata.ogImageParams.description,
   path: metadata.ogImageParams.path,
+  displayHost: SITE_OG_STATIC_DISPLAY_HOST,
   pill: metadata.ogImageParams.pill || "",
   blogImage: metadata.ogImageParams.blog_image || "",
   blogRevision: metadata.ogImageParams.blog_rev || "",

--- a/tests/unit/siteOgMetadata.test.ts
+++ b/tests/unit/siteOgMetadata.test.ts
@@ -89,8 +89,14 @@ describe('site OG static generation helpers', () => {
     const payload = buildSiteOgStaticRenderPayload(metadata);
     const hashA = computeSiteOgStaticPayloadHash(payload);
     const hashB = computeSiteOgStaticPayloadHash(payload);
+    const hashWithDifferentHost = computeSiteOgStaticPayloadHash({
+      ...payload,
+      displayHost: 'example.com',
+    });
 
     expect(hashA).toBe(hashB);
+    expect(payload.displayHost).toBe('travelflowapp.netlify.app');
+    expect(hashWithDifferentHost).not.toBe(hashA);
     expect(hashA).toMatch(/^[a-f0-9]{16}$/);
 
     const allTargets = collectSiteOgStaticTargets();


### PR DESCRIPTION
## Summary
- fix pre-generated site OG footer URL host so it always uses the canonical domain (`travelflowapp.netlify.app`) instead of local batch-render hosts (`127.0.0.1:*`)
- add a `display_host` query override in `site-og-image` and have static generation inject it from `SITE_OG_BUILD_ORIGIN`
- bump static OG template revision so existing incorrect assets are replaced on next build

## Validation
- `pnpm -s vitest run tests/unit/siteOgMetadata.test.ts`
- `pnpm -s og:site:build && pnpm -s og:site:validate`
- `pnpm -s updates:validate`
- `pnpm -s edge:validate`
