### PR TITLE
chore(release): publish v0.75.0 tripview timeline update

### DIFF
--- a/content/updates/2026-02-28-trip-page-calendar-and-timeline-list-mode.md
+++ b/content/updates/2026-02-28-trip-page-calendar-and-timeline-list-mode.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-02-28-trip-page-calendar-and-timeline-list-mode
-version: v0.63.0
+version: v0.75.0
 title: "Trip page calendar and timeline list mode"
-date: 2026-02-28
-published_at: 2026-02-28T18:30:00Z
-status: draft
+date: 2026-03-01
+published_at: 2026-03-01T17:05:17Z
+status: published
 notify_in_app: true
 in_app_hours: 24
 summary: "Trip planning now supports a modern timeline list mode with today-focused navigation and saved view preferences."


### PR DESCRIPTION
## Summary
- publish the merged tripview timeline/list release note metadata after PR #221
- bump release version to `v0.75.0`
- set `status: published`
- set `published_at` to the actual merge timestamp `2026-03-01T17:05:17Z`
- align release `date` with publication day

## Validation
- `pnpm updates:validate`
