### PR TITLE
docs(release): publish admin trip ops release note

### DIFF
--- a/content/updates/2026-02-24-admin-trip-ops-real-data.md
+++ b/content/updates/2026-02-24-admin-trip-ops-real-data.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-02-24-admin-trip-ops-real-data
-version: v0.57.0
+version: v0.72.0
 title: "Admin trips real-data recovery and action controls"
 date: 2026-02-24
-published_at: 2026-02-24T12:55:00Z
-status: draft
+published_at: 2026-03-01T09:50:00Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Admin overview and trip operations now stay on live records, with expanded trip actions in both the table and side panel."


### PR DESCRIPTION
## Summary
- mark the admin trip ops release note as published
- bump release version metadata to the next available version
- set post-merge publication timestamp

## Details
- Updated `content/updates/2026-02-24-admin-trip-ops-real-data.md`
  - `version: v0.72.0`
  - `published_at: 2026-03-01T09:50:00Z`
  - `status: published`

## Follow-up tracking
- Low-priority replay export size-guard follow-up tracked in #214.
