### PR TITLE
Admin dashboard: stacked trends, DD.MM dates, and table scroll fix

### DIFF
--- a/components/admin/adminDashboardChartData.ts
+++ b/components/admin/adminDashboardChartData.ts
@@ -1,0 +1,168 @@
+import type { AdminDateRange } from './AdminShell';
+import { isIsoDateInRange } from './adminDateRange';
+import type { AdminTripRecord, AdminUserRecord } from '../../services/adminService';
+import type { AdminDashboardUserLevelBreakdownItem } from './adminDashboardUserBreakdown';
+import { resolveAdminDashboardUserLevelKey } from './adminDashboardUserBreakdown';
+
+type RowWithDate = { date: string };
+
+const DEFAULT_MAX_DAYS = 21;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const TRIP_STATUS_STACKED_CATEGORIES = ['Active trips', 'Expired trips', 'Archived trips'] as const;
+export const ACTIVITY_STACKED_CATEGORIES = ['New users', 'New trips'] as const;
+
+const tripStatusCategoryByStatus: Record<AdminTripRecord['status'], (typeof TRIP_STATUS_STACKED_CATEGORIES)[number]> = {
+    active: 'Active trips',
+    expired: 'Expired trips',
+    archived: 'Archived trips',
+};
+
+const toDayKey = (isoDate: string | null | undefined): string | null => {
+    if (!isoDate) return null;
+    const timestamp = Date.parse(isoDate);
+    if (!Number.isFinite(timestamp)) return null;
+    return new Date(timestamp).toISOString().slice(0, 10);
+};
+
+const toDayLabel = (dayKey: string): string => `${dayKey.slice(8, 10)}.${dayKey.slice(5, 7)}`;
+
+const sortAndSliceRecent = <TRow extends RowWithDate>(rows: TRow[], maxDays: number): TRow[] => (
+    [...rows]
+        .sort((a, b) => a.date.localeCompare(b.date))
+        .slice(-Math.max(1, maxDays))
+);
+
+export const filterDashboardUsersByRange = (
+    users: AdminUserRecord[],
+    dateRange: AdminDateRange
+): AdminUserRecord[] => users.filter((user) => isIsoDateInRange(user.created_at, dateRange));
+
+export const filterDashboardTripsByRange = (
+    trips: AdminTripRecord[],
+    dateRange: AdminDateRange
+): AdminTripRecord[] => trips.filter((trip) => isIsoDateInRange(trip.created_at, dateRange));
+
+export const buildUserLevelCumulativeStackedChartData = (
+    allUsers: AdminUserRecord[],
+    visibleRangeUsers: AdminUserRecord[],
+    userLevelBreakdown: AdminDashboardUserLevelBreakdownItem[],
+    dateRange: AdminDateRange
+): Array<{ date: string } & Record<string, number>> => {
+    const labels = userLevelBreakdown.map((item) => item.label);
+    if (labels.length === 0) return [];
+
+    const labelByKey = new Map(userLevelBreakdown.map((item) => [item.key, item.label]));
+    const dynamicDayKeys = Array.from(new Set(visibleRangeUsers
+        .map((user) => toDayKey(user.created_at))
+        .filter((dayKey): dayKey is string => typeof dayKey === 'string'))).sort((a, b) => a.localeCompare(b));
+    const staticRangeDayCount = dateRange === '7d' ? 7 : dateRange === '30d' ? 30 : dateRange === '90d' ? 90 : null;
+    const dayKeys = staticRangeDayCount
+        ? Array.from({ length: staticRangeDayCount }, (_, index) => {
+            const offsetDays = staticRangeDayCount - index - 1;
+            return new Date(Date.now() - (offsetDays * DAY_MS)).toISOString().slice(0, 10);
+        })
+        : dynamicDayKeys;
+    if (dayKeys.length === 0) return [];
+
+    const firstDay = dayKeys[0];
+    const baselineTotals: Record<string, number> = Object.fromEntries(labels.map((label) => [label, 0]));
+
+    allUsers.forEach((user) => {
+        const dayKey = toDayKey(user.created_at);
+        if (!dayKey || dayKey >= firstDay) return;
+        const label = labelByKey.get(resolveAdminDashboardUserLevelKey(user));
+        if (!label) return;
+        baselineTotals[label] += 1;
+    });
+
+    const dailyIncrements = new Map<string, Record<string, number>>();
+    visibleRangeUsers.forEach((user) => {
+        const dayKey = toDayKey(user.created_at);
+        if (!dayKey) return;
+        const label = labelByKey.get(resolveAdminDashboardUserLevelKey(user));
+        if (!label) return;
+        const existing = dailyIncrements.get(dayKey) || Object.fromEntries(labels.map((name) => [name, 0]));
+        existing[label] += 1;
+        dailyIncrements.set(dayKey, existing);
+    });
+
+    const runningTotals: Record<string, number> = { ...baselineTotals };
+    const result = dayKeys.map((dayKey) => {
+        const increments = dailyIncrements.get(dayKey);
+        if (increments) {
+            labels.forEach((label) => {
+                runningTotals[label] += increments[label] || 0;
+            });
+        }
+        return {
+            date: dayKey,
+            ...runningTotals,
+        };
+    });
+
+    return sortAndSliceRecent(result, dayKeys.length).map((row) => ({
+        ...row,
+        date: toDayLabel(row.date),
+    }));
+};
+
+export const buildTripStatusStackedChartData = (
+    trips: AdminTripRecord[],
+    maxDays = DEFAULT_MAX_DAYS
+): Array<{ date: string } & Record<(typeof TRIP_STATUS_STACKED_CATEGORIES)[number], number>> => {
+    const buckets = new Map<string, { date: string } & Record<(typeof TRIP_STATUS_STACKED_CATEGORIES)[number], number>>();
+    trips.forEach((trip) => {
+        const dayKey = toDayKey(trip.created_at);
+        if (!dayKey) return;
+        const existing = buckets.get(dayKey) || {
+            date: dayKey,
+            'Active trips': 0,
+            'Expired trips': 0,
+            'Archived trips': 0,
+        };
+        existing[tripStatusCategoryByStatus[trip.status]] += 1;
+        buckets.set(dayKey, existing);
+    });
+    return sortAndSliceRecent(Array.from(buckets.values()), maxDays).map((row) => ({
+        ...row,
+        date: toDayLabel(row.date),
+    }));
+};
+
+export const buildUsersVsTripsStackedChartData = (
+    users: AdminUserRecord[],
+    trips: AdminTripRecord[],
+    maxDays = DEFAULT_MAX_DAYS
+): Array<{ date: string } & Record<(typeof ACTIVITY_STACKED_CATEGORIES)[number], number>> => {
+    const buckets = new Map<string, { date: string } & Record<(typeof ACTIVITY_STACKED_CATEGORIES)[number], number>>();
+
+    users.forEach((user) => {
+        const dayKey = toDayKey(user.created_at);
+        if (!dayKey) return;
+        const existing = buckets.get(dayKey) || {
+            date: dayKey,
+            'New users': 0,
+            'New trips': 0,
+        };
+        existing['New users'] += 1;
+        buckets.set(dayKey, existing);
+    });
+
+    trips.forEach((trip) => {
+        const dayKey = toDayKey(trip.created_at);
+        if (!dayKey) return;
+        const existing = buckets.get(dayKey) || {
+            date: dayKey,
+            'New users': 0,
+            'New trips': 0,
+        };
+        existing['New trips'] += 1;
+        buckets.set(dayKey, existing);
+    });
+
+    return sortAndSliceRecent(Array.from(buckets.values()), maxDays).map((row) => ({
+        ...row,
+        date: toDayLabel(row.date),
+    }));
+};

--- a/components/admin/adminDashboardUserBreakdown.ts
+++ b/components/admin/adminDashboardUserBreakdown.ts
@@ -1,0 +1,69 @@
+import { PLAN_CATALOG } from '../../config/planCatalog';
+import type { AdminUserRecord } from '../../services/adminService';
+import type { PlanTierKey } from '../../types';
+
+export type AdminDashboardUserLevelKey = 'admin' | PlanTierKey;
+
+export interface AdminDashboardUserLevelBreakdownItem {
+    key: AdminDashboardUserLevelKey;
+    label: string;
+    count: number;
+    shareOfTotal: number;
+    shareLabel: string;
+    tooltip: string;
+}
+
+const INTEGER_FORMATTER = new Intl.NumberFormat();
+const SHARE_FORMATTER = new Intl.NumberFormat(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 1 });
+
+const USER_LEVEL_ORDER: AdminDashboardUserLevelKey[] = [
+    'admin',
+    'tier_premium',
+    'tier_mid',
+    'tier_free',
+];
+
+const USER_LEVEL_LABELS: Record<AdminDashboardUserLevelKey, string> = {
+    admin: 'Admin',
+    tier_premium: PLAN_CATALOG.tier_premium.publicName,
+    tier_mid: PLAN_CATALOG.tier_mid.publicName,
+    tier_free: PLAN_CATALOG.tier_free.publicName,
+};
+
+export const resolveAdminDashboardUserLevelKey = (user: AdminUserRecord): AdminDashboardUserLevelKey => {
+    if (user.system_role === 'admin') return 'admin';
+    return user.tier_key;
+};
+
+const buildInitialCounts = (): Record<AdminDashboardUserLevelKey, number> => ({
+    admin: 0,
+    tier_premium: 0,
+    tier_mid: 0,
+    tier_free: 0,
+});
+
+export const buildAdminDashboardUserLevelBreakdown = (
+    users: AdminUserRecord[]
+): AdminDashboardUserLevelBreakdownItem[] => {
+    const counts = buildInitialCounts();
+    users.forEach((user) => {
+        const levelKey = resolveAdminDashboardUserLevelKey(user);
+        counts[levelKey] += 1;
+    });
+
+    const totalUsers = users.length;
+    return USER_LEVEL_ORDER.map((key) => {
+        const count = counts[key];
+        const shareOfTotal = totalUsers > 0 ? count / totalUsers : 0;
+        const shareLabel = `${SHARE_FORMATTER.format(shareOfTotal * 100)}%`;
+        const tooltip = `${USER_LEVEL_LABELS[key]}: ${INTEGER_FORMATTER.format(count)} of ${INTEGER_FORMATTER.format(totalUsers)} total users (${shareLabel})`;
+        return {
+            key,
+            label: USER_LEVEL_LABELS[key],
+            count,
+            shareOfTotal,
+            shareLabel,
+            tooltip,
+        };
+    });
+};

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -6,7 +6,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto overscroll-none"
+      className="relative w-full overflow-x-auto overscroll-x-contain"
     >
       <table
         data-slot="table"

--- a/content/updates/2026-03-05-admin-dashboard-user-level-breakdown.md
+++ b/content/updates/2026-03-05-admin-dashboard-user-level-breakdown.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-03-05-admin-dashboard-user-level-breakdown
+version: v0.0.0
+title: "Admin dashboard user-level breakdown in Total Users card"
+date: 2026-03-05
+published_at: 2026-03-05T12:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Updated the admin dashboard Total Users card to show a clear breakdown by user level with total-share tooltips."
+---
+
+## Changes
+- [ ] [Internal] 📊 Refreshed admin dashboard visuals with stacked Tremor bar charts for cumulative user levels over time, trip status trends, and a new users-vs-trips throughput view.
+- [ ] [Internal] 🗓️ Corrected dashboard date-range scoping so charted trip/user trends consistently follow the selected range by creation time.
+- [ ] [Internal] 📅 Standardized dashboard chart date labels to `DD.MM` (year omitted for current yearly scope).
+- [ ] [Internal] 🧭 Updated shared table scroll containment so hovering admin data tables no longer blocks vertical page scrolling.

--- a/pages/AdminDashboardPage.tsx
+++ b/pages/AdminDashboardPage.tsx
@@ -1,11 +1,20 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { AdminShell, type AdminDateRange } from '../components/admin/AdminShell';
-import { isIsoDateInRange } from '../components/admin/adminDateRange';
 import { adminListTrips, adminListUsers, type AdminTripRecord, type AdminUserRecord } from '../services/adminService';
 import { AdminReloadButton } from '../components/admin/AdminReloadButton';
 import { AdminCountUpNumber } from '../components/admin/AdminCountUpNumber';
-import { Card, Metric, Text, Flex, Grid, ProgressBar, BarChart, DonutChart, Title } from '@tremor/react';
+import { buildAdminDashboardUserLevelBreakdown } from '../components/admin/adminDashboardUserBreakdown';
+import {
+    ACTIVITY_STACKED_CATEGORIES,
+    buildTripStatusStackedChartData,
+    buildUserLevelCumulativeStackedChartData,
+    buildUsersVsTripsStackedChartData,
+    filterDashboardTripsByRange,
+    filterDashboardUsersByRange,
+    TRIP_STATUS_STACKED_CATEGORIES,
+} from '../components/admin/adminDashboardChartData';
+import { Card, Metric, Text, Flex, Grid, ProgressBar, BarChart, Title } from '@tremor/react';
 
 const formatValue = (value: number): string => new Intl.NumberFormat().format(value);
 
@@ -74,29 +83,25 @@ export const AdminDashboardPage: React.FC = () => {
     }, [dateRange, searchValue]);
 
     const scopedUsers = useMemo(
-        () => users.filter((user) => isIsoDateInRange(user.created_at, dateRange)),
+        () => filterDashboardUsersByRange(users, dateRange),
         [dateRange, users]
     );
 
     const scopedTrips = useMemo(
-        () => trips.filter((trip) => isIsoDateInRange(trip.updated_at || trip.created_at, dateRange)),
+        () => filterDashboardTripsByRange(trips, dateRange),
         [dateRange, trips]
     );
 
     const metrics = useMemo(() => {
         const totalUsers = scopedUsers.length;
-        const activeUsers = scopedUsers.filter((user) => (user.account_status || 'active') === 'active').length;
         const disabledUsers = scopedUsers.filter((user) => user.account_status === 'disabled').length;
-        const adminUsers = scopedUsers.filter((user) => user.system_role === 'admin').length;
         const totalTrips = scopedTrips.length;
         const activeTrips = scopedTrips.filter((trip) => trip.status === 'active').length;
         const expiredTrips = scopedTrips.filter((trip) => trip.status === 'expired').length;
         const archivedTrips = scopedTrips.filter((trip) => trip.status === 'archived').length;
         return {
             totalUsers,
-            activeUsers,
             disabledUsers,
-            adminUsers,
             totalTrips,
             activeTrips,
             expiredTrips,
@@ -104,6 +109,25 @@ export const AdminDashboardPage: React.FC = () => {
         };
     }, [scopedTrips, scopedUsers]);
 
+    const userLevelBreakdown = useMemo(
+        () => buildAdminDashboardUserLevelBreakdown(scopedUsers),
+        [scopedUsers]
+    );
+
+    const userLevelTrendStackedChartData = useMemo(
+        () => buildUserLevelCumulativeStackedChartData(users, scopedUsers, userLevelBreakdown, dateRange),
+        [dateRange, scopedUsers, userLevelBreakdown, users]
+    );
+
+    const tripStatusStackedChartData = useMemo(
+        () => buildTripStatusStackedChartData(scopedTrips),
+        [scopedTrips]
+    );
+
+    const usersVsTripsStackedChartData = useMemo(
+        () => buildUsersVsTripsStackedChartData(scopedUsers, scopedTrips),
+        [scopedTrips, scopedUsers]
+    );
 
 
     return (
@@ -132,11 +156,18 @@ export const AdminDashboardPage: React.FC = () => {
                 <Card decoration="top" decorationColor="indigo">
                     <Text>Total Users</Text>
                     <Metric><AdminCountUpNumber value={metrics.totalUsers} /></Metric>
-                    <Flex className="mt-4">
-                        <Text>Active / Total</Text>
-                        <Text>{formatValue(metrics.activeUsers)} / {formatValue(metrics.totalUsers)}</Text>
-                    </Flex>
-                    <ProgressBar value={metrics.totalUsers ? (metrics.activeUsers / metrics.totalUsers) * 100 : 0} color="indigo" className="mt-2" />
+                    <div className="mt-4 space-y-2">
+                        {userLevelBreakdown.map((level) => (
+                            <Flex
+                                key={`total-users-level-${level.key}`}
+                                className="rounded-md border border-slate-100 bg-slate-50 px-2 py-1.5"
+                                data-tooltip={level.tooltip}
+                            >
+                                <Text>{level.label}</Text>
+                                <Text>{formatValue(level.count)} ({level.shareLabel})</Text>
+                            </Flex>
+                        ))}
+                    </div>
                 </Card>
                 <Card decoration="top" decorationColor="emerald">
                     <Text>Total Trips</Text>
@@ -145,7 +176,7 @@ export const AdminDashboardPage: React.FC = () => {
                         <Text>Active / Total</Text>
                         <Text>{formatValue(metrics.activeTrips)} / {formatValue(metrics.totalTrips)}</Text>
                     </Flex>
-                    <ProgressBar value={metrics.totalTrips ? (metrics.activeTrips / metrics.totalTrips) * 100 : 0} color="emerald" className="mt-2" />
+                    <ProgressBar value={metrics.totalTrips ? (metrics.activeTrips / metrics.totalTrips) * 100 : 0} className="mt-2" />
                 </Card>
                 <Card decoration="top" decorationColor="amber">
                     <Text>Expired Trips</Text>
@@ -161,45 +192,46 @@ export const AdminDashboardPage: React.FC = () => {
 
             <Grid numItemsLg={2} className="gap-6 mt-6">
                 <Card>
-                    <Title>Trips Created Over Time</Title>
+                    <Title>User Levels Over Time</Title>
+                    <Text className="mt-1">Cumulative total users by level for each day in the selected range.</Text>
                     <BarChart
                         className="mt-6 h-72"
-                        data={(() => {
-                            const days: Record<string, number> = {};
-                            scopedTrips.forEach((t) => {
-                                const d = new Date(t.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-                                days[d] = (days[d] || 0) + 1;
-                            });
-                            return Object.entries(days).map(([date, count]) => ({ date, 'Trips Created': count })).reverse().slice(0, 14).reverse();
-                        })()}
+                        data={userLevelTrendStackedChartData}
                         index="date"
-                        categories={['Trips Created']}
-                        colors={['indigo']}
+                        categories={userLevelBreakdown.map((level) => level.label)}
+                        stack
                         yAxisWidth={48}
                     />
                 </Card>
 
                 <Card>
-                    <Title>User Login Providers</Title>
-                    <div className="mt-6 flex h-72 items-center justify-center">
-                        <DonutChart
-                            data={(() => {
-                                const counts: Record<string, number> = {};
-                                scopedUsers.forEach((u) => {
-                                    const label = getLoginLabel(u);
-                                    counts[label] = (counts[label] || 0) + 1;
-                                });
-                                return Object.entries(counts).map(([name, value]) => ({ name, value })).sort((a, b) => b.value - a.value);
-                            })()}
-                            category="value"
-                            index="name"
-                            colors={['indigo', 'cyan', 'amber', 'emerald', 'slate']}
-                            className="h-full w-full max-h-[240px]"
-                            showAnimation
-                        />
-                    </div>
+                    <Title>Trips by Status Over Time</Title>
+                    <Text className="mt-1">Single stacked view of active, expired, and archived trips by creation day.</Text>
+                    <BarChart
+                        className="mt-6 h-72"
+                        data={tripStatusStackedChartData}
+                        index="date"
+                        categories={[...TRIP_STATUS_STACKED_CATEGORIES]}
+                        stack
+                        yAxisWidth={48}
+                    />
                 </Card>
             </Grid>
+
+            <section className="mt-6">
+                <Card>
+                    <Title>New Users vs New Trips</Title>
+                    <Text className="mt-1">Acquisition and planning throughput trend within the selected date range.</Text>
+                    <BarChart
+                        className="mt-6 h-72"
+                        data={usersVsTripsStackedChartData}
+                        index="date"
+                        categories={[...ACTIVITY_STACKED_CATEGORIES]}
+                        stack
+                        yAxisWidth={48}
+                    />
+                </Card>
+            </section>
 
             <section className="mt-6">
                 <Card>

--- a/tests/unit/adminDashboardChartData.test.ts
+++ b/tests/unit/adminDashboardChartData.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AdminTripRecord, AdminUserRecord } from '../../services/adminService';
+import {
+    buildTripStatusStackedChartData,
+    buildUserLevelCumulativeStackedChartData,
+    buildUsersVsTripsStackedChartData,
+    filterDashboardTripsByRange,
+} from '../../components/admin/adminDashboardChartData';
+import type { AdminDashboardUserLevelBreakdownItem } from '../../components/admin/adminDashboardUserBreakdown';
+
+const buildTrip = (overrides: Partial<AdminTripRecord>): AdminTripRecord => ({
+    trip_id: 'trip-1',
+    owner_id: 'user-1',
+    owner_email: 'user@example.com',
+    title: 'Trip',
+    status: 'active',
+    generation_state: null,
+    trip_expires_at: null,
+    archived_at: null,
+    source_kind: null,
+    created_at: '2026-03-01T10:00:00.000Z',
+    updated_at: '2026-03-01T10:00:00.000Z',
+    ...overrides,
+});
+
+const buildUser = (overrides: Partial<AdminUserRecord>): AdminUserRecord => ({
+    user_id: 'user-1',
+    email: 'user@example.com',
+    system_role: 'user',
+    tier_key: 'tier_free',
+    entitlements_override: null,
+    created_at: '2026-03-01T10:00:00.000Z',
+    updated_at: '2026-03-01T10:00:00.000Z',
+    ...overrides,
+});
+
+describe('components/admin/adminDashboardChartData', () => {
+    beforeEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('filters dashboard trips by created_at so updated legacy trips do not leak into range', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-03-31T12:00:00.000Z'));
+        const filtered = filterDashboardTripsByRange([
+            buildTrip({
+                trip_id: 'legacy-trip',
+                created_at: '2025-12-01T09:00:00.000Z',
+                updated_at: '2026-03-30T09:00:00.000Z',
+            }),
+            buildTrip({
+                trip_id: 'recent-trip',
+                created_at: '2026-03-20T09:00:00.000Z',
+                updated_at: '2026-03-20T09:00:00.000Z',
+            }),
+        ], '30d');
+        expect(filtered.map((trip) => trip.trip_id)).toEqual(['recent-trip']);
+    });
+
+    it('builds stacked trip-status trend rows by creation day', () => {
+        const data = buildTripStatusStackedChartData([
+            buildTrip({ trip_id: 'a', status: 'active', created_at: '2026-03-02T12:00:00.000Z' }),
+            buildTrip({ trip_id: 'b', status: 'expired', created_at: '2026-03-02T18:00:00.000Z' }),
+            buildTrip({ trip_id: 'c', status: 'archived', created_at: '2026-03-03T08:00:00.000Z' }),
+        ], 30);
+        expect(data).toEqual([
+            { date: '02.03', 'Active trips': 1, 'Expired trips': 1, 'Archived trips': 0 },
+            { date: '03.03', 'Active trips': 0, 'Expired trips': 0, 'Archived trips': 1 },
+        ]);
+    });
+
+    it('builds stacked users-vs-trips trend rows by day', () => {
+        const data = buildUsersVsTripsStackedChartData(
+            [
+                buildUser({ user_id: 'u1', created_at: '2026-03-02T08:00:00.000Z' }),
+                buildUser({ user_id: 'u2', created_at: '2026-03-02T09:00:00.000Z' }),
+                buildUser({ user_id: 'u3', created_at: '2026-03-03T09:00:00.000Z' }),
+            ],
+            [
+                buildTrip({ trip_id: 't1', created_at: '2026-03-02T11:00:00.000Z' }),
+                buildTrip({ trip_id: 't2', created_at: '2026-03-04T11:00:00.000Z' }),
+            ],
+            30
+        );
+        expect(data).toEqual([
+            { date: '02.03', 'New users': 2, 'New trips': 1 },
+            { date: '03.03', 'New users': 1, 'New trips': 0 },
+            { date: '04.03', 'New users': 0, 'New trips': 1 },
+        ]);
+    });
+
+    it('builds cumulative user-level totals over time (not per-day new counts)', () => {
+        const breakdown: AdminDashboardUserLevelBreakdownItem[] = [
+            { key: 'admin', label: 'Admin', count: 2, shareOfTotal: 0.2, shareLabel: '20%', tooltip: 'Admin: 2 of 10 total users (20%)' },
+            { key: 'tier_premium', label: 'Globetrotter', count: 2, shareOfTotal: 0.2, shareLabel: '20%', tooltip: 'Globetrotter: 2 of 10 total users (20%)' },
+            { key: 'tier_mid', label: 'Explorer', count: 3, shareOfTotal: 0.3, shareLabel: '30%', tooltip: 'Explorer: 3 of 10 total users (30%)' },
+            { key: 'tier_free', label: 'Backpacker', count: 3, shareOfTotal: 0.3, shareLabel: '30%', tooltip: 'Backpacker: 3 of 10 total users (30%)' },
+        ];
+        const allUsers = [
+            buildUser({ user_id: 'base-admin', system_role: 'admin', created_at: '2026-02-20T10:00:00.000Z' }),
+            buildUser({ user_id: 'base-mid', tier_key: 'tier_mid', created_at: '2026-02-22T10:00:00.000Z' }),
+            buildUser({ user_id: 'r1', tier_key: 'tier_free', created_at: '2026-03-01T10:00:00.000Z' }),
+            buildUser({ user_id: 'r2', tier_key: 'tier_mid', created_at: '2026-03-02T10:00:00.000Z' }),
+            buildUser({ user_id: 'r3', tier_key: 'tier_premium', created_at: '2026-03-02T11:00:00.000Z' }),
+            buildUser({ user_id: 'r4', system_role: 'admin', created_at: '2026-03-03T10:00:00.000Z' }),
+        ];
+        const visibleRangeUsers = allUsers.filter((user) => user.created_at >= '2026-03-01');
+        const data = buildUserLevelCumulativeStackedChartData(allUsers, visibleRangeUsers, breakdown, 'all');
+        expect(data).toEqual([
+            { date: '01.03', Admin: 1, Globetrotter: 0, Explorer: 1, Backpacker: 1 },
+            { date: '02.03', Admin: 1, Globetrotter: 1, Explorer: 2, Backpacker: 1 },
+            { date: '03.03', Admin: 2, Globetrotter: 1, Explorer: 2, Backpacker: 1 },
+        ]);
+    });
+
+    it('fills fixed-range days so cumulative totals remain visible even on no-signup days', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-03-07T12:00:00.000Z'));
+        const breakdown: AdminDashboardUserLevelBreakdownItem[] = [
+            { key: 'admin', label: 'Admin', count: 1, shareOfTotal: 0.5, shareLabel: '50%', tooltip: 'Admin: 1 of 2 total users (50%)' },
+            { key: 'tier_premium', label: 'Globetrotter', count: 0, shareOfTotal: 0, shareLabel: '0%', tooltip: 'Globetrotter: 0 of 2 total users (0%)' },
+            { key: 'tier_mid', label: 'Explorer', count: 0, shareOfTotal: 0, shareLabel: '0%', tooltip: 'Explorer: 0 of 2 total users (0%)' },
+            { key: 'tier_free', label: 'Backpacker', count: 1, shareOfTotal: 0.5, shareLabel: '50%', tooltip: 'Backpacker: 1 of 2 total users (50%)' },
+        ];
+        const allUsers = [
+            buildUser({ user_id: 'base-admin', system_role: 'admin', created_at: '2026-02-20T10:00:00.000Z' }),
+            buildUser({ user_id: 'range-free', tier_key: 'tier_free', created_at: '2026-03-05T10:00:00.000Z' }),
+        ];
+        const visibleRangeUsers = allUsers.filter((user) => user.created_at >= '2026-03-01');
+        const data = buildUserLevelCumulativeStackedChartData(allUsers, visibleRangeUsers, breakdown, '7d');
+        expect(data).toHaveLength(7);
+        expect(data[0]).toMatchObject({ date: '01.03', Admin: 1, Backpacker: 0 });
+        expect(data[4]).toMatchObject({ date: '05.03', Admin: 1, Backpacker: 1 });
+        expect(data[6]).toMatchObject({ date: '07.03', Admin: 1, Backpacker: 1 });
+    });
+});

--- a/tests/unit/adminDashboardUserBreakdown.test.ts
+++ b/tests/unit/adminDashboardUserBreakdown.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { AdminUserRecord } from '../../services/adminService';
+import { buildAdminDashboardUserLevelBreakdown } from '../../components/admin/adminDashboardUserBreakdown';
+
+const buildUser = (overrides: Partial<AdminUserRecord>): AdminUserRecord => ({
+    user_id: 'user-1',
+    email: 'user@example.com',
+    system_role: 'user',
+    tier_key: 'tier_free',
+    entitlements_override: null,
+    created_at: '2026-03-01T10:00:00.000Z',
+    updated_at: '2026-03-01T10:00:00.000Z',
+    ...overrides,
+});
+
+describe('components/admin/adminDashboardUserBreakdown', () => {
+    it('builds the level breakdown with counts, shares, and tooltip totals', () => {
+        const rows = [
+            buildUser({ user_id: 'admin-1', system_role: 'admin', tier_key: 'tier_premium' }),
+            buildUser({ user_id: 'premium-1', tier_key: 'tier_premium' }),
+            buildUser({ user_id: 'mid-1', tier_key: 'tier_mid' }),
+            buildUser({ user_id: 'free-1', tier_key: 'tier_free' }),
+            buildUser({ user_id: 'anon-1', is_anonymous: true, email: null }),
+            buildUser({ user_id: 'anon-2', auth_provider: 'anonymous', email: null }),
+        ];
+
+        const breakdown = buildAdminDashboardUserLevelBreakdown(rows);
+        expect(breakdown.map((entry) => entry.key)).toEqual([
+            'admin',
+            'tier_premium',
+            'tier_mid',
+            'tier_free',
+        ]);
+        expect(breakdown.map((entry) => entry.count)).toEqual([1, 1, 1, 3]);
+        expect(breakdown.map((entry) => entry.shareLabel)).toEqual(['16.7%', '16.7%', '16.7%', '50%']);
+        expect(breakdown[0]?.tooltip).toContain('of 6 total users');
+    });
+
+    it('keeps admin users in the admin bucket', () => {
+        const rows = [
+            buildUser({
+                user_id: 'admin-1',
+                system_role: 'admin',
+                is_anonymous: true,
+                auth_provider: 'anonymous',
+                email: null,
+            }),
+        ];
+
+        const breakdown = buildAdminDashboardUserLevelBreakdown(rows);
+        expect(breakdown.find((entry) => entry.key === 'admin')?.count).toBe(1);
+        expect(breakdown.find((entry) => entry.key === 'tier_free')?.count).toBe(0);
+    });
+
+    it('returns zero-share labels when there are no users', () => {
+        const breakdown = buildAdminDashboardUserLevelBreakdown([]);
+        expect(breakdown.every((entry) => entry.count === 0)).toBe(true);
+        expect(breakdown.every((entry) => entry.shareLabel === '0%')).toBe(true);
+    });
+});

--- a/tests/unit/tablePrimitive.test.ts
+++ b/tests/unit/tablePrimitive.test.ts
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react';
 import { Table } from '../../components/ui/table';
 
 describe('ui Table primitive', () => {
-  it('uses overscroll-behavior none on the scroll container', () => {
+  it('only contains horizontal overscroll so page vertical scroll can continue', () => {
     render(
       React.createElement(
         Table,
@@ -21,6 +21,6 @@ describe('ui Table primitive', () => {
     const tableNode = screen.getByRole('table');
     const container = tableNode.closest('[data-slot="table-container"]');
     expect(container).not.toBeNull();
-    expect(container?.className).toContain('overscroll-none');
+    expect(container?.className).toContain('overscroll-x-contain');
   });
 });


### PR DESCRIPTION
## Summary
- replace admin dashboard visualizations with stacked Tremor bar charts using default palette
- show user levels as cumulative totals over time (Admin + tiers only), not daily-new counts
- keep trip status as a single stacked chart and add stacked new-users vs new-trips throughput chart
- format dashboard chart dates as `DD.MM` (no year for now)
- fix admin table scroll behavior so hovering a table no longer blocks vertical page scrolling
- keep release note as draft during PR development

## Validation
- `pnpm exec vitest run tests/unit/adminDashboardChartData.test.ts tests/unit/adminDashboardUserBreakdown.test.ts tests/unit/tablePrimitive.test.ts`
- `pnpm test:core`
- `pnpm updates:validate`
- `pnpm dlx react-doctor@latest . --verbose --diff`

## Release Notes
- updated `content/updates/2026-03-05-admin-dashboard-user-level-breakdown.md` (still `status: draft`)
