### PR TITLE
fix(tripview): stabilize timeline scroll sync and mode persistence

### DIFF
--- a/components/tripview/TripViewPlannerWorkspace.tsx
+++ b/components/tripview/TripViewPlannerWorkspace.tsx
@@ -109,7 +109,7 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
         <div className="flex flex-wrap items-center justify-end gap-2 pointer-events-auto">
             {timelineMode === 'calendar' && (
                 <>
-                    <div className="inline-flex items-center rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur">
+                    <div className="inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur">
                         <button
                             type="button"
                             onClick={() => onTimelineViewChange('horizontal')}
@@ -139,7 +139,7 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
                             <ArrowUpDown size={16} />
                         </button>
                     </div>
-                    <div className="inline-flex items-center rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur">
+                    <div className="inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur">
                         <button
                             type="button"
                             onClick={onZoomOut}
@@ -161,7 +161,7 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
                     </div>
                 </>
             )}
-            <div className="ms-auto inline-flex items-center rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur">
+            <div className="ms-auto inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur">
                 <button
                     type="button"
                     onClick={() => onTimelineModeChange('calendar')}

--- a/content/updates/2026-02-28-trip-page-calendar-and-timeline-list-mode.md
+++ b/content/updates/2026-02-28-trip-page-calendar-and-timeline-list-mode.md
@@ -22,6 +22,15 @@ summary: "Trip planning now supports a modern timeline list mode with today-focu
 - [x] [Improved] 🔲 Timeline transfer pills now show a clear selected outline state to match calendar-style selection feedback.
 - [x] [Improved] 🟢 "Today" is highlighted with a badge and the timeline list auto-scrolls to today when opened.
 - [x] [Improved] 🎛️ Calendar/list mode switching now uses icon-only controls with accessible labels, with the mode toggle pinned to the far right.
+- [x] [Improved] 🗺️ Scrolling through timeline list sections now keeps map focus in sync by highlighting the city currently in view.
+- [x] [Fixed] 🔁 Calendar mode now stays selected reliably instead of occasionally snapping back to timeline mode after background refreshes.
+- [x] [Improved] ↔️ Calendar and list mode icon tabs now use consistent spacing so the controls no longer feel crowded.
+- [x] [Improved] 🎯 Switching from calendar to timeline list now keeps the active selection and scrolls to the selected city or activity automatically.
+- [x] [Improved] 🧭 Timeline list now opens in a neutral state with no auto-selected details unless you already selected something.
+- [x] [Improved] 🔴 Timeline list "Today" badges now match the calendar-style red emphasis with uppercase visual treatment.
+- [x] [Fixed] 📍 Timeline list now reliably smooth-scrolls to the current-day marker after load when that marker starts outside the visible viewport.
+- [x] [Improved] 🧩 Scrolling through timeline chapters now updates details only when a selection is already open, avoiding unwanted panel opens from passive scrolling.
+- [x] [Fixed] 🧵 Versioned trip links now keep the selected calendar/list mode stable even when delayed sync refreshes arrive.
 - [x] [Improved] 🗺️ Map controls now stay visible even when the map is unavailable, while map-only actions stay safely disabled until map load succeeds.
 - [ ] [Internal] 💾 Active view mode is now saved with each trip view state so reloads restore the selected mode.
 - [ ] [Internal] ♻️ Undo and redo history now includes view-mode changes together with other planner view updates.

--- a/tests/browser/tripview/TripTimelineListView.browser.test.ts
+++ b/tests/browser/tripview/TripTimelineListView.browser.test.ts
@@ -119,4 +119,322 @@ describe('components/tripview/TripTimelineListView', () => {
       city_id: 'city-b',
     });
   });
+
+  it('selects the active city when scrolling into a new section', () => {
+    const kabulCity = makeCityItem({ id: 'city-a', title: 'Kabul', startDateOffset: 0, duration: 2, color: 'bg-rose-400' });
+    const heratCity = makeCityItem({ id: 'city-b', title: 'Herat', startDateOffset: 2.2, duration: 2, color: 'bg-amber-400' });
+    const trip = makeTrip({
+      startDate: '2026-03-01',
+      items: [kabulCity, makeTravelItem('travel-a-b', 2.05, 'Morning transfer'), heratCity],
+    });
+    const onSelect = vi.fn();
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    const cancelRafSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+
+    try {
+      const { container } = render(
+        React.createElement(TripTimelineListView, {
+          trip,
+          selectedItemId: 'city-a',
+          onSelect,
+        }),
+      );
+
+      const viewport = container.querySelector('.h-full.overflow-y-auto') as HTMLDivElement | null;
+      expect(viewport).not.toBeNull();
+
+      const cityASection = container.querySelector('[data-city-section-id="city-a"]') as HTMLElement | null;
+      const cityBSection = container.querySelector('[data-city-section-id="city-b"]') as HTMLElement | null;
+      expect(cityASection).not.toBeNull();
+      expect(cityBSection).not.toBeNull();
+
+      if (!viewport || !cityASection || !cityBSection) {
+        throw new Error('Expected viewport and city sections to render');
+      }
+
+      Object.defineProperty(viewport, 'clientHeight', {
+        configurable: true,
+        value: 600,
+      });
+      viewport.getBoundingClientRect = vi.fn(() => ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 900,
+        bottom: 600,
+        width: 900,
+        height: 600,
+        toJSON: () => ({}),
+      })) as any;
+      cityASection.getBoundingClientRect = vi.fn(() => ({
+        x: 0,
+        y: -260,
+        top: -260,
+        left: 0,
+        right: 900,
+        bottom: 120,
+        width: 900,
+        height: 380,
+        toJSON: () => ({}),
+      })) as any;
+      cityBSection.getBoundingClientRect = vi.fn(() => ({
+        x: 0,
+        y: 40,
+        top: 40,
+        left: 0,
+        right: 900,
+        bottom: 420,
+        width: 900,
+        height: 380,
+        toJSON: () => ({}),
+      })) as any;
+
+      fireEvent.wheel(viewport);
+      fireEvent.scroll(viewport);
+
+      expect(onSelect).toHaveBeenCalledWith('city-b', { isCity: true });
+    } finally {
+      rafSpy.mockRestore();
+      cancelRafSpy.mockRestore();
+    }
+  });
+
+  it('does not auto-select a city while scrolling when no details panel is open', () => {
+    const kabulCity = makeCityItem({ id: 'city-a', title: 'Kabul', startDateOffset: 0, duration: 2, color: 'bg-rose-400' });
+    const heratCity = makeCityItem({ id: 'city-b', title: 'Herat', startDateOffset: 2.2, duration: 2, color: 'bg-amber-400' });
+    const trip = makeTrip({
+      startDate: '2026-03-01',
+      items: [kabulCity, makeTravelItem('travel-a-b', 2.05, 'Morning transfer'), heratCity],
+    });
+    const onSelect = vi.fn();
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    const cancelRafSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+
+    try {
+      const { container } = render(
+        React.createElement(TripTimelineListView, {
+          trip,
+          selectedItemId: null,
+          onSelect,
+        }),
+      );
+
+      const viewport = container.querySelector('.h-full.overflow-y-auto') as HTMLDivElement | null;
+      const cityASection = container.querySelector('[data-city-section-id="city-a"]') as HTMLElement | null;
+      const cityBSection = container.querySelector('[data-city-section-id="city-b"]') as HTMLElement | null;
+      if (!viewport || !cityASection || !cityBSection) {
+        throw new Error('Expected viewport and city sections to render');
+      }
+
+      Object.defineProperty(viewport, 'clientHeight', {
+        configurable: true,
+        value: 600,
+      });
+      viewport.getBoundingClientRect = vi.fn(() => ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 900,
+        bottom: 600,
+        width: 900,
+        height: 600,
+        toJSON: () => ({}),
+      })) as any;
+      cityASection.getBoundingClientRect = vi.fn(() => ({
+        x: 0,
+        y: -260,
+        top: -260,
+        left: 0,
+        right: 900,
+        bottom: 120,
+        width: 900,
+        height: 380,
+        toJSON: () => ({}),
+      })) as any;
+      cityBSection.getBoundingClientRect = vi.fn(() => ({
+        x: 0,
+        y: 40,
+        top: 40,
+        left: 0,
+        right: 900,
+        bottom: 420,
+        width: 900,
+        height: 380,
+        toJSON: () => ({}),
+      })) as any;
+
+      fireEvent.wheel(viewport);
+      fireEvent.scroll(viewport);
+
+      expect(onSelect).not.toHaveBeenCalled();
+    } finally {
+      rafSpy.mockRestore();
+      cancelRafSpy.mockRestore();
+    }
+  });
+
+  it('auto-scrolls to the selected item when opening timeline list with an existing selection', () => {
+    const kabulCity = makeCityItem({ id: 'city-a', title: 'Kabul', startDateOffset: 0, duration: 2, color: 'bg-rose-400' });
+    const activity = makeActivityItem('activity-a-1', 'Kabul', 0.5);
+    activity.title = 'Museum visit';
+    const trip = makeTrip({
+      startDate: '2026-03-01',
+      items: [kabulCity, activity],
+    });
+    const onSelect = vi.fn();
+    const scrollSpy = vi.fn();
+
+    const { container, rerender } = render(
+      React.createElement(TripTimelineListView, {
+        trip,
+        selectedItemId: 'city-a',
+        onSelect,
+      }),
+    );
+
+    const activityMarker = container.querySelector('[data-activity-marker-id="activity-a-1"]') as HTMLElement | null;
+    const viewport = container.querySelector('.h-full.overflow-y-auto') as HTMLDivElement | null;
+    if (!activityMarker || !viewport) {
+      throw new Error('Expected selected activity marker and viewport to render');
+    }
+
+    viewport.getBoundingClientRect = vi.fn(() => ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 900,
+      bottom: 300,
+      width: 900,
+      height: 300,
+      toJSON: () => ({}),
+    })) as any;
+    activityMarker.getBoundingClientRect = vi.fn(() => ({
+      x: 0,
+      y: 640,
+      top: 640,
+      left: 0,
+      right: 900,
+      bottom: 720,
+      width: 900,
+      height: 80,
+      toJSON: () => ({}),
+    })) as any;
+    (activityMarker as any).scrollIntoView = scrollSpy;
+
+    rerender(
+      React.createElement(TripTimelineListView, {
+        trip,
+        selectedItemId: 'activity-a-1',
+        onSelect,
+      }),
+    );
+
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+
+  it('renders today pills with red uppercase styling', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));
+
+    try {
+      const city = makeCityItem({ id: 'city-a', title: 'Kabul', startDateOffset: 0, duration: 2, color: 'bg-rose-400' });
+      const trip = makeTrip({
+        startDate: '2026-03-01',
+        items: [city, makeActivityItem('activity-a-1', 'Kabul', 0.5)],
+      });
+      render(
+        React.createElement(TripTimelineListView, {
+          trip,
+          selectedItemId: null,
+          onSelect: vi.fn(),
+        }),
+      );
+
+      const todayPills = screen.getAllByText('Today');
+      expect(todayPills.length).toBeGreaterThan(0);
+      for (const pill of todayPills) {
+        expect(pill).toHaveClass('uppercase');
+        expect(pill).toHaveClass('text-red-700');
+        expect(pill).toHaveClass('bg-red-50');
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('smooth-scrolls to today marker on initial load when today is out of view', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-02T12:00:00Z'));
+
+    const domRect = (
+      top: number,
+      bottom: number,
+      left = 0,
+      right = 900,
+      width = 900,
+      height = bottom - top,
+    ): DOMRect => ({
+      x: left,
+      y: top,
+      top,
+      bottom,
+      left,
+      right,
+      width,
+      height,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const previousScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollIntoView');
+    const scrollIntoViewSpy = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      writable: true,
+      value: scrollIntoViewSpy,
+    });
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function mockRect(this: HTMLElement) {
+      if (this.classList.contains('h-full') && this.classList.contains('overflow-y-auto')) {
+        return domRect(0, 320);
+      }
+      if (this.dataset.cityMarkerId === 'city-a') {
+        return domRect(640, 660);
+      }
+      return domRect(0, 0, 0, 0, 0, 0);
+    });
+
+    try {
+      const city = makeCityItem({ id: 'city-a', title: 'Kabul', startDateOffset: 0, duration: 3, color: 'bg-rose-400' });
+      const trip = makeTrip({
+        startDate: '2026-03-01',
+        items: [city, makeActivityItem('activity-a-1', 'Kabul', 0.5)],
+      });
+
+      render(
+        React.createElement(TripTimelineListView, {
+          trip,
+          selectedItemId: null,
+          onSelect: vi.fn(),
+        }),
+      );
+
+      expect(scrollIntoViewSpy).toHaveBeenCalled();
+    } finally {
+      rectSpy.mockRestore();
+      if (previousScrollIntoViewDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', previousScrollIntoViewDescriptor);
+      } else {
+        delete (HTMLElement.prototype as HTMLElement & { scrollIntoView?: unknown }).scrollIntoView;
+      }
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/browser/tripview/TripViewPlannerWorkspace.browser.test.ts
+++ b/tests/browser/tripview/TripViewPlannerWorkspace.browser.test.ts
@@ -78,6 +78,7 @@ describe('components/tripview/TripViewPlannerWorkspace', () => {
     const modeGroup = calendarModeButton.parentElement;
     const controlsRoot = modeGroup?.parentElement;
     expect(controlsRoot?.lastElementChild).toBe(modeGroup);
+    expect(modeGroup).toHaveClass('gap-1');
   });
 
   it('hides calendar-only controls in timeline list mode', () => {


### PR DESCRIPTION
## Summary
- stop timeline chapter scroll sync from opening details when no selection is open
- make initial timeline today-marker auto-scroll reliable with viewport visibility checks
- prevent delayed loader refreshes from reverting calendar/list mode for versioned trip URLs
- keep calendar/list icon tabs consistently spaced
- add regression coverage for timeline scroll sync and loader version precedence
- update the existing release note draft for this feature work

## Testing
- `pnpm vitest tests/browser/tripview/TripTimelineListView.browser.test.ts tests/browser/routes/tripLoaderRoute.browser.test.ts tests/browser/tripview/TripViewPlannerWorkspace.browser.test.ts`
- `pnpm test:core`
- `pnpm dlx react-doctor@latest . --verbose --diff`
- `pnpm updates:validate`
