### PR TITLE
fix: mark legacy loading-error trips as failed

### DIFF
--- a/content/updates/2026-03-03-failed-trip-generation-observability-retry.md
+++ b/content/updates/2026-03-03-failed-trip-generation-observability-retry.md
@@ -26,6 +26,7 @@ summary: "Failed trip generations are now easier to spot, inspect, and retry on 
 - [x] [Improved] 🤖 Retry model selectors now group models by provider with logos and a clear “current” pill in trip diagnostics.
 - [x] [Fixed] 🔁 Retry attempt history now collapses duplicate in-flight entries and resolves stale running attempts to failed when timeout windows are exceeded.
 - [x] [Fixed] 🛑 Failed-generation trips no longer get stuck in an endless “Planning your trip” overlay; loading overlays now follow real generation state.
+- [x] [Fixed] 🚨 Legacy failed trip drafts now correctly show a failed AI-generation status instead of appearing as succeeded.
 - [x] [Improved] 🔁 Retrying generation now re-triggers tab feedback (title + favicon animation) so background progress is visible again.
 - [x] [Improved] 🧾 Trip diagnostics now show the full captured input snapshot JSON (flow, dates, and payload) for easier replay and debugging.
 - [x] [Improved] 🧩 Admin users/trips tables now use subtler, consistent row/column highlight states with corrected sticky-column alignment.

--- a/services/tripGenerationDiagnosticsService.ts
+++ b/services/tripGenerationDiagnosticsService.ts
@@ -276,6 +276,18 @@ const mergeAttemptMetadata = (
     return Object.keys(merged).length > 0 ? merged : null;
 };
 
+const LEGACY_FAILED_PLACEHOLDER_PREFIX = 'loading-error-';
+
+const isLegacyFailedGenerationPlaceholderTrip = (trip: ITrip): boolean => {
+    if (trip.aiMeta?.generation?.state) return false;
+    return trip.items.some((item) => (
+        item.type === 'city'
+        && item.loading !== true
+        && typeof item.id === 'string'
+        && item.id.startsWith(LEGACY_FAILED_PLACEHOLDER_PREFIX)
+    ));
+};
+
 export const createTripGenerationAttemptId = (): string => randomUuid();
 export const createTripGenerationRequestId = (): string => randomUuid();
 
@@ -305,6 +317,7 @@ export const getTripGenerationState = (trip: ITrip, nowMs = Date.now()): TripGen
         return explicit;
     }
     if (trip.items.some((item) => item.loading)) return 'running';
+    if (isLegacyFailedGenerationPlaceholderTrip(trip)) return 'failed';
     return 'succeeded';
 };
 

--- a/tests/services/tripGenerationDiagnosticsService.test.ts
+++ b/tests/services/tripGenerationDiagnosticsService.test.ts
@@ -146,6 +146,25 @@ describe('tripGenerationDiagnosticsService', () => {
     expect(getTripGenerationState(runningTrip, nowMs)).toBe('failed');
   });
 
+  it('treats legacy loading-error placeholders as failed without aiMeta state', () => {
+    const legacyFailedTrip = buildTrip();
+    legacyFailedTrip.title = 'Trip generation failed. Please try again.';
+    legacyFailedTrip.items = [
+      {
+        id: 'loading-error-trip-1',
+        type: 'city',
+        title: 'Trip generation failed. Please try again.',
+        startDateOffset: 0,
+        duration: 3,
+        color: 'bg-rose-100 border-rose-300 text-rose-700',
+        description: 'Provider error',
+        location: 'Albania',
+      },
+    ];
+
+    expect(getTripGenerationState(legacyFailedTrip)).toBe('failed');
+  });
+
   it('rewrites latest attempt id to canonical db id and keeps attempt history deduped', () => {
     const runningTrip = markTripGenerationRunning(buildTrip(), {
       flow: 'classic',


### PR DESCRIPTION
## Summary
- mark legacy `loading-error-*` placeholder trips as failed when no explicit `aiMeta.generation.state` exists
- keep existing success fallback for normal trips with no failure/loading indicators
- add regression coverage for placeholder-only legacy rows
- update the current draft release note with the user-visible fix

## Why
Some historic failed trip generations were stored without `aiMeta.generation.state` but with `loading-error-*` city placeholders. The diagnostics fallback treated those rows as `succeeded`, which hid retry UX and showed misleading "AI generation: succeeded".

## Testing
- `pnpm vitest tests/services/tripGenerationDiagnosticsService.test.ts --run`
- `pnpm test:core`
