### PR TITLE
Publish admin playground dialog release note

### DIFF
--- a/content/updates/2026-02-28-admin-playground-app-dialog-coverage.md
+++ b/content/updates/2026-02-28-admin-playground-app-dialog-coverage.md
@@ -3,8 +3,8 @@ id: rel-2026-02-28-admin-playground-app-dialog-coverage
 version: v0.70.0
 title: "Admin playground app dialog coverage follow-up"
 date: 2026-02-28
-published_at: 2026-02-28T08:30:00Z
-status: draft
+published_at: 2026-02-28T14:05:16Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Extended the admin design playground with real shared confirm/prompt dialog variants used across app and admin flows."


### PR DESCRIPTION
## Summary
Publish the merged admin-playground dialog follow-up release note metadata.

## Changes
- Set `status` from `draft` to `published`.
- Set `published_at` to the actual merge timestamp (`2026-02-28T14:05:16Z`).

## Validation
- `pnpm updates:validate`
