### PR TITLE
Final async trip worker cleanup

### DIFF
--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -51,6 +51,7 @@ import { useTripLayoutControlsState } from './tripview/useTripLayoutControlsStat
 import { useTripCityForceFill } from './tripview/useTripCityForceFill';
 import { useTripFavoriteHandler } from './tripview/useTripFavoriteHandler';
 import { resolveTripToastUndoAction } from './tripview/tripToastUndoAction';
+import { buildQueuedTripGenerationRetryToastOptions } from './tripview/tripGenerationRetryToast';
 import { useTripItemMutationHandlers } from './tripview/useTripItemMutationHandlers';
 import { useTripItemUpdateHandlers } from './tripview/useTripItemUpdateHandlers';
 import { useTripRouteStatusState } from './tripview/useTripRouteStatusState';
@@ -1760,10 +1761,12 @@ const useTripViewRender = ({
 
             if (result.state === 'queued') {
                 keepRetryFeedbackActive = true;
-                showToast(t('tripView.generation.retry.queued'), {
-                    tone: 'neutral',
-                    title: t('tripView.generation.retry.queuedTitle'),
-                });
+                showToast(
+                    t('tripView.generation.retry.queued'),
+                    buildQueuedTripGenerationRetryToastOptions(
+                        t('tripView.generation.retry.queuedTitle'),
+                    ),
+                );
             } else if (result.state === 'succeeded') {
                 retryGenerationTabFeedbackSessionRef.current?.complete('success', {
                     title: result.trip.title,

--- a/components/tripview/tripGenerationRetryToast.ts
+++ b/components/tripview/tripGenerationRetryToast.ts
@@ -1,0 +1,13 @@
+interface QueuedTripGenerationRetryToastOptions {
+  tone: 'neutral';
+  title: string;
+  disableDefaultUndo: true;
+}
+
+export const buildQueuedTripGenerationRetryToastOptions = (
+  title: string,
+): QueuedTripGenerationRetryToastOptions => ({
+  tone: 'neutral',
+  title,
+  disableDefaultUndo: true,
+});

--- a/content/updates/2026-03-03-failed-trip-generation-observability-retry.md
+++ b/content/updates/2026-03-03-failed-trip-generation-observability-retry.md
@@ -125,3 +125,5 @@ summary: "Trip generation now keeps running in the background, recovers more saf
 - [ ] [Internal] ⚡ Trip routes now paint a lightweight loading shell immediately while planner data and the heavy trip workspace load in the background, making first open feel much faster.
 - [ ] [Internal] ⚪ Trip pages no longer flash a half-screen grey loading block before the planner shell appears.
 - [ ] [Internal] 🧭 The very first app bootstrap frame now shows a branded TravelFlow shell with header chrome instead of a blank white page.
+- [ ] [Internal] 🧭 Queued retry toasts now suppress the default Undo action once async generation has already been enqueued.
+- [ ] [Internal] 🧭 Bootstrap header sizing now mirrors the real site navigation more closely, using real nav/button chrome instead of oversized placeholder bars.

--- a/docs/ASYNC_GENERATION_STABILIZATION_TODO.md
+++ b/docs/ASYNC_GENERATION_STABILIZATION_TODO.md
@@ -1,6 +1,6 @@
 # Async Generation Stabilization TODO Tracker
 
-Status date: 2026-03-06
+Status date: 2026-03-07
 
 ## Done
 - [x] Fixed local `pnpm dev:netlify` edge-function startup by correcting the TSX generic syntax in `trip-og-image.tsx`, so async worker and map-preview routes load again in Netlify dev.
@@ -28,6 +28,9 @@ Status date: 2026-03-06
 - [x] Added session-local trip commit dedupe in `App.tsx` so identical trip/view commits no longer create repeated `upsert_trip` / `add_trip_version` churn when only top-level `updatedAt` changes.
 - [x] Reverted the over-dark city-lane contrast pass so generated trip colors match the intended default palette depth again instead of rendering noticeably darker than existing trips.
 - [x] Production spot-check confirmed city panels look correct again after the palette rollback.
+- [x] Production spot-check confirmed `user_settings` write bursts no longer show up in normal trip usage after the sync dedupe hardening.
+- [x] Production spot-check confirmed My Trips no longer triggers cosmetic remote trip writes during normal usage.
+- [x] Production spot-check confirmed failed-trip retry now completes cleanly in normal traveler flows without the earlier duplicate first-click behavior.
 - [x] Create/retry async bootstrap now persists optimistic trip snapshots before queue confirmation, replacing the initial high-frequency canonical-attempt fetch burst with a short confirmation window.
 - [x] Trip-view async stall recovery now force-kicks missing jobs before failing, and no longer marks a still-leased worker job as `ASYNC_WORKER_JOB_MISSING`.
 - [x] Route-level suspense fallbacks for trip/share/example pages now use the real planner loading shell, eliminating the pre-shell half-screen grey placeholder flash.
@@ -39,9 +42,7 @@ Status date: 2026-03-06
 ## Open
 - [ ] Verify in live runtime that fresh create-trip runs complete under the new background worker path instead of timing out at 20s.
 - [ ] Verify in live runtime that retry-triggered worker nudges no longer flood repeated trip fetches while a queued job waits to start.
-- [ ] Verify in live runtime that `user_settings` write bursts are reduced after hook dedupe patch.
 - [ ] Verify in live runtime that completed trips stop generation polling/fetch loops after the stale queued/running state fallback patch.
-- [ ] Verify in live runtime that My Trips no longer triggers remote trip write churn from country enrichment.
 - [ ] Verify in live runtime that admin override-enabled trips can restart generation from both the failed banner and Trip Info without disabled-state drift.
 - [ ] Verify in live runtime that trip/share/example first paint no longer flashes the half-screen grey bootstrap block before the planner shell appears.
 - [ ] Produce postmortem package for browser -> async worker migration:

--- a/index.html
+++ b/index.html
@@ -51,64 +51,67 @@
       }
 
       .tf-boot-header {
-        border-bottom: 1px solid #e2e8f0;
-        background: #ffffff;
+        border-bottom: 1px solid rgba(226, 232, 240, 0.7);
+        background: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(10px);
       }
 
       .tf-boot-header-inner {
-        height: 72px;
-        max-width: 1600px;
+        min-height: 72px;
+        max-width: 1280px;
         margin: 0 auto;
-        display: grid;
-        grid-template-columns: auto minmax(0, 1fr) auto;
+        display: flex;
         align-items: center;
-        gap: 24px;
-        padding: 0 24px;
+        justify-content: space-between;
+        gap: 20px;
+        padding-inline: 20px;
+        padding-block: 16px;
       }
 
       .tf-boot-brand {
         display: inline-flex;
         align-items: center;
-        gap: 14px;
+        gap: 8px;
         min-width: 0;
+        flex: 0 0 auto;
       }
 
       .tf-boot-logo-frame {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        height: 46px;
-        width: 46px;
-        border-radius: 14px;
+        height: 32px;
+        width: 32px;
+        border-radius: 8px;
         background: linear-gradient(135deg, #4f46e5 0%, #6366f1 100%);
-        box-shadow: 0 14px 30px rgba(79, 70, 229, 0.18);
+        box-shadow: 0 10px 24px rgba(165, 180, 252, 0.9);
       }
 
       .tf-boot-logo-image {
-        height: 28px;
-        width: 28px;
+        height: 18px;
+        width: 18px;
         display: block;
       }
 
       .tf-boot-wordmark {
-        font-size: 2rem;
-        line-height: 1;
-        font-weight: 900;
-        letter-spacing: -0.035em;
-        color: #111827;
+        font-size: 1.125rem;
+        line-height: 1.75rem;
+        font-weight: 800;
+        letter-spacing: -0.025em;
+        color: #0f172a;
       }
 
       .tf-boot-nav {
         display: flex;
         align-items: center;
         justify-content: center;
-        gap: 22px;
+        gap: 16px;
         min-width: 0;
+        flex: 1 1 auto;
+        font-size: 0.875rem;
       }
 
       .tf-boot-nav-link,
-      .tf-boot-action-chip,
-      .tf-boot-action-button,
       .tf-boot-line,
       .tf-boot-card,
       .tf-boot-metric,
@@ -124,48 +127,67 @@
       }
 
       .tf-boot-nav-link {
-        height: 14px;
         flex: 0 0 auto;
+        color: #64748b;
+        font-weight: 600;
+        white-space: nowrap;
       }
-
-      .tf-boot-nav-link:nth-child(1) { width: 72px; }
-      .tf-boot-nav-link:nth-child(2) { width: 94px; }
-      .tf-boot-nav-link:nth-child(3) { width: 110px; }
-      .tf-boot-nav-link:nth-child(4) { width: 48px; }
-      .tf-boot-nav-link:nth-child(5) { width: 64px; }
 
       .tf-boot-actions {
         display: inline-flex;
         align-items: center;
-        gap: 10px;
+        gap: 8px;
+        flex: 0 0 auto;
       }
 
       .tf-boot-action-chip,
       .tf-boot-action-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         flex: 0 0 auto;
         border: 1px solid #e2e8f0;
-        background-color: #ffffff;
+        background-color: rgba(255, 255, 255, 0.96);
         box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+        border-radius: 8px;
+        font-size: 0.875rem;
+        line-height: 1.25rem;
       }
 
       .tf-boot-action-chip {
-        height: 44px;
+        height: 36px;
+        padding-inline: 12px;
+        color: #334155;
+        font-weight: 600;
       }
 
       .tf-boot-action-chip--locale {
-        width: 146px;
+        gap: 8px;
       }
 
       .tf-boot-action-chip--login {
-        width: 96px;
+        min-width: 80px;
       }
 
       .tf-boot-action-button {
-        height: 44px;
-        width: 140px;
+        height: 36px;
+        padding-inline: 12px;
         background:
           linear-gradient(135deg, rgba(79, 70, 229, 0.92) 0%, rgba(99, 102, 241, 0.92) 100%);
-        box-shadow: 0 10px 22px rgba(79, 70, 229, 0.18);
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+        border-color: rgba(99, 102, 241, 0.36);
+        color: #ffffff;
+        font-weight: 600;
+      }
+
+      .tf-boot-action-locale-flag {
+        font-size: 0.875rem;
+        line-height: 1;
+      }
+
+      .tf-boot-action-locale-caret {
+        font-size: 0.75rem;
+        color: #64748b;
       }
 
       .tf-boot-main {
@@ -174,9 +196,10 @@
       }
 
       .tf-boot-page {
-        max-width: 1600px;
+        max-width: 1280px;
         margin: 0 auto;
-        padding: 28px 24px 40px;
+        padding-inline: 20px;
+        padding-block: 28px 40px;
       }
 
       .tf-boot-page--trip {
@@ -396,7 +419,6 @@
 
       @media (max-width: 1200px) {
         .tf-boot-header-inner {
-          grid-template-columns: auto 1fr auto;
           gap: 18px;
         }
 
@@ -410,10 +432,6 @@
       }
 
       @media (max-width: 960px) {
-        .tf-boot-header-inner {
-          grid-template-columns: auto auto;
-        }
-
         .tf-boot-nav {
           display: none;
         }
@@ -425,28 +443,31 @@
 
       @media (max-width: 640px) {
         .tf-boot-header-inner {
-          height: 64px;
-          padding: 0 14px;
+          min-height: 64px;
+          padding-inline: 14px;
+          padding-block: 14px;
           gap: 12px;
         }
 
         .tf-boot-logo-frame {
-          height: 40px;
-          width: 40px;
-          border-radius: 12px;
+          height: 32px;
+          width: 32px;
+          border-radius: 8px;
         }
 
         .tf-boot-logo-image {
-          height: 24px;
-          width: 24px;
+          height: 18px;
+          width: 18px;
         }
 
         .tf-boot-wordmark {
-          font-size: 1.6rem;
+          font-size: 1.125rem;
+          line-height: 1.75rem;
         }
 
         .tf-boot-page {
-          padding: 18px 14px 24px;
+          padding-inline: 14px;
+          padding-block: 18px 24px;
         }
 
         .tf-boot-action-chip--locale,
@@ -455,8 +476,7 @@
         }
 
         .tf-boot-action-button {
-          width: 104px;
-          height: 40px;
+          height: 36px;
         }
 
         .tf-boot-hero {
@@ -486,9 +506,6 @@
       }
 
       @media (prefers-reduced-motion: reduce) {
-        .tf-boot-nav-link,
-        .tf-boot-action-chip,
-        .tf-boot-action-button,
         .tf-boot-line,
         .tf-boot-card,
         .tf-boot-metric,
@@ -583,16 +600,20 @@
               <span class="tf-boot-wordmark">TravelFlow</span>
             </div>
             <nav class="tf-boot-nav" aria-hidden="true">
-              <span class="tf-boot-nav-link"></span>
-              <span class="tf-boot-nav-link"></span>
-              <span class="tf-boot-nav-link"></span>
-              <span class="tf-boot-nav-link"></span>
-              <span class="tf-boot-nav-link"></span>
+              <span class="tf-boot-nav-link">Features</span>
+              <span class="tf-boot-nav-link">Inspirations</span>
+              <span class="tf-boot-nav-link">News &amp; Updates</span>
+              <span class="tf-boot-nav-link">Blog</span>
+              <span class="tf-boot-nav-link">Pricing</span>
             </nav>
             <div class="tf-boot-actions">
-              <span class="tf-boot-action-chip tf-boot-action-chip--locale"></span>
-              <span class="tf-boot-action-chip tf-boot-action-chip--login"></span>
-              <span class="tf-boot-action-button"></span>
+              <span class="tf-boot-action-chip tf-boot-action-chip--locale">
+                <span class="tf-boot-action-locale-flag" aria-hidden="true">🇬🇧</span>
+                <span>English</span>
+                <span class="tf-boot-action-locale-caret" aria-hidden="true">⌄</span>
+              </span>
+              <span class="tf-boot-action-chip tf-boot-action-chip--login">Login</span>
+              <span class="tf-boot-action-button">Create Trip</span>
             </div>
           </div>
         </header>

--- a/tests/unit/adminAuditPage.import.test.ts
+++ b/tests/unit/adminAuditPage.import.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 describe('pages/AdminAuditPage module', () => {
-  it('loads the page component without module errors', async () => {
+  it('loads the page component without module errors', { timeout: 60000 }, async () => {
     const module = await import('../../pages/AdminAuditPage');
     expect(typeof module.AdminAuditPage).toBe('function');
   });

--- a/tests/unit/adminTripsPage.import.test.ts
+++ b/tests/unit/adminTripsPage.import.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 describe('pages/AdminTripsPage module', () => {
-  it('loads the page component without module errors', async () => {
+  it('loads the page component without module errors', { timeout: 60000 }, async () => {
     const module = await import('../../pages/AdminTripsPage');
     expect(typeof module.AdminTripsPage).toBe('function');
   });

--- a/tests/unit/indexBootstrapShell.test.ts
+++ b/tests/unit/indexBootstrapShell.test.ts
@@ -12,6 +12,9 @@ describe('index.html bootstrap shell', () => {
     expect(html).toContain('class="tf-boot-page tf-boot-page--marketing"');
     expect(html).toContain('src="/favicon.svg"');
     expect(html).toContain('TravelFlow');
+    expect(html).toContain('Features');
+    expect(html).toContain('News &amp; Updates');
+    expect(html).toContain('Create Trip');
   });
 
   it('switches to a trip-specific bootstrap shell on trip-like routes before hydration', () => {

--- a/tests/unit/tripGenerationRetryToast.test.ts
+++ b/tests/unit/tripGenerationRetryToast.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { buildQueuedTripGenerationRetryToastOptions } from '../../components/tripview/tripGenerationRetryToast';
+
+describe('components/tripview/tripGenerationRetryToast', () => {
+  it('disables the default undo action for queued retry toasts', () => {
+    expect(
+      buildQueuedTripGenerationRetryToastOptions('Retry started'),
+    ).toEqual({
+      tone: 'neutral',
+      title: 'Retry started',
+      disableDefaultUndo: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- remove the default Undo action from queued retry toasts once async generation has already started
- align the pre-hydration bootstrap header with the real site navigation sizing/chrome instead of the oversized placeholder version
- stabilize the two slow admin import smoke tests under full-suite load and refresh the async-generation tracker/release-note bookkeeping

## Testing
- `pnpm test tests/unit/indexBootstrapShell.test.ts tests/unit/tripGenerationRetryToast.test.ts tests/browser/tripview/tripToastUndoAction.browser.test.ts`
- `pnpm test tests/unit/adminTripsPage.import.test.ts tests/unit/adminAuditPage.import.test.ts tests/unit/indexBootstrapShell.test.ts tests/unit/tripGenerationRetryToast.test.ts`
- `pnpm updates:validate`
- `pnpm test:core`
- `pnpm dlx react-doctor@latest . --verbose --diff`
