### PR TITLE
docs(release): publish trip reactivation bridge release note

### DIFF
--- a/content/updates/2026-03-01-trip-reactivation-bridge.md
+++ b/content/updates/2026-03-01-trip-reactivation-bridge.md
@@ -3,8 +3,8 @@ id: rel-2026-03-01-trip-reactivation-bridge
 version: v0.74.0
 title: "Expired trip reactivation bridge for signed-in users"
 date: 2026-03-01
-published_at: 2026-03-01T18:30:00Z
-status: draft
+published_at: 2026-03-01T12:27:17Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Signed-in travelers can now reactivate expired trips instantly while we prepare the full subscription upgrade flow."


### PR DESCRIPTION
## Summary
- publish the merged trip reactivation bridge release note
- set `status: published` and `published_at: 2026-03-01T12:27:17Z` (actual merge timestamp of PR #217)
- keep release version at `v0.74.0` (next version after latest published `v0.73.0`)

## Related Issues
- Refs #217

## Validation
- [ ] `pnpm test:core`
- [ ] `pnpm build`
- [ ] `pnpm storage:validate`
- [x] `pnpm updates:validate`

## New Module Guard
- [x] New module guard completed
- [x] If I added files under `services/` or `config/`, I listed matching `tests/**` paths below.

### Matching `tests/**` Entries (required when adding `services/` or `config/` files)
- Not applicable (no files added under `services/` or `config/`).
