### PR TITLE
Stabilize floating map transitions during resize bursts

### DIFF
--- a/components/tripview/TripFloatingMapPreview.tsx
+++ b/components/tripview/TripFloatingMapPreview.tsx
@@ -29,6 +29,7 @@ const FLOATING_MAP_DRAG_THRESHOLD = 4;
 const FLOATING_MAP_MAX_ROTATION = 11;
 const FLOATING_MAP_ROTATION_VELOCITY_FACTOR = 0.015;
 const FLOATING_MAP_SETTLE_DURATION_MS = 380;
+const FLOATING_MAP_RESIZE_SETTLE_MS = 140;
 const FLOATING_MAP_BORDER_RADIUS = '1rem';
 const FLOATING_MAP_NAV_TOP_OFFSET = 92;
 const FLOATING_MAP_ASPECT_RATIO: Record<FloatingMapOrientation, number> = {
@@ -269,9 +270,19 @@ export const TripFloatingMapPreview: React.FC<TripFloatingMapPreviewProps> = ({
     const [isHandlePressed, setIsHandlePressed] = useState(false);
     const [hasResolvedInitialGeometry, setHasResolvedInitialGeometry] = useState(false);
     const dragSettleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const viewportResizeRafRef = useRef<number | null>(null);
+    const floatingResizePersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const dockedResizeRafRef = useRef<number | null>(null);
+    const dockedResizeSettleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const floatingMapDragControls = useDragControls();
     const floatingMapPositionRef = useRef<{ x: number; y: number } | null>(null);
     const floatingMapAnchorRef = useRef<FloatingMapSideAnchor | null>(null);
+    const pendingDockedResizeRectRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
+    const pendingFloatingPersistStateRef = useRef<{
+        position: { x: number; y: number };
+        sizePreset: FloatingMapSizePreset;
+        orientation: FloatingMapOrientation;
+    } | null>(null);
     const initialStoredPositionRef = useRef<{ x: number; y: number } | null>(
         initialPersistedStateRef.current.position ?? null,
     );
@@ -297,6 +308,18 @@ export const TripFloatingMapPreview: React.FC<TripFloatingMapPreviewProps> = ({
         if (!dragSettleTimerRef.current) return;
         clearTimeout(dragSettleTimerRef.current);
         dragSettleTimerRef.current = null;
+    }, []);
+
+    const clearFloatingResizePersistTimer = useCallback(() => {
+        if (!floatingResizePersistTimerRef.current) return;
+        clearTimeout(floatingResizePersistTimerRef.current);
+        floatingResizePersistTimerRef.current = null;
+    }, []);
+
+    const clearDockedResizeSettleTimer = useCallback(() => {
+        if (!dockedResizeSettleTimerRef.current) return;
+        clearTimeout(dockedResizeSettleTimerRef.current);
+        dockedResizeSettleTimerRef.current = null;
     }, []);
 
     const applySurfaceGeometry = useCallback((
@@ -386,8 +409,20 @@ export const TripFloatingMapPreview: React.FC<TripFloatingMapPreviewProps> = ({
     useEffect(() => {
         return () => {
             clearFloatingMapSettleTimer();
+            clearFloatingResizePersistTimer();
+            clearDockedResizeSettleTimer();
+            if (typeof window !== 'undefined') {
+                if (viewportResizeRafRef.current !== null) {
+                    window.cancelAnimationFrame(viewportResizeRafRef.current);
+                    viewportResizeRafRef.current = null;
+                }
+                if (dockedResizeRafRef.current !== null) {
+                    window.cancelAnimationFrame(dockedResizeRafRef.current);
+                    dockedResizeRafRef.current = null;
+                }
+            }
         };
-    }, [clearFloatingMapSettleTimer]);
+    }, [clearDockedResizeSettleTimer, clearFloatingMapSettleTimer, clearFloatingResizePersistTimer]);
 
     useEffect(() => {
         const didResolve = syncSurfaceGeometry(hasResolvedInitialGeometry);
@@ -415,48 +450,72 @@ export const TripFloatingMapPreview: React.FC<TripFloatingMapPreviewProps> = ({
     useEffect(() => {
         if (typeof window === 'undefined') return;
         const handleResize = () => {
-            const nextBaseWidth = resolveFloatingMapWidth();
-            setFloatingMapBaseWidth(nextBaseWidth);
-            if (mapDockMode === 'floating') {
-                const currentPosition = floatingMapPositionRef.current ?? {
-                    x: floatingMapX.get(),
-                    y: floatingMapY.get(),
-                };
-                const currentWidth = surfaceWidth.get();
-                const currentHeight = surfaceHeight.get();
-                const sideAnchor = floatingMapAnchorRef.current
-                    ?? resolveFloatingMapSideAnchor(currentPosition, currentWidth, currentHeight);
-                const normalizedPreset = normalizeFloatingMapSizePreset(floatingMapSizePresetRef.current);
-                const nextShortEdge = resolveWidthForPreset(nextBaseWidth, normalizedPreset);
-                const nextDimensions = resolveFloatingMapDimensions(nextShortEdge, floatingMapOrientationRef.current);
-                const anchoredPosition = resolveFloatingMapPositionForAnchor(
-                    sideAnchor,
-                    nextDimensions.width,
-                    nextDimensions.height,
-                );
+            if (viewportResizeRafRef.current !== null) return;
+            viewportResizeRafRef.current = -1;
+            const rafId = window.requestAnimationFrame(() => {
+                viewportResizeRafRef.current = null;
+                const nextBaseWidth = resolveFloatingMapWidth();
+                setFloatingMapBaseWidth(nextBaseWidth);
+                if (mapDockMode === 'floating') {
+                    const currentPosition = floatingMapPositionRef.current ?? {
+                        x: floatingMapX.get(),
+                        y: floatingMapY.get(),
+                    };
+                    const currentWidth = surfaceWidth.get();
+                    const currentHeight = surfaceHeight.get();
+                    const sideAnchor = floatingMapAnchorRef.current
+                        ?? resolveFloatingMapSideAnchor(currentPosition, currentWidth, currentHeight);
+                    const normalizedPreset = normalizeFloatingMapSizePreset(floatingMapSizePresetRef.current);
+                    const nextShortEdge = resolveWidthForPreset(nextBaseWidth, normalizedPreset);
+                    const nextDimensions = resolveFloatingMapDimensions(nextShortEdge, floatingMapOrientationRef.current);
+                    const anchoredPosition = resolveFloatingMapPositionForAnchor(
+                        sideAnchor,
+                        nextDimensions.width,
+                        nextDimensions.height,
+                    );
 
-                floatingMapAnchorRef.current = sideAnchor;
-                floatingMapPositionRef.current = anchoredPosition;
-                applySurfaceGeometry(
-                    {
-                        x: anchoredPosition.x,
-                        y: anchoredPosition.y,
-                        width: nextDimensions.width,
-                        height: nextDimensions.height,
-                    },
-                    true,
-                );
-                writeFloatingMapPreviewState({
-                    position: anchoredPosition,
-                    sizePreset: normalizedPreset,
-                    orientation: floatingMapOrientationRef.current,
-                });
-                return;
+                    floatingMapAnchorRef.current = sideAnchor;
+                    floatingMapPositionRef.current = anchoredPosition;
+                    applySurfaceGeometry(
+                        {
+                            x: anchoredPosition.x,
+                            y: anchoredPosition.y,
+                            width: nextDimensions.width,
+                            height: nextDimensions.height,
+                        },
+                        false,
+                    );
+                    pendingFloatingPersistStateRef.current = {
+                        position: anchoredPosition,
+                        sizePreset: normalizedPreset,
+                        orientation: floatingMapOrientationRef.current,
+                    };
+                    clearFloatingResizePersistTimer();
+                    floatingResizePersistTimerRef.current = setTimeout(() => {
+                        const pendingState = pendingFloatingPersistStateRef.current;
+                        if (!pendingState) return;
+                        writeFloatingMapPreviewState({
+                            position: pendingState.position,
+                            sizePreset: pendingState.sizePreset,
+                            orientation: pendingState.orientation,
+                        });
+                    }, FLOATING_MAP_RESIZE_SETTLE_MS);
+                    return;
+                }
+                syncSurfaceGeometry(false);
+            });
+            if (viewportResizeRafRef.current !== null) {
+                viewportResizeRafRef.current = rafId;
             }
-            syncSurfaceGeometry(true);
         };
         window.addEventListener('resize', handleResize);
-        return () => window.removeEventListener('resize', handleResize);
+        return () => {
+            window.removeEventListener('resize', handleResize);
+            if (viewportResizeRafRef.current !== null) {
+                window.cancelAnimationFrame(viewportResizeRafRef.current);
+                viewportResizeRafRef.current = null;
+            }
+        };
     }, [
         applySurfaceGeometry,
         floatingMapX,
@@ -475,13 +534,37 @@ export const TripFloatingMapPreview: React.FC<TripFloatingMapPreviewProps> = ({
         const observer = new ResizeObserver(() => {
             const nextDockedRect = resolveDockedMapRect(anchor);
             if (!nextDockedRect) return;
-            lastDockedMapRectRef.current = nextDockedRect;
-            applySurfaceGeometry(nextDockedRect, true);
+            pendingDockedResizeRectRef.current = nextDockedRect;
+            if (dockedResizeRafRef.current !== null) return;
+            dockedResizeRafRef.current = -1;
+            const rafId = window.requestAnimationFrame(() => {
+                dockedResizeRafRef.current = null;
+                const pendingDockedRect = pendingDockedResizeRectRef.current;
+                if (!pendingDockedRect) return;
+                lastDockedMapRectRef.current = pendingDockedRect;
+                applySurfaceGeometry(pendingDockedRect, false);
+                clearDockedResizeSettleTimer();
+                dockedResizeSettleTimerRef.current = setTimeout(() => {
+                    const settledRect = pendingDockedResizeRectRef.current;
+                    if (!settledRect) return;
+                    applySurfaceGeometry(settledRect, true);
+                }, FLOATING_MAP_RESIZE_SETTLE_MS);
+            });
+            if (dockedResizeRafRef.current !== null) {
+                dockedResizeRafRef.current = rafId;
+            }
         });
 
         observer.observe(anchor);
-        return () => observer.disconnect();
-    }, [applySurfaceGeometry, dockedGeometryKey, dockedMapAnchorRef, mapDockMode]);
+        return () => {
+            observer.disconnect();
+            if (dockedResizeRafRef.current !== null) {
+                window.cancelAnimationFrame(dockedResizeRafRef.current);
+                dockedResizeRafRef.current = null;
+            }
+            clearDockedResizeSettleTimer();
+        };
+    }, [applySurfaceGeometry, clearDockedResizeSettleTimer, dockedGeometryKey, dockedMapAnchorRef, mapDockMode]);
 
     useEffect(() => {
         if (!isHandlePressed) return;
@@ -685,6 +768,8 @@ export const TripFloatingMapPreview: React.FC<TripFloatingMapPreviewProps> = ({
         );
     }, [clearFloatingMapSettleTimer, floatingMapRotation, floatingMapX, floatingMapY, persistFloatingMapState, surfaceHeight, surfaceWidth]);
 
+    const shouldPromoteMapLayer = mapDockMode === 'floating' && (isFloatingMapDragging || isFloatingMapSettling || isHandlePressed);
+
     return (
         <LazyMotion features={domMax}>
             <m.div
@@ -726,6 +811,7 @@ export const TripFloatingMapPreview: React.FC<TripFloatingMapPreviewProps> = ({
                     rotate: floatingMapVisualRotation,
                     transformOrigin: '50% 0%',
                     borderRadius: mapDockMode === 'floating' ? FLOATING_MAP_BORDER_RADIUS : '0px',
+                    ...(shouldPromoteMapLayer ? { willChange: 'transform,width,height' } : {}),
                 }}
             >
                 {mapDockMode === 'floating' && (

--- a/content/updates/2026-03-02-map-transition-stability-followup.md
+++ b/content/updates/2026-03-02-map-transition-stability-followup.md
@@ -1,0 +1,18 @@
+---
+id: rel-2026-03-02-map-transition-stability-followup
+version: v0.77.0
+title: "Floating map transition stability follow-up"
+date: 2026-03-02
+published_at: 2026-03-02T09:30:00Z
+status: draft
+notify_in_app: true
+in_app_hours: 24
+summary: "Trip planner floating map transitions were hardened to stay stable under rapid layout and resize interactions."
+---
+
+## Changes
+- [x] [Improved] 🛡️ Floating map resize handling is now throttled and debounced to reduce burst animation load during rapid layout and panel resizing.
+- [x] [Improved] ⚙️ Floating map geometry updates now avoid continuous spring churn during active resize bursts and settle smoothly afterward.
+- [x] [Improved] 🎯 Floating map rendering hints now activate only during active interaction to keep motion smoother under stress.
+- [ ] [Internal] 🧪 Added regression coverage for rapid viewport-resize persistence behavior in floating map mode.
+- [ ] [Internal] 🔍 Added follow-up crash investigation issue tracking for intermittent planner instability during map/layout transition bursts.

--- a/tests/browser/tripview/TripFloatingMapPreview.browser.test.ts
+++ b/tests/browser/tripview/TripFloatingMapPreview.browser.test.ts
@@ -136,6 +136,7 @@ describe('components/tripview/TripFloatingMapPreview', () => {
   });
 
   it('keeps bottom-right edge anchoring when viewport grows after resize', () => {
+    vi.useFakeTimers();
     const originalInnerWidth = window.innerWidth;
     const originalInnerHeight = window.innerHeight;
     const mapViewportRef = { current: null as HTMLDivElement | null };
@@ -162,6 +163,7 @@ describe('components/tripview/TripFloatingMapPreview', () => {
       Object.defineProperty(window, 'innerHeight', { configurable: true, value: nextInnerHeight });
       act(() => {
         window.dispatchEvent(new Event('resize'));
+        vi.advanceTimersByTime(180);
       });
 
       const state = readFloatingMapPreviewState();
@@ -180,10 +182,12 @@ describe('components/tripview/TripFloatingMapPreview', () => {
     } finally {
       Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
       Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight });
+      vi.useRealTimers();
     }
   });
 
   it('keeps bottom-center anchoring when viewport grows after resize', () => {
+    vi.useFakeTimers();
     const originalInnerWidth = window.innerWidth;
     const originalInnerHeight = window.innerHeight;
     const mapViewportRef = { current: null as HTMLDivElement | null };
@@ -223,6 +227,7 @@ describe('components/tripview/TripFloatingMapPreview', () => {
       Object.defineProperty(window, 'innerHeight', { configurable: true, value: nextInnerHeight });
       act(() => {
         window.dispatchEvent(new Event('resize'));
+        vi.advanceTimersByTime(180);
       });
 
       const state = readFloatingMapPreviewState();
@@ -244,6 +249,80 @@ describe('components/tripview/TripFloatingMapPreview', () => {
     } finally {
       Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
       Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight });
+      vi.useRealTimers();
+    }
+  });
+
+  it('debounces floating resize persistence during rapid viewport resize bursts', () => {
+    vi.useFakeTimers();
+    const originalInnerWidth = window.innerWidth;
+    const originalInnerHeight = window.innerHeight;
+    const mapViewportRef = { current: null as HTMLDivElement | null };
+    const dockedMapAnchorRef = { current: null as HTMLDivElement | null };
+
+    try {
+      render(
+        React.createElement(
+          TripFloatingMapPreview,
+          {
+            mapDockMode: 'floating',
+            mapViewportRef,
+            dockedMapAnchorRef,
+            dockedGeometryKey: 'floating',
+            tripId: 'trip-resize-debounce',
+          },
+          React.createElement('div', { 'data-testid': 'map-content' }, 'map'),
+        ),
+      );
+
+      const startState = readFloatingMapPreviewState();
+      const firstInnerWidth = originalInnerWidth + 180;
+      const firstInnerHeight = originalInnerHeight + 120;
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: firstInnerWidth });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: firstInnerHeight });
+      act(() => {
+        window.dispatchEvent(new Event('resize'));
+      });
+
+      const secondInnerWidth = originalInnerWidth + 260;
+      const secondInnerHeight = originalInnerHeight + 200;
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: secondInnerWidth });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: secondInnerHeight });
+      act(() => {
+        window.dispatchEvent(new Event('resize'));
+        vi.advanceTimersByTime(60);
+      });
+
+      const beforeSettle = readFloatingMapPreviewState();
+      expect(beforeSettle.position?.x).toBe(startState.position?.x);
+      expect(beforeSettle.position?.y).toBe(startState.position?.y);
+
+      act(() => {
+        vi.advanceTimersByTime(180);
+        vi.runOnlyPendingTimers();
+      });
+
+      const afterSettle = readFloatingMapPreviewState();
+      expect(afterSettle.position).toBeTruthy();
+      expect(afterSettle.sizePreset).toBe('lg');
+      expect(afterSettle.orientation).toBe('portrait');
+
+      const nextBaseWidth = Math.max(180, Math.min(420, secondInnerWidth * 0.26));
+      const nextShortEdge = resolveFloatingMapPresetWidths(nextBaseWidth).lg;
+      const nextWidth = nextShortEdge;
+      const nextHeight = nextShortEdge * 1.5;
+      const minX = 24;
+      const maxX = Math.max(24, secondInnerWidth - nextWidth - 24);
+      const minY = 92;
+      const maxY = Math.max(92, secondInnerHeight - nextHeight - 24);
+      expect(afterSettle.position?.x).toBeGreaterThanOrEqual(minX);
+      expect(afterSettle.position?.x).toBeLessThanOrEqual(maxX);
+      expect(afterSettle.position?.y).toBeGreaterThanOrEqual(minY);
+      expect(afterSettle.position?.y).toBeLessThanOrEqual(maxY);
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight });
+      vi.useRealTimers();
     }
   });
 });


### PR DESCRIPTION
## Summary
- harden floating map geometry updates during rapid viewport and docked-surface resize bursts
- throttle resize processing via `requestAnimationFrame` and debounce persistence/settle work to reduce transition churn
- preserve anchor-based reposition behavior while preventing duplicate high-frequency state writes under stress
- add browser regression coverage for resize-burst persistence behavior
- add draft release note for this follow-up

## Issue
Closes #223

## Testing
- `pnpm test:core`
- `pnpm vitest tests/browser/tripview/TripFloatingMapPreview.browser.test.ts tests/browser/tripview/TripViewPlannerWorkspace.browser.test.ts tests/browser/tripview/useTripResizeControls.browser.test.ts tests/unit/viewChangeDiff.test.ts`
- `pnpm dlx react-doctor@latest . --verbose --diff`
- `pnpm updates:validate`
- `pnpm storage:validate`

## Notes
- `react-doctor` reports only non-blocking structural warnings (component size / state count) for `TripFloatingMapPreview`.
- release note file: `content/updates/2026-03-02-map-transition-stability-followup.md` (kept in `status: draft`)
