### PR TITLE
Polish bootstrap shell and publish async trip update

### DIFF
--- a/content/updates/2026-03-03-failed-trip-generation-observability-retry.md
+++ b/content/updates/2026-03-03-failed-trip-generation-observability-retry.md
@@ -1,16 +1,20 @@
 ---
 id: rel-2026-03-03-failed-trip-generation-observability-retry
-version: v0.80.0
-title: "Failed Trip Generation Visibility And Retry"
-date: 2026-03-03
-published_at: 2026-03-03T16:00:00Z
-status: draft
+version: v0.85.0
+title: "Background Trip Generation, Safer Recovery, And Faster Trip Startup"
+date: 2026-03-07
+published_at: 2026-03-07T07:39:57Z
+status: published
 notify_in_app: false
 in_app_hours: 24
-summary: "Failed trip generations are now easier to spot, inspect, and retry on the same trip."
+summary: "Trip generation now keeps running in the background, recovers more safely when jobs stall, and makes failed plans easier to inspect and retry."
 ---
 
 ## Changes
+- [x] [Improved] ⚙️ Trip generation now keeps running in the background, so create-trip and retry are no longer tied to keeping the tab open.
+- [x] [Improved] 🛟 Stalled generation jobs now use safer recovery and retry guards, helping stuck plans recover without losing the trip.
+- [x] [Improved] 🤖 Planning and retry now default to OpenAI GPT-5.4, with expanded model choices available for trip creation and benchmark runs.
+- [x] [Improved] ⚡ Trip pages now open with a branded loading shell and faster planner startup while heavier route data loads in the background.
 - [x] [Improved] 🚨 Failed trip generations now stay visible in plan lists and trip screens with clear generation-status badges.
 - [x] [Improved] 🧾 Trip details now show richer AI generation diagnostics, including model/provider context and latest failure details.
 - [x] [New feature] 🔁 Travelers can retry failed generation directly on the same trip using the default model.
@@ -53,7 +57,7 @@ summary: "Failed trip generations are now easier to spot, inspect, and retry on 
 - [ ] [Internal] ⚙️ Scheduled worker triggers now hand off processing to a protected background function, avoiding 30s scheduled-function limits and keeping queued jobs draining reliably.
 - [ ] [Internal] 🛠️ Netlify worker triggers now use deploy-safe function handlers (`handler` exports + HTTP bridge) so both cron and background worker functions are bundled and callable in production.
 - [ ] [Internal] ⚙️ Async worker provider timeout now stays within edge-runtime-safe bounds (short default + capped max) so jobs fail deterministically instead of lingering in leased/queued limbo.
-- [x] [Improved] 🤖 Default generation + retry model baseline now uses OpenAI GPT-5.4 across create-trip and retry entry points.
+- [ ] [Internal] 🤖 Default generation + retry model baseline now uses OpenAI GPT-5.4 across create-trip and retry entry points.
 - [ ] [Internal] 🛠️ Queue-claim RPC now rejects already-claimed requests instead of returning stale rows, preventing duplicate trip generation from repeated claim calls.
 - [ ] [Internal] 🛠️ Admin trip-list RPC fallback now also handles PostgREST overload-selection errors (`best candidate function`) for stable table loading during mixed-schema rollouts.
 - [ ] [Internal] 🛠️ Worker success merge now preserves existing trip preference fields (favorites and map/style settings) instead of resetting them to generated defaults.
@@ -118,6 +122,6 @@ summary: "Failed trip generations are now easier to spot, inspect, and retry on 
 - [ ] [Internal] 🛠️ Trip view now polls/nudges queued worker jobs less aggressively to cut duplicate request bursts while still surfacing async progress.
 - [ ] [Internal] 🛠️ Create/retry async bootstrap now persists optimistic snapshots before canonical-attempt confirmation, reducing the first-click burst of repeated trip reads during queue handoff.
 - [ ] [Internal] 🛠️ Trip-view stall recovery now force-kicks missing async jobs before failing and does not mark still-leased jobs as `ASYNC_WORKER_JOB_MISSING`.
-- [x] [Improved] ⚡ Trip routes now paint a lightweight loading shell immediately while planner data and the heavy trip workspace load in the background, making first open feel much faster.
-- [x] [Fixed] ⚪ Trip pages no longer flash a half-screen grey loading block before the planner shell appears.
-- [x] [Improved] 🧭 The very first app bootstrap frame now shows a branded TravelFlow shell with header chrome instead of a blank white page.
+- [ ] [Internal] ⚡ Trip routes now paint a lightweight loading shell immediately while planner data and the heavy trip workspace load in the background, making first open feel much faster.
+- [ ] [Internal] ⚪ Trip pages no longer flash a half-screen grey loading block before the planner shell appears.
+- [ ] [Internal] 🧭 The very first app bootstrap frame now shows a branded TravelFlow shell with header chrome instead of a blank white page.

--- a/index.html
+++ b/index.html
@@ -51,152 +51,227 @@
       }
 
       .tf-boot-header {
-        height: 64px;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 16px;
-        padding: 0 20px;
         border-bottom: 1px solid #e2e8f0;
         background: #ffffff;
       }
 
+      .tf-boot-header-inner {
+        height: 72px;
+        max-width: 1600px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        align-items: center;
+        gap: 24px;
+        padding: 0 24px;
+      }
+
       .tf-boot-brand {
-        display: flex;
+        display: inline-flex;
         align-items: center;
         gap: 14px;
         min-width: 0;
       }
 
-      .tf-boot-logo {
-        height: 40px;
-        width: 40px;
-        border-radius: 14px;
-        background: linear-gradient(135deg, #4f46e5 0%, #6366f1 100%);
-        color: #ffffff;
+      .tf-boot-logo-frame {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        font-size: 14px;
-        font-weight: 900;
-        letter-spacing: 0.02em;
-        box-shadow: 0 10px 25px rgba(79, 70, 229, 0.18);
+        height: 46px;
+        width: 46px;
+        border-radius: 14px;
+        background: linear-gradient(135deg, #4f46e5 0%, #6366f1 100%);
+        box-shadow: 0 14px 30px rgba(79, 70, 229, 0.18);
       }
 
-      .tf-boot-title {
-        font-size: 1.75rem;
-        font-weight: 900;
+      .tf-boot-logo-image {
+        height: 28px;
+        width: 28px;
+        display: block;
+      }
+
+      .tf-boot-wordmark {
+        font-size: 2rem;
         line-height: 1;
+        font-weight: 900;
+        letter-spacing: -0.035em;
         color: #111827;
       }
 
-      .tf-boot-title span {
-        color: #4f46e5;
-      }
-
-      .tf-boot-actions {
+      .tf-boot-nav {
         display: flex;
         align-items: center;
-        gap: 10px;
+        justify-content: center;
+        gap: 22px;
+        min-width: 0;
       }
 
-      .tf-boot-pill,
-      .tf-boot-cta {
-        height: 40px;
-        border-radius: 14px;
-        border: 1px solid #e2e8f0;
-        background: #ffffff;
-        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
-      }
-
-      .tf-boot-pill {
-        width: 40px;
-      }
-
-      .tf-boot-cta {
-        width: 112px;
-      }
-
-      .tf-boot-main {
-        padding: 0;
-      }
-
-      .tf-boot-strip {
-        height: 52px;
-        display: flex;
-        align-items: center;
-        padding: 0 20px;
-        border-bottom: 1px solid #fde68a;
-        background: rgba(254, 243, 199, 0.55);
-      }
-
-      .tf-boot-strip-line {
-        height: 14px;
-        width: min(320px, 52vw);
-        border-radius: 999px;
-        background: linear-gradient(90deg, #fde68a 0%, #fef3c7 45%, #fde68a 100%);
-        background-size: 200% 100%;
-        animation: tf-boot-shimmer 1.4s linear infinite;
-      }
-
-      .tf-boot-grid {
-        display: grid;
-        grid-template-columns: repeat(5, minmax(0, 1fr));
-        border-bottom: 1px solid #e2e8f0;
-      }
-
-      .tf-boot-day {
-        min-height: 78px;
-        padding: 16px 14px;
-        border-right: 1px solid #f1f5f9;
-      }
-
-      .tf-boot-day:last-child {
-        border-right: 0;
-      }
-
+      .tf-boot-nav-link,
+      .tf-boot-action-chip,
+      .tf-boot-action-button,
       .tf-boot-line,
-      .tf-boot-chip,
-      .tf-boot-card-line,
-      .tf-boot-card-pill,
-      .tf-boot-map,
-      .tf-boot-metric {
+      .tf-boot-card,
+      .tf-boot-metric,
+      .tf-boot-trip-day,
+      .tf-boot-trip-block,
+      .tf-boot-trip-side-card,
+      .tf-boot-trip-status,
+      .tf-boot-trip-toolbar-pill {
         border-radius: 999px;
         background: linear-gradient(90deg, #e2e8f0 0%, #f8fafc 45%, #e2e8f0 100%);
         background-size: 200% 100%;
         animation: tf-boot-shimmer 1.4s linear infinite;
       }
 
-      .tf-boot-line {
-        height: 12px;
+      .tf-boot-nav-link {
+        height: 14px;
+        flex: 0 0 auto;
       }
 
-      .tf-boot-line--sm {
-        width: 52px;
+      .tf-boot-nav-link:nth-child(1) { width: 72px; }
+      .tf-boot-nav-link:nth-child(2) { width: 94px; }
+      .tf-boot-nav-link:nth-child(3) { width: 110px; }
+      .tf-boot-nav-link:nth-child(4) { width: 48px; }
+      .tf-boot-nav-link:nth-child(5) { width: 64px; }
+
+      .tf-boot-actions {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
       }
 
-      .tf-boot-line--md {
-        width: 74px;
-        margin-top: 12px;
-        height: 28px;
-      }
-
-      .tf-boot-workspace {
-        display: grid;
-        gap: 20px;
-        grid-template-columns: minmax(0, 1fr);
-        padding: 24px 20px 28px;
-      }
-
-      .tf-boot-planner {
-        min-height: 420px;
+      .tf-boot-action-chip,
+      .tf-boot-action-button {
+        flex: 0 0 auto;
         border: 1px solid #e2e8f0;
-        border-radius: 30px;
-        background: rgba(248, 250, 252, 0.72);
-        padding: 18px;
+        background-color: #ffffff;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
       }
 
-      .tf-boot-planner-head {
+      .tf-boot-action-chip {
+        height: 44px;
+      }
+
+      .tf-boot-action-chip--locale {
+        width: 146px;
+      }
+
+      .tf-boot-action-chip--login {
+        width: 96px;
+      }
+
+      .tf-boot-action-button {
+        height: 44px;
+        width: 140px;
+        background:
+          linear-gradient(135deg, rgba(79, 70, 229, 0.92) 0%, rgba(99, 102, 241, 0.92) 100%);
+        box-shadow: 0 10px 22px rgba(79, 70, 229, 0.18);
+      }
+
+      .tf-boot-main {
+        min-height: calc(100vh - 73px);
+        background: #ffffff;
+      }
+
+      .tf-boot-page {
+        max-width: 1600px;
+        margin: 0 auto;
+        padding: 28px 24px 40px;
+      }
+
+      .tf-boot-page--trip {
+        display: none;
+      }
+
+      html[data-tf-boot-route="trip"] .tf-boot-page--marketing {
+        display: none;
+      }
+
+      html[data-tf-boot-route="trip"] .tf-boot-page--trip {
+        display: block;
+      }
+
+      .tf-boot-hero {
+        border-radius: 28px;
+        border: 1px solid #e2e8f0;
+        background:
+          radial-gradient(circle at top left, rgba(224, 231, 255, 0.42), transparent 48%),
+          linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+        padding: 28px;
+      }
+
+      .tf-boot-hero-lines {
+        display: grid;
+        gap: 14px;
+        max-width: 720px;
+      }
+
+      .tf-boot-line {
+        height: 14px;
+      }
+
+      .tf-boot-line--headline {
+        width: min(540px, 100%);
+        height: 24px;
+      }
+
+      .tf-boot-line--body-lg {
+        width: min(640px, 100%);
+      }
+
+      .tf-boot-line--body-md {
+        width: min(520px, 85%);
+      }
+
+      .tf-boot-line--body-sm {
+        width: min(360px, 62%);
+      }
+
+      .tf-boot-hero-actions {
+        display: flex;
+        gap: 12px;
+        margin-top: 22px;
+      }
+
+      .tf-boot-hero-action {
+        border-radius: 16px;
+        border: 1px solid #e2e8f0;
+        background: #ffffff;
+        box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+      }
+
+      .tf-boot-hero-action--primary {
+        width: 156px;
+        height: 48px;
+      }
+
+      .tf-boot-hero-action--secondary {
+        width: 134px;
+        height: 48px;
+      }
+
+      .tf-boot-marketing-grid {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        margin-top: 22px;
+      }
+
+      .tf-boot-card {
+        min-height: 150px;
+        border-radius: 24px;
+        border: 1px solid #e2e8f0;
+        background-color: #ffffff;
+        box-shadow: 0 10px 24px rgba(15, 23, 42, 0.04);
+      }
+
+      .tf-boot-trip-status {
+        height: 14px;
+        width: min(280px, 46vw);
+        margin-bottom: 18px;
+      }
+
+      .tf-boot-trip-summary {
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -204,85 +279,114 @@
         margin-bottom: 16px;
       }
 
-      .tf-boot-chip {
-        height: 36px;
-        width: 128px;
-      }
-
-      .tf-boot-card {
-        border: 1px solid #e2e8f0;
-        border-radius: 24px;
-        background: rgba(255, 255, 255, 0.94);
-        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
-        padding: 16px;
-        margin-bottom: 14px;
-      }
-
-      .tf-boot-card-row {
-        display: flex;
-        align-items: flex-start;
-        justify-content: space-between;
-        gap: 16px;
-      }
-
-      .tf-boot-card-copy {
+      .tf-boot-trip-summary-copy {
+        display: grid;
+        gap: 12px;
         flex: 1 1 auto;
         min-width: 0;
       }
 
-      .tf-boot-card-line {
-        height: 22px;
-        width: 180px;
-        margin-bottom: 12px;
-      }
-
-      .tf-boot-card-line--wide {
-        width: min(560px, 100%);
-        height: 14px;
-      }
-
-      .tf-boot-card-line--mid {
-        width: min(430px, 78%);
-        height: 14px;
-        margin-top: 10px;
-      }
-
-      .tf-boot-card-pill {
-        width: 82px;
-        height: 40px;
+      .tf-boot-trip-toolbar {
+        display: flex;
+        gap: 10px;
         flex: 0 0 auto;
       }
 
-      .tf-boot-side {
-        display: none;
-        min-height: 420px;
-        border: 1px solid #e2e8f0;
-        border-radius: 30px;
-        background: rgba(248, 250, 252, 0.8);
-        padding: 18px;
-      }
-
-      .tf-boot-map {
-        width: 100%;
-        aspect-ratio: 4 / 5;
-        border-radius: 24px;
+      .tf-boot-trip-toolbar-pill {
+        height: 42px;
+        width: 42px;
         border: 1px solid #e2e8f0;
         background-color: #ffffff;
+        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+      }
+
+      .tf-boot-trip-layout {
+        display: grid;
+        gap: 18px;
+        grid-template-columns: minmax(0, 1fr) 290px;
+      }
+
+      .tf-boot-trip-canvas {
+        min-height: 460px;
+        border: 1px solid #e2e8f0;
+        border-radius: 30px;
+        background:
+          linear-gradient(180deg, rgba(248, 250, 252, 0.82), rgba(255, 255, 255, 0.98));
+        overflow: hidden;
+      }
+
+      .tf-boot-trip-grid {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        border-bottom: 1px solid #e2e8f0;
+      }
+
+      .tf-boot-trip-day {
+        height: 76px;
+        border-right: 1px solid #eef2f7;
+        background-color: rgba(255, 255, 255, 0.64);
+      }
+
+      .tf-boot-trip-day:last-child {
+        border-right: 0;
+      }
+
+      .tf-boot-trip-body {
+        padding: 22px 18px;
+      }
+
+      .tf-boot-trip-block {
+        height: 74px;
+        border-radius: 22px;
+        border: 1px solid #e2e8f0;
+        background-color: rgba(255, 255, 255, 0.94);
+      }
+
+      .tf-boot-trip-block + .tf-boot-trip-block {
         margin-top: 14px;
+      }
+
+      .tf-boot-trip-block--thin {
+        height: 56px;
+      }
+
+      .tf-boot-trip-sidebar {
+        display: grid;
+        gap: 14px;
+      }
+
+      .tf-boot-trip-side-card {
+        min-height: 180px;
+        border-radius: 26px;
+        border: 1px solid #e2e8f0;
+        background-color: #ffffff;
+        box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+      }
+
+      .tf-boot-trip-side-card--map {
+        min-height: 280px;
       }
 
       .tf-boot-metrics {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
         gap: 12px;
-        margin-top: 14px;
       }
 
       .tf-boot-metric {
-        height: 66px;
-        border-radius: 20px;
+        height: 86px;
+        border-radius: 22px;
         border: 1px solid #e2e8f0;
         background-color: #ffffff;
+      }
+
+      .tf-boot-surface {
+        margin-top: 22px;
+        min-height: 220px;
+        border: 1px solid #e2e8f0;
+        border-radius: 28px;
+        background:
+          linear-gradient(180deg, rgba(248, 250, 252, 0.82), rgba(255, 255, 255, 0.98));
       }
 
       @keyframes tf-boot-shimmer {
@@ -290,54 +394,109 @@
         100% { background-position: -200% 0; }
       }
 
-      @media (min-width: 1024px) {
-        .tf-boot-workspace {
-          grid-template-columns: minmax(0, 1fr) 320px;
+      @media (max-width: 1200px) {
+        .tf-boot-header-inner {
+          grid-template-columns: auto 1fr auto;
+          gap: 18px;
         }
 
-        .tf-boot-side {
-          display: block;
+        .tf-boot-nav {
+          gap: 18px;
+        }
+
+        .tf-boot-trip-layout {
+          grid-template-columns: minmax(0, 1fr);
+        }
+      }
+
+      @media (max-width: 960px) {
+        .tf-boot-header-inner {
+          grid-template-columns: auto auto;
+        }
+
+        .tf-boot-nav {
+          display: none;
+        }
+
+        .tf-boot-marketing-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
         }
       }
 
       @media (max-width: 640px) {
-        .tf-boot-header {
+        .tf-boot-header-inner {
+          height: 64px;
           padding: 0 14px;
+          gap: 12px;
         }
 
-        .tf-boot-title {
-          font-size: 1.45rem;
+        .tf-boot-logo-frame {
+          height: 40px;
+          width: 40px;
+          border-radius: 12px;
         }
 
-        .tf-boot-pill {
+        .tf-boot-logo-image {
+          height: 24px;
+          width: 24px;
+        }
+
+        .tf-boot-wordmark {
+          font-size: 1.6rem;
+        }
+
+        .tf-boot-page {
+          padding: 18px 14px 24px;
+        }
+
+        .tf-boot-action-chip--locale,
+        .tf-boot-action-chip--login {
           display: none;
         }
 
-        .tf-boot-cta {
-          width: 88px;
+        .tf-boot-action-button {
+          width: 104px;
+          height: 40px;
         }
 
-        .tf-boot-grid {
+        .tf-boot-hero {
+          padding: 20px 18px;
+        }
+
+        .tf-boot-marketing-grid {
+          grid-template-columns: minmax(0, 1fr);
+        }
+
+        .tf-boot-trip-grid {
           grid-template-columns: repeat(3, minmax(0, 1fr));
         }
 
-        .tf-boot-grid .tf-boot-day:nth-child(n+4) {
+        .tf-boot-trip-grid .tf-boot-trip-day:nth-child(n+4) {
           display: none;
         }
 
-        .tf-boot-workspace {
-          padding: 18px 14px 22px;
+        .tf-boot-trip-summary {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .tf-boot-trip-toolbar {
+          justify-content: flex-start;
         }
       }
 
       @media (prefers-reduced-motion: reduce) {
-        .tf-boot-strip-line,
+        .tf-boot-nav-link,
+        .tf-boot-action-chip,
+        .tf-boot-action-button,
         .tf-boot-line,
-        .tf-boot-chip,
-        .tf-boot-card-line,
-        .tf-boot-card-pill,
-        .tf-boot-map,
-        .tf-boot-metric {
+        .tf-boot-card,
+        .tf-boot-metric,
+        .tf-boot-trip-day,
+        .tf-boot-trip-block,
+        .tf-boot-trip-side-card,
+        .tf-boot-trip-status,
+        .tf-boot-trip-toolbar-pill {
           animation: none;
         }
       }
@@ -402,78 +561,99 @@
         z-index: 99999 !important;
       }
     </style>
+    <script>
+      (() => {
+        const path = window.location.pathname || '/';
+        const isTripLikeRoute = /^\/(?:[a-z]{2}(?:-[A-Z]{2})?\/)?(?:trip|s|example)(?:\/|$)/.test(path);
+        if (isTripLikeRoute) {
+          document.documentElement.setAttribute('data-tf-boot-route', 'trip');
+        }
+      })();
+    </script>
 </head>
   <body>
     <div id="root">
       <div class="tf-boot-shell" aria-hidden="true">
         <header class="tf-boot-header">
-          <div class="tf-boot-brand">
-            <div class="tf-boot-logo">TF</div>
-            <div class="tf-boot-title">Travel<span>Flow</span></div>
-          </div>
-          <div class="tf-boot-actions">
-            <div class="tf-boot-pill"></div>
-            <div class="tf-boot-pill"></div>
-            <div class="tf-boot-cta"></div>
+          <div class="tf-boot-header-inner">
+            <div class="tf-boot-brand">
+              <span class="tf-boot-logo-frame">
+                <img class="tf-boot-logo-image" src="/favicon.svg" alt="" />
+              </span>
+              <span class="tf-boot-wordmark">TravelFlow</span>
+            </div>
+            <nav class="tf-boot-nav" aria-hidden="true">
+              <span class="tf-boot-nav-link"></span>
+              <span class="tf-boot-nav-link"></span>
+              <span class="tf-boot-nav-link"></span>
+              <span class="tf-boot-nav-link"></span>
+              <span class="tf-boot-nav-link"></span>
+            </nav>
+            <div class="tf-boot-actions">
+              <span class="tf-boot-action-chip tf-boot-action-chip--locale"></span>
+              <span class="tf-boot-action-chip tf-boot-action-chip--login"></span>
+              <span class="tf-boot-action-button"></span>
+            </div>
           </div>
         </header>
         <main class="tf-boot-main">
-          <div class="tf-boot-strip">
-            <div class="tf-boot-strip-line"></div>
-          </div>
-          <div class="tf-boot-grid">
-            <div class="tf-boot-day"><div class="tf-boot-line tf-boot-line--sm"></div><div class="tf-boot-line tf-boot-line--md"></div></div>
-            <div class="tf-boot-day"><div class="tf-boot-line tf-boot-line--sm"></div><div class="tf-boot-line tf-boot-line--md"></div></div>
-            <div class="tf-boot-day"><div class="tf-boot-line tf-boot-line--sm"></div><div class="tf-boot-line tf-boot-line--md"></div></div>
-            <div class="tf-boot-day"><div class="tf-boot-line tf-boot-line--sm"></div><div class="tf-boot-line tf-boot-line--md"></div></div>
-            <div class="tf-boot-day"><div class="tf-boot-line tf-boot-line--sm"></div><div class="tf-boot-line tf-boot-line--md"></div></div>
-          </div>
-          <div class="tf-boot-workspace">
-            <section class="tf-boot-planner">
-              <div class="tf-boot-planner-head">
-                <div class="tf-boot-line" style="width: 124px;"></div>
-                <div class="tf-boot-chip"></div>
+          <section class="tf-boot-page tf-boot-page--marketing">
+            <div class="tf-boot-hero">
+              <div class="tf-boot-hero-lines">
+                <div class="tf-boot-line tf-boot-line--headline"></div>
+                <div class="tf-boot-line tf-boot-line--body-lg"></div>
+                <div class="tf-boot-line tf-boot-line--body-md"></div>
+                <div class="tf-boot-line tf-boot-line--body-sm"></div>
               </div>
-              <div class="tf-boot-card">
-                <div class="tf-boot-card-row">
-                  <div class="tf-boot-card-copy">
-                    <div class="tf-boot-card-line"></div>
-                    <div class="tf-boot-card-line tf-boot-card-line--wide"></div>
-                    <div class="tf-boot-card-line tf-boot-card-line--mid"></div>
-                  </div>
-                  <div class="tf-boot-card-pill"></div>
+              <div class="tf-boot-hero-actions" aria-hidden="true">
+                <span class="tf-boot-hero-action tf-boot-hero-action--primary"></span>
+                <span class="tf-boot-hero-action tf-boot-hero-action--secondary"></span>
+              </div>
+            </div>
+            <div class="tf-boot-marketing-grid" aria-hidden="true">
+              <div class="tf-boot-card"></div>
+              <div class="tf-boot-card"></div>
+              <div class="tf-boot-card"></div>
+            </div>
+            <div class="tf-boot-surface" aria-hidden="true"></div>
+          </section>
+          <section class="tf-boot-page tf-boot-page--trip">
+            <div class="tf-boot-trip-status"></div>
+            <div class="tf-boot-trip-summary">
+              <div class="tf-boot-trip-summary-copy">
+                <div class="tf-boot-line tf-boot-line--headline" style="width:min(420px,72%);"></div>
+                <div class="tf-boot-line tf-boot-line--body-md" style="width:min(300px,56%);"></div>
+              </div>
+              <div class="tf-boot-trip-toolbar" aria-hidden="true">
+                <span class="tf-boot-trip-toolbar-pill"></span>
+                <span class="tf-boot-trip-toolbar-pill"></span>
+                <span class="tf-boot-trip-toolbar-pill"></span>
+              </div>
+            </div>
+            <div class="tf-boot-trip-layout">
+              <section class="tf-boot-trip-canvas" aria-hidden="true">
+                <div class="tf-boot-trip-grid">
+                  <div class="tf-boot-trip-day"></div>
+                  <div class="tf-boot-trip-day"></div>
+                  <div class="tf-boot-trip-day"></div>
+                  <div class="tf-boot-trip-day"></div>
+                  <div class="tf-boot-trip-day"></div>
                 </div>
-              </div>
-              <div class="tf-boot-card">
-                <div class="tf-boot-card-row">
-                  <div class="tf-boot-card-copy">
-                    <div class="tf-boot-card-line" style="width: 156px;"></div>
-                    <div class="tf-boot-card-line tf-boot-card-line--wide"></div>
-                    <div class="tf-boot-card-line tf-boot-card-line--mid"></div>
-                  </div>
-                  <div class="tf-boot-card-pill"></div>
+                <div class="tf-boot-trip-body">
+                  <div class="tf-boot-trip-block"></div>
+                  <div class="tf-boot-trip-block tf-boot-trip-block--thin"></div>
+                  <div class="tf-boot-trip-block"></div>
                 </div>
-              </div>
-              <div class="tf-boot-card" style="margin-bottom: 0;">
-                <div class="tf-boot-card-row">
-                  <div class="tf-boot-card-copy">
-                    <div class="tf-boot-card-line" style="width: 132px;"></div>
-                    <div class="tf-boot-card-line tf-boot-card-line--wide"></div>
-                    <div class="tf-boot-card-line tf-boot-card-line--mid"></div>
-                  </div>
-                  <div class="tf-boot-card-pill"></div>
+              </section>
+              <aside class="tf-boot-trip-sidebar" aria-hidden="true">
+                <div class="tf-boot-trip-side-card tf-boot-trip-side-card--map"></div>
+                <div class="tf-boot-metrics">
+                  <div class="tf-boot-metric"></div>
+                  <div class="tf-boot-metric"></div>
                 </div>
-              </div>
+              </aside>
             </section>
-            <aside class="tf-boot-side">
-              <div class="tf-boot-line" style="width: 110px;"></div>
-              <div class="tf-boot-map"></div>
-              <div class="tf-boot-metrics">
-                <div class="tf-boot-metric"></div>
-                <div class="tf-boot-metric"></div>
-              </div>
-            </aside>
-          </div>
+          </section>
         </main>
       </div>
     </div>

--- a/tests/unit/indexBootstrapShell.test.ts
+++ b/tests/unit/indexBootstrapShell.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('index.html bootstrap shell', () => {
+  const indexHtmlPath = resolve(process.cwd(), 'index.html');
+  const html = readFileSync(indexHtmlPath, 'utf8');
+
+  it('renders the branded marketing shell by default', () => {
+    expect(html).toContain('class="tf-boot-header-inner"');
+    expect(html).toContain('class="tf-boot-nav"');
+    expect(html).toContain('class="tf-boot-page tf-boot-page--marketing"');
+    expect(html).toContain('src="/favicon.svg"');
+    expect(html).toContain('TravelFlow');
+  });
+
+  it('switches to a trip-specific bootstrap shell on trip-like routes before hydration', () => {
+    expect(html).toContain("document.documentElement.setAttribute('data-tf-boot-route', 'trip')");
+    expect(html).toContain("window.location.pathname || '/'");
+    expect(html).toContain('class="tf-boot-page tf-boot-page--trip"');
+    expect(html).toContain('(?:trip|s|example)');
+  });
+});


### PR DESCRIPTION
## Summary
- replace the default pre-hydration planner shell with a branded marketing-header bootstrap shell
- keep a lighter trip-specific bootstrap variant only for trip/share/example routes
- publish the async trip generation release note with visible worker/recovery/model/startup benefits

## Validation
- pnpm test tests/unit/indexBootstrapShell.test.ts tests/unit/netlifyContactFormRegistration.test.ts
- pnpm updates:validate
- pnpm test:core
