### PR TITLE
Add remember login across page/modal and localhost auth bridge

### DIFF
--- a/components/auth/AuthModal.tsx
+++ b/components/auth/AuthModal.tsx
@@ -6,10 +6,15 @@ import {
 } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { Checkbox } from '../ui/checkbox';
 import { useAuth } from '../../hooks/useAuth';
 import type { OAuthProviderId } from '../../services/authService';
 import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analyticsService';
 import { buildPasswordResetRedirectUrl } from '../../services/authNavigationService';
+import {
+    isRememberLoginEnabled,
+    setRememberLoginEnabled,
+} from '../../services/authSessionPersistenceService';
 import {
     clearPendingOAuthProvider,
     getLastUsedOAuthProvider,
@@ -117,6 +122,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [infoMessage, setInfoMessage] = useState<string | null>(null);
+    const [rememberLogin, setRememberLogin] = useState<boolean>(() => isRememberLoginEnabled());
     const [lastUsedProvider, setLastUsedProviderState] = useState<OAuthProviderId | null>(() => getLastUsedOAuthProvider());
     const [sessionRestoreState, setSessionRestoreState] = useState<'idle' | 'restoring' | 'restored'>('idle');
     const hasHandledSuccessRef = useRef(false);
@@ -134,6 +140,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
     const oauthButtons = useMemo(() => getOAuthButtons(i18n.language), [i18n.language]);
     const emailInputId = 'auth-modal-email';
     const secondaryInputId = 'auth-modal-secondary';
+    const rememberLoginInputId = 'auth-modal-remember-login';
 
     const oauthRedirectTo = useMemo(() => {
         if (typeof window === 'undefined') return undefined;
@@ -306,6 +313,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
             setErrorMessage(t('errors.default'));
             return;
         }
+        setRememberLoginEnabled(rememberLogin);
         clearPendingOAuthProvider();
 
         const requestId = pendingRequestRef.current + 1;
@@ -386,6 +394,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
         setIsSubmitting(true);
         setErrorMessage(null);
         setInfoMessage(isSlowConnection ? t('states.slowNetworkDetected') : null);
+        setRememberLoginEnabled(rememberLogin);
         setPendingOAuthProvider(provider);
         trackEvent('auth__method--select', { method: provider, source: 'modal' });
         const outcome = await runTimedRequest(
@@ -474,6 +483,12 @@ export const AuthModal: React.FC<AuthModalProps> = ({
         if (!(event.target instanceof HTMLInputElement)) return;
         event.preventDefault();
         event.currentTarget.requestSubmit();
+    };
+
+    const handleRememberLoginToggle = (checked: boolean) => {
+        setRememberLogin(checked);
+        setRememberLoginEnabled(checked);
+        trackEvent('auth__remember_login--toggle', { source: 'modal', remember_login: checked });
     };
 
     return (
@@ -609,6 +624,20 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                                 </div>
                                 {mode === 'login' && (
                                     <div className="space-y-2">
+                                        <label
+                                            htmlFor={rememberLoginInputId}
+                                            className="inline-flex cursor-pointer items-center gap-2 text-sm font-semibold text-slate-800"
+                                        >
+                                            <Checkbox
+                                                id={rememberLoginInputId}
+                                                checked={rememberLogin}
+                                                onCheckedChange={(checked) => handleRememberLoginToggle(checked === true)}
+                                                disabled={isSubmitting || isRestoreBlocked}
+                                                aria-label={t('labels.rememberLogin')}
+                                                {...getAnalyticsDebugAttributes('auth__remember_login--toggle', { source: 'modal' })}
+                                            />
+                                            <span>{t('labels.rememberLogin')}</span>
+                                        </label>
                                         <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
                                             <button
                                                 type="button"

--- a/content/updates/2026-03-03-remember-login-localhost-auth.md
+++ b/content/updates/2026-03-03-remember-login-localhost-auth.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-03-03-remember-login-localhost-auth
+version: v0.0.0
+title: "Remember login option and smoother local sign-in reuse"
+date: 2026-03-03
+published_at: 2026-03-03T10:30:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Added a remember-login control in sign-in flows and improved local auth session reuse during development."
+---
+
+## Changes
+- [x] [Improved] 🔐 Added a "Remember login" option in sign-in page and modal flows so you can choose whether your session persists on that browser.
+- [ ] [Internal] 🧪 Added localhost auth-bridge persistence so valid sessions can be reused across different local development ports.
+- [ ] [Internal] 🧹 Cleared localhost auth bridge cookies during auth recovery so stale local tokens cannot restore unexpectedly.

--- a/lib/legal/cookies.config.ts
+++ b/lib/legal/cookies.config.ts
@@ -74,6 +74,21 @@ export const COOKIE_REGISTRY: CookieRegistry = {
       notes: 'May be stored in sessionStorage by Supabase internals during OAuth handshakes.',
     },
     {
+      name: 'tf_localhost_supabase_auth_bridge_*',
+      purpose: 'Localhost-only cookie bridge for sharing Supabase auth sessions across local dev ports.',
+      duration: 'Up to 30 days',
+      provider: 'TravelFlow',
+      storage: 'cookie',
+      notes: 'Used only on localhost for development workflows; not set in production environments.',
+    },
+    {
+      name: 'tf_auth_session_persistence_v1',
+      purpose: 'Stores whether login sessions should persist across browser restarts.',
+      duration: 'Persistent',
+      provider: 'TravelFlow',
+      storage: 'localStorage',
+    },
+    {
       name: 'tf_auth_return_path_v1',
       purpose: 'Remembers the intended in-app path after successful login.',
       duration: 'Until consumed or cleared',

--- a/locales/de/auth.json
+++ b/locales/de/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "E-Mail",
     "password": "Passwort",
+    "rememberLogin": "Angemeldet bleiben",
     "newPassword": "Neues Passwort",
     "confirmPassword": "Passwort bestätigen"
   },

--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "Email",
     "password": "Password",
+    "rememberLogin": "Remember login",
     "newPassword": "New password",
     "confirmPassword": "Confirm password"
   },

--- a/locales/es/auth.json
+++ b/locales/es/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "Email",
     "password": "Password",
+    "rememberLogin": "Recordar inicio de sesión",
     "newPassword": "New password",
     "confirmPassword": "Confirm password"
   },

--- a/locales/fa/auth.json
+++ b/locales/fa/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "Email",
     "password": "Password",
+    "rememberLogin": "Remember login",
     "newPassword": "New password",
     "confirmPassword": "Confirm password"
   },

--- a/locales/fr/auth.json
+++ b/locales/fr/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "Email",
     "password": "Password",
+    "rememberLogin": "Remember login",
     "newPassword": "New password",
     "confirmPassword": "Confirm password"
   },

--- a/locales/it/auth.json
+++ b/locales/it/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "Email",
     "password": "Password",
+    "rememberLogin": "Remember login",
     "newPassword": "New password",
     "confirmPassword": "Confirm password"
   },

--- a/locales/ko/auth.json
+++ b/locales/ko/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "이메일",
     "password": "비밀번호",
+    "rememberLogin": "로그인 상태 유지",
     "newPassword": "새 비밀번호",
     "confirmPassword": "비밀번호 확인"
   },

--- a/locales/pl/auth.json
+++ b/locales/pl/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "Email",
     "password": "Password",
+    "rememberLogin": "Remember login",
     "newPassword": "New password",
     "confirmPassword": "Confirm password"
   },

--- a/locales/pt/auth.json
+++ b/locales/pt/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "Email",
     "password": "Password",
+    "rememberLogin": "Remember login",
     "newPassword": "New password",
     "confirmPassword": "Confirm password"
   },

--- a/locales/ru/auth.json
+++ b/locales/ru/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "Email",
     "password": "Password",
+    "rememberLogin": "Remember login",
     "newPassword": "New password",
     "confirmPassword": "Confirm password"
   },

--- a/locales/ur/auth.json
+++ b/locales/ur/auth.json
@@ -16,6 +16,7 @@
   "labels": {
     "email": "Email",
     "password": "Password",
+    "rememberLogin": "Remember login",
     "newPassword": "New password",
     "confirmPassword": "Confirm password"
   },

--- a/pages/LoginPage.tsx
+++ b/pages/LoginPage.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ArrowRight, SpinnerGap as Loader2 } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { Checkbox } from '../components/ui/checkbox';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
 import { useAuth } from '../hooks/useAuth';
 import { getAnalyticsDebugAttributes, trackEvent } from '../services/analyticsService';
@@ -19,6 +20,10 @@ import {
     rememberAuthReturnPath,
     resolvePreferredNextPath,
 } from '../services/authNavigationService';
+import {
+    isRememberLoginEnabled,
+    setRememberLoginEnabled,
+} from '../services/authSessionPersistenceService';
 import {
     clearPendingOAuthProvider,
     getLastUsedOAuthProvider,
@@ -90,6 +95,7 @@ const buildLoginRedirectUrl = (claimRequestId: string | null, nextPath: string):
 };
 const LOGIN_PAGE_EMAIL_INPUT_ID = 'login-page-email';
 const LOGIN_PAGE_SECONDARY_INPUT_ID = 'login-page-secondary';
+const LOGIN_PAGE_REMEMBER_CHECKBOX_ID = 'login-page-remember-login';
 
 export const LoginPage: React.FC = () => {
     const { t, i18n } = useTranslation('auth');
@@ -114,6 +120,7 @@ export const LoginPage: React.FC = () => {
     const [hasPostAuthAttempted, setHasPostAuthAttempted] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [infoMessage, setInfoMessage] = useState<string | null>(null);
+    const [rememberLogin, setRememberLogin] = useState<boolean>(() => isRememberLoginEnabled());
     const [lastUsedProvider, setLastUsedProvider] = useState<OAuthProviderId | null>(() => getLastUsedOAuthProvider());
 
     const oauthButtons = useMemo(() => getOAuthButtons(i18n.language), [i18n.language]);
@@ -250,6 +257,7 @@ export const LoginPage: React.FC = () => {
             setErrorMessage(t('errors.default'));
             return;
         }
+        setRememberLoginEnabled(rememberLogin);
         clearPendingOAuthProvider();
 
         setIsSubmitting(true);
@@ -287,6 +295,7 @@ export const LoginPage: React.FC = () => {
     const handleOAuthLogin = async (provider: OAuthProviderId) => {
         setErrorMessage(null);
         setInfoMessage(null);
+        setRememberLoginEnabled(rememberLogin);
         setPendingOAuthProvider(provider);
         trackEvent('auth__method--select', { method: provider });
         const response = await loginWithOAuth(provider, oauthRedirectTo);
@@ -335,6 +344,12 @@ export const LoginPage: React.FC = () => {
         if (!(event.target instanceof HTMLInputElement)) return;
         event.preventDefault();
         event.currentTarget.requestSubmit();
+    };
+
+    const handleRememberLoginToggle = (checked: boolean) => {
+        setRememberLogin(checked);
+        setRememberLoginEnabled(checked);
+        trackEvent('auth__remember_login--toggle', { remember_login: checked });
     };
 
     return (
@@ -417,6 +432,20 @@ export const LoginPage: React.FC = () => {
                         </div>
                         {mode === 'login' && (
                             <div className="space-y-2">
+                                <label
+                                    htmlFor={LOGIN_PAGE_REMEMBER_CHECKBOX_ID}
+                                    className="inline-flex cursor-pointer items-center gap-2 text-sm font-semibold text-slate-800"
+                                >
+                                    <Checkbox
+                                        id={LOGIN_PAGE_REMEMBER_CHECKBOX_ID}
+                                        checked={rememberLogin}
+                                        onCheckedChange={(checked) => handleRememberLoginToggle(checked === true)}
+                                        disabled={isSubmitting || isPostAuthProcessing}
+                                        aria-label={t('labels.rememberLogin')}
+                                        {...getAnalyticsDebugAttributes('auth__remember_login--toggle')}
+                                    />
+                                    <span>{t('labels.rememberLogin')}</span>
+                                </label>
                                 <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
                                     <button
                                         type="button"

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -3,6 +3,7 @@ import { getFreePlanEntitlements } from '../config/planCatalog';
 import type { PlanTierKey, SystemRole, UserAccessContext } from '../types';
 import { trackEvent } from './analyticsService';
 import { appendAuthTraceEntry } from './authTraceService';
+import { clearLocalhostSupabaseBridgeCookies } from './authSessionPersistenceService';
 import { appendClientErrorLog } from './clientErrorLogger';
 import {
     removeLocalStorageItem,
@@ -81,6 +82,7 @@ const reportAuthSupabaseSuccess = (operation: string): void => {
 
 export const clearSupabaseAuthStorage = (): void => {
     if (typeof window === 'undefined') return;
+    clearLocalhostSupabaseBridgeCookies();
     const shouldClear = (key: string): boolean => (
         key.startsWith('sb-') &&
         (

--- a/services/authSessionPersistenceService.ts
+++ b/services/authSessionPersistenceService.ts
@@ -1,0 +1,191 @@
+import {
+    readLocalStorageItem,
+    readSessionStorageItem,
+    removeLocalStorageItem,
+    removeSessionStorageItem,
+    writeLocalStorageItem,
+    writeSessionStorageItem,
+} from './browserStorageService';
+
+export type AuthSessionPersistence = 'persistent' | 'session';
+
+const AUTH_SESSION_PERSISTENCE_KEY = 'tf_auth_session_persistence_v1';
+const LOCALHOST_BRIDGE_COOKIE_ROOT = 'tf_localhost_supabase_auth_bridge_';
+const LOCALHOST_BRIDGE_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+const isBrowserRuntime = (): boolean =>
+    typeof window !== 'undefined' && typeof document !== 'undefined';
+
+const isLocalhostRuntime = (): boolean => {
+    if (!isBrowserRuntime()) return false;
+    const hostname = window.location.hostname.trim().toLowerCase();
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+};
+
+const normalizePersistenceMode = (value: unknown): AuthSessionPersistence => (
+    value === 'session' ? 'session' : 'persistent'
+);
+
+const hashStorageKey = (keyName: string): string => {
+    let hash = 2166136261;
+    for (let index = 0; index < keyName.length; index += 1) {
+        hash ^= keyName.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0).toString(16);
+};
+
+const getLocalhostBridgeCookieName = (keyName: string): string =>
+    `${LOCALHOST_BRIDGE_COOKIE_ROOT}${hashStorageKey(keyName)}`;
+
+const readCookie = (cookieName: string): string | null => {
+    if (!isBrowserRuntime()) return null;
+    const cookieParts = document.cookie ? document.cookie.split(';') : [];
+    for (const cookiePart of cookieParts) {
+        const [rawName, ...rawValueParts] = cookiePart.trim().split('=');
+        if (!rawName || rawName !== cookieName) continue;
+        const rawValue = rawValueParts.join('=');
+        try {
+            return decodeURIComponent(rawValue);
+        } catch {
+            return null;
+        }
+    }
+    return null;
+};
+
+const writeCookie = (cookieName: string, value: string): void => {
+    if (!isBrowserRuntime()) return;
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${cookieName}=${encodeURIComponent(value)}; Path=/; Max-Age=${LOCALHOST_BRIDGE_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
+};
+
+const removeCookie = (cookieName: string): void => {
+    if (!isBrowserRuntime()) return;
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${cookieName}=; Path=/; Max-Age=0; SameSite=Lax${secure}`;
+};
+
+const isSupabaseAuthTokenKey = (keyName: string): boolean =>
+    keyName.startsWith('sb-') && keyName.includes('auth-token');
+
+const readFromMedium = (medium: AuthSessionPersistence, keyName: string): string | null => (
+    medium === 'session'
+        ? readSessionStorageItem(keyName)
+        : readLocalStorageItem(keyName)
+);
+
+const writeToMedium = (medium: AuthSessionPersistence, keyName: string, value: string): void => {
+    if (medium === 'session') {
+        writeSessionStorageItem(keyName, value);
+        return;
+    }
+    writeLocalStorageItem(keyName, value);
+};
+
+const removeFromMedium = (medium: AuthSessionPersistence, keyName: string): void => {
+    if (medium === 'session') {
+        removeSessionStorageItem(keyName);
+        return;
+    }
+    removeLocalStorageItem(keyName);
+};
+
+export const getAuthSessionPersistencePreference = (): AuthSessionPersistence => {
+    if (!isBrowserRuntime()) return 'persistent';
+    const raw = readLocalStorageItem(AUTH_SESSION_PERSISTENCE_KEY);
+    return normalizePersistenceMode(raw);
+};
+
+export const setAuthSessionPersistencePreference = (mode: AuthSessionPersistence): void => {
+    if (!isBrowserRuntime()) return;
+    const normalizedMode = normalizePersistenceMode(mode);
+    writeLocalStorageItem(AUTH_SESSION_PERSISTENCE_KEY, normalizedMode);
+};
+
+export const isRememberLoginEnabled = (): boolean =>
+    getAuthSessionPersistencePreference() === 'persistent';
+
+export const setRememberLoginEnabled = (rememberLogin: boolean): void => {
+    setAuthSessionPersistencePreference(rememberLogin ? 'persistent' : 'session');
+};
+
+const syncLocalhostBridgeCookieFromStorage = (keyName: string, value: string): void => {
+    if (!isLocalhostRuntime()) return;
+    if (!isSupabaseAuthTokenKey(keyName)) return;
+    writeCookie(getLocalhostBridgeCookieName(keyName), value);
+};
+
+const restorePersistentValueFromCookie = (keyName: string): string | null => {
+    if (!isLocalhostRuntime()) return null;
+    if (!isSupabaseAuthTokenKey(keyName)) return null;
+    const cookieValue = readCookie(getLocalhostBridgeCookieName(keyName));
+    if (!cookieValue) return null;
+    writeToMedium('persistent', keyName, cookieValue);
+    return cookieValue;
+};
+
+const clearLocalhostBridgeCookieForKey = (keyName: string): void => {
+    if (!isLocalhostRuntime()) return;
+    if (!isSupabaseAuthTokenKey(keyName)) return;
+    removeCookie(getLocalhostBridgeCookieName(keyName));
+};
+
+export const clearLocalhostSupabaseBridgeCookies = (): void => {
+    if (!isLocalhostRuntime()) return;
+    const cookieParts = document.cookie ? document.cookie.split(';') : [];
+    for (const cookiePart of cookieParts) {
+        const [rawName] = cookiePart.trim().split('=');
+        if (!rawName || !rawName.startsWith(LOCALHOST_BRIDGE_COOKIE_ROOT)) continue;
+        removeCookie(rawName);
+    }
+};
+
+interface SupabaseStorageAdapter {
+    getItem: (keyName: string) => string | null;
+    setItem: (keyName: string, value: string) => void;
+    removeItem: (keyName: string) => void;
+}
+
+export const createSupabaseAuthStorageAdapter = (): SupabaseStorageAdapter => ({
+    getItem: (keyName: string): string | null => {
+        const persistenceMode = getAuthSessionPersistencePreference();
+        const primaryValue = readFromMedium(persistenceMode, keyName);
+        if (primaryValue) {
+            if (persistenceMode === 'persistent') {
+                syncLocalhostBridgeCookieFromStorage(keyName, primaryValue);
+            }
+            return primaryValue;
+        }
+
+        if (persistenceMode === 'persistent') {
+            const bridgedCookieValue = restorePersistentValueFromCookie(keyName);
+            if (bridgedCookieValue) return bridgedCookieValue;
+
+            const legacySessionValue = readFromMedium('session', keyName);
+            if (legacySessionValue) {
+                writeToMedium('persistent', keyName, legacySessionValue);
+                removeFromMedium('session', keyName);
+                syncLocalhostBridgeCookieFromStorage(keyName, legacySessionValue);
+                return legacySessionValue;
+            }
+        }
+
+        return null;
+    },
+    setItem: (keyName: string, value: string): void => {
+        const persistenceMode = getAuthSessionPersistencePreference();
+        writeToMedium(persistenceMode, keyName, value);
+        removeFromMedium(persistenceMode === 'persistent' ? 'session' : 'persistent', keyName);
+        if (persistenceMode === 'persistent') {
+            syncLocalhostBridgeCookieFromStorage(keyName, value);
+            return;
+        }
+        clearLocalhostBridgeCookieForKey(keyName);
+    },
+    removeItem: (keyName: string): void => {
+        removeFromMedium('persistent', keyName);
+        removeFromMedium('session', keyName);
+        clearLocalhostBridgeCookieForKey(keyName);
+    },
+});

--- a/services/supabaseClient.ts
+++ b/services/supabaseClient.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { createSupabaseAuthStorageAdapter } from './authSessionPersistenceService';
 
 const normalizeEnvValue = (value: unknown): string =>
     typeof value === 'string' ? value.trim() : '';
@@ -23,6 +24,7 @@ const rawSupabaseUrl = normalizeEnvValue(import.meta.env.VITE_SUPABASE_URL);
 const supabaseUrl = toValidHttpUrl(rawSupabaseUrl);
 const supabaseAnonKey = normalizeEnvValue(import.meta.env.VITE_SUPABASE_ANON_KEY);
 const hasSupabaseAnonKey = !isUnsetEnvValue(supabaseAnonKey);
+const supabaseAuthStorage = createSupabaseAuthStorageAdapter();
 
 export const isSupabaseEnabled = Boolean(supabaseUrl && hasSupabaseAnonKey);
 
@@ -35,7 +37,8 @@ export const supabase = supabaseUrl && hasSupabaseAnonKey
         auth: {
             persistSession: true,
             autoRefreshToken: true,
-            detectSessionInUrl: true
+            detectSessionInUrl: true,
+            storage: supabaseAuthStorage,
         }
     })
     : null;

--- a/tests/browser/authModal.browser.test.ts
+++ b/tests/browser/authModal.browser.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  onClose: vi.fn(),
+  rememberLoginEnabled: true,
+  setRememberLoginEnabled: vi.fn(),
+  auth: {
+    isLoading: false,
+    isAuthenticated: false,
+    isAnonymous: false,
+    loginWithPassword: vi.fn().mockResolvedValue({ error: null }),
+    registerWithPassword: vi.fn().mockResolvedValue({ error: null, data: { session: null } }),
+    loginWithOAuth: vi.fn().mockResolvedValue({ error: null }),
+    sendPasswordResetEmail: vi.fn().mockResolvedValue({ error: null }),
+  },
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock('../../components/ui/checkbox', () => ({
+  Checkbox: ({
+    id,
+    checked,
+    disabled,
+    onCheckedChange,
+    ...props
+  }: {
+    id?: string;
+    checked?: boolean;
+    disabled?: boolean;
+    onCheckedChange?: (value: boolean) => void;
+    [key: string]: unknown;
+  }) => React.createElement('input', {
+    ...props,
+    id,
+    type: 'checkbox',
+    checked: checked === true,
+    disabled,
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => onCheckedChange?.(event.currentTarget.checked),
+  }),
+}));
+
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => mocks.auth,
+}));
+
+vi.mock('../../hooks/useFocusTrap', () => ({
+  useFocusTrap: () => undefined,
+}));
+
+vi.mock('../../hooks/useNetworkStatus', () => ({
+  useNetworkStatus: () => ({ isOnline: true, isSlowConnection: false }),
+}));
+
+vi.mock('../../services/networkStatus', () => ({
+  getAuthRequestTimeoutMs: () => 8000,
+  getAuthRestoreTimeoutMs: () => 8000,
+}));
+
+vi.mock('../../services/analyticsService', () => ({
+  trackEvent: mocks.trackEvent,
+  getAnalyticsDebugAttributes: () => ({}),
+}));
+
+vi.mock('../../services/authNavigationService', () => ({
+  buildPasswordResetRedirectUrl: () => 'https://example.com/auth/reset-password',
+}));
+
+vi.mock('../../services/authUiPreferencesService', () => ({
+  clearPendingOAuthProvider: vi.fn(),
+  getLastUsedOAuthProvider: () => null,
+  setPendingOAuthProvider: vi.fn(),
+}));
+
+vi.mock('../../services/authSessionPersistenceService', () => ({
+  isRememberLoginEnabled: () => mocks.rememberLoginEnabled,
+  setRememberLoginEnabled: mocks.setRememberLoginEnabled,
+}));
+
+vi.mock('../../components/auth/SocialProviderIcon', () => ({
+  SocialProviderIcon: () => React.createElement('span', null, 'icon'),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      language: 'en',
+      resolvedLanguage: 'en',
+    },
+  }),
+}));
+
+import { AuthModal } from '../../components/auth/AuthModal';
+
+describe('components/auth/AuthModal remember login', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rememberLoginEnabled = true;
+    mocks.auth.isLoading = false;
+    mocks.auth.isAuthenticated = false;
+    mocks.auth.isAnonymous = false;
+  });
+
+  it('uses session-only persistence when remember login is unchecked before password sign-in', async () => {
+    const user = userEvent.setup();
+
+    render(
+      React.createElement(AuthModal, {
+        isOpen: true,
+        source: 'test',
+        nextPath: '/create-trip',
+        reloadOnSuccess: false,
+        onClose: mocks.onClose,
+      }),
+    );
+
+    const rememberCheckbox = screen.getByRole('checkbox', { name: 'labels.rememberLogin' });
+    const emailInput = screen.getByLabelText('labels.email');
+    const passwordInput = screen.getByLabelText('labels.password');
+    const submitButton = screen.getByRole('button', { name: 'actions.submitLogin' });
+
+    await user.click(rememberCheckbox);
+    await user.type(emailInput, 'traveler@example.com');
+    await user.type(passwordInput, 'password123');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mocks.auth.loginWithPassword).toHaveBeenCalledWith('traveler@example.com', 'password123');
+    });
+    expect(mocks.setRememberLoginEnabled).toHaveBeenLastCalledWith(false);
+  });
+});
+

--- a/tests/browser/authService.browser.test.ts
+++ b/tests/browser/authService.browser.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from 'vitest';
 import { clearSupabaseAuthStorage } from '../../services/authService';
+import { createSupabaseAuthStorageAdapter, setAuthSessionPersistencePreference } from '../../services/authSessionPersistenceService';
 import {
   readLocalStorageItem,
   readSessionStorageItem,
@@ -15,6 +16,10 @@ describe('services/authService clearSupabaseAuthStorage', () => {
   });
 
   it('clears wildcard Supabase auth keys from both local and session storage', () => {
+    const storageAdapter = createSupabaseAuthStorageAdapter();
+    setAuthSessionPersistencePreference('persistent');
+    storageAdapter.setItem('sb-demo-auth-token', 'local-auth');
+
     expect(writeLocalStorageItem('sb-demo-auth-token', 'local-auth')).toBe(true);
     expect(writeLocalStorageItem('sb-demo-refresh-token', 'local-refresh')).toBe(true);
     expect(writeLocalStorageItem('sb-demo-code-verifier', 'local-code')).toBe(true);
@@ -34,5 +39,6 @@ describe('services/authService clearSupabaseAuthStorage', () => {
     expect(readSessionStorageItem('sb-demo-code-verifier')).toBeNull();
     expect(readLocalStorageItem('tf_map_style')).toBe('standard');
     expect(window.sessionStorage.getItem('sb-demo-provider-state')).toBe('keep');
+    expect(storageAdapter.getItem('sb-demo-auth-token')).toBeNull();
   });
 });

--- a/tests/browser/authSessionPersistenceService.browser.test.ts
+++ b/tests/browser/authSessionPersistenceService.browser.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  createSupabaseAuthStorageAdapter,
+  getAuthSessionPersistencePreference,
+  setAuthSessionPersistencePreference,
+  setRememberLoginEnabled,
+} from '../../services/authSessionPersistenceService';
+import { readLocalStorageItem, readSessionStorageItem } from '../../services/browserStorageService';
+
+const SUPABASE_AUTH_KEY = 'sb-demo-auth-token';
+
+const clearAllCookies = (): void => {
+  const cookieParts = document.cookie ? document.cookie.split(';') : [];
+  for (const cookiePart of cookieParts) {
+    const [name] = cookiePart.trim().split('=');
+    if (!name) continue;
+    document.cookie = `${name}=; Path=/; Max-Age=0; SameSite=Lax`;
+  }
+};
+
+describe('services/authSessionPersistenceService', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    clearAllCookies();
+    setAuthSessionPersistencePreference('persistent');
+  });
+
+  it('stores remember-login preference in localStorage', () => {
+    expect(getAuthSessionPersistencePreference()).toBe('persistent');
+
+    setRememberLoginEnabled(false);
+    expect(getAuthSessionPersistencePreference()).toBe('session');
+
+    setRememberLoginEnabled(true);
+    expect(getAuthSessionPersistencePreference()).toBe('persistent');
+  });
+
+  it('uses persistent localStorage mode and restores from localhost bridge cookie', () => {
+    const storage = createSupabaseAuthStorageAdapter();
+    storage.setItem(SUPABASE_AUTH_KEY, 'persistent-token');
+
+    expect(readLocalStorageItem(SUPABASE_AUTH_KEY)).toBe('persistent-token');
+    expect(readSessionStorageItem(SUPABASE_AUTH_KEY)).toBeNull();
+
+    window.localStorage.removeItem(SUPABASE_AUTH_KEY);
+
+    expect(storage.getItem(SUPABASE_AUTH_KEY)).toBe('persistent-token');
+    expect(readLocalStorageItem(SUPABASE_AUTH_KEY)).toBe('persistent-token');
+  });
+
+  it('uses sessionStorage mode without reading localhost bridge cookies', () => {
+    const storage = createSupabaseAuthStorageAdapter();
+    storage.setItem(SUPABASE_AUTH_KEY, 'persistent-token');
+
+    setAuthSessionPersistencePreference('session');
+    window.localStorage.removeItem(SUPABASE_AUTH_KEY);
+
+    expect(storage.getItem(SUPABASE_AUTH_KEY)).toBeNull();
+
+    storage.setItem(SUPABASE_AUTH_KEY, 'session-token');
+    expect(readSessionStorageItem(SUPABASE_AUTH_KEY)).toBe('session-token');
+    expect(readLocalStorageItem(SUPABASE_AUTH_KEY)).toBeNull();
+  });
+});
+

--- a/tests/browser/loginPage.browser.test.ts
+++ b/tests/browser/loginPage.browser.test.ts
@@ -22,6 +22,8 @@ const mocks = vi.hoisted(() => ({
     loginWithOAuth: vi.fn().mockResolvedValue({ error: null }),
     sendPasswordResetEmail: vi.fn().mockResolvedValue({ error: null }),
   },
+  rememberLoginEnabled: true,
+  setRememberLoginEnabled: vi.fn(),
   runOpportunisticTripQueueCleanup: vi.fn().mockResolvedValue(undefined),
   processQueuedTripGenerationAfterAuth: vi.fn(),
   runOpportunisticAnonymousAssetClaimCleanup: vi.fn().mockResolvedValue(undefined),
@@ -38,6 +40,29 @@ vi.mock('react-router-dom', () => ({
 
 vi.mock('../../components/marketing/MarketingLayout', () => ({
   MarketingLayout: ({ children }: { children: React.ReactNode }) => React.createElement('div', null, children),
+}));
+
+vi.mock('../../components/ui/checkbox', () => ({
+  Checkbox: ({
+    id,
+    checked,
+    disabled,
+    onCheckedChange,
+    ...props
+  }: {
+    id?: string;
+    checked?: boolean;
+    disabled?: boolean;
+    onCheckedChange?: (value: boolean) => void;
+    [key: string]: unknown;
+  }) => React.createElement('input', {
+    ...props,
+    id,
+    type: 'checkbox',
+    checked: checked === true,
+    disabled,
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => onCheckedChange?.(event.currentTarget.checked),
+  }),
 }));
 
 vi.mock('../../hooks/useAuth', () => ({
@@ -74,6 +99,11 @@ vi.mock('../../services/authUiPreferencesService', () => ({
   setPendingOAuthProvider: vi.fn(),
 }));
 
+vi.mock('../../services/authSessionPersistenceService', () => ({
+  isRememberLoginEnabled: () => mocks.rememberLoginEnabled,
+  setRememberLoginEnabled: mocks.setRememberLoginEnabled,
+}));
+
 vi.mock('../../components/auth/SocialProviderIcon', () => ({
   SocialProviderIcon: () => React.createElement('span', null, 'icon'),
 }));
@@ -104,6 +134,7 @@ describe('pages/LoginPage keyboard submit', () => {
     mocks.auth.isLoading = false;
     mocks.auth.isAuthenticated = false;
     mocks.auth.isAnonymous = false;
+    mocks.rememberLoginEnabled = true;
   });
 
   it('submits credentials when Enter is pressed in the password field', async () => {
@@ -120,6 +151,26 @@ describe('pages/LoginPage keyboard submit', () => {
     await waitFor(() => {
       expect(mocks.auth.loginWithPassword).toHaveBeenCalledWith('traveler@example.com', 'password123');
     });
+    expect(mocks.setRememberLoginEnabled).toHaveBeenLastCalledWith(true);
+  });
+
+  it('switches to session-only persistence when remember login is unchecked', async () => {
+    const user = userEvent.setup();
+
+    render(React.createElement(LoginPage));
+
+    const rememberCheckbox = screen.getByRole('checkbox', { name: 'labels.rememberLogin' });
+    const emailInput = screen.getByLabelText('labels.email');
+    const passwordInput = screen.getByLabelText('labels.password');
+
+    await user.click(rememberCheckbox);
+    await user.type(emailInput, 'traveler@example.com');
+    await user.type(passwordInput, 'password123{enter}');
+
+    await waitFor(() => {
+      expect(mocks.auth.loginWithPassword).toHaveBeenCalledWith('traveler@example.com', 'password123');
+    });
+    expect(mocks.setRememberLoginEnabled).toHaveBeenLastCalledWith(false);
   });
 
   it('processes asset claim before queued generation claim after auth callback', async () => {


### PR DESCRIPTION
## Summary
- add a `Remember login` checkbox to both login entry points: the full login page and the auth modal
- persist the remember-login preference and route Supabase auth storage through a custom adapter
- support localhost cross-port auth reuse (`localhost:517x`) when remember-login is enabled via a localhost-only cookie bridge
- clear localhost auth bridge cookies during auth recovery/logout cleanup to avoid stale session restoration
- register new storage keys in legal storage registry and update auth locale keys
- add regression coverage for login page, auth modal, auth persistence service, and auth storage cleanup behavior

## Testing
- `pnpm test:run tests/browser/authModal.browser.test.ts tests/browser/loginPage.browser.test.ts tests/browser/authSessionPersistenceService.browser.test.ts tests/browser/authService.browser.test.ts`
- `pnpm i18n:validate`
- `pnpm storage:validate`
- `pnpm test:core`
- `pnpm updates:validate`
- `pnpm dlx react-doctor@latest . --verbose --diff`

## Notes
- `react-doctor` reported warnings in existing large components/files; no new blocking errors were introduced by this change.
