### PR TITLE
Fix ProgressiveImage skipFade regression

### DIFF
--- a/components/ProgressiveImage.tsx
+++ b/components/ProgressiveImage.tsx
@@ -59,6 +59,7 @@ export interface ProgressiveImageProps {
     placeholderBlurhash?: string;
     onError?: () => void;
     disableCdn?: boolean;
+    skipFade?: boolean;
 }
 
 export const ProgressiveImage: React.FC<ProgressiveImageProps> = ({
@@ -75,6 +76,7 @@ export const ProgressiveImage: React.FC<ProgressiveImageProps> = ({
     placeholderBlurhash,
     onError,
     disableCdn = false,
+    skipFade = false,
 }) => {
     const [isLoaded, setIsLoaded] = useState(false);
     const [hasError, setHasError] = useState(false);

--- a/content/updates/2026-03-09-progressive-image-skipfade-hotfix.md
+++ b/content/updates/2026-03-09-progressive-image-skipfade-hotfix.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-03-09-progressive-image-skipfade-hotfix
+version: v0.0.0
+title: "Progressive image skip-fade hotfix"
+date: 2026-03-09
+published_at: 2026-03-09T19:58:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Fixes a blog image regression that could crash pages using the immediate image reveal path."
+---
+
+## Changes
+- [x] [Fixed] 🖼️ Blog pages no longer crash when shared transitions request an immediate image reveal.
+- [ ] [Internal] 🧪 Restored the `skipFade` prop contract on `ProgressiveImage` and added a component regression test for the render path.

--- a/test/components/ProgressiveImage.test.tsx
+++ b/test/components/ProgressiveImage.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ProgressiveImage } from '../../components/ProgressiveImage';
+
+describe('ProgressiveImage', () => {
+    beforeEach(() => {
+        cleanup();
+    });
+
+    it('renders with skipFade enabled without throwing and keeps the image visible immediately', () => {
+        render(
+            <ProgressiveImage
+                src="/images/test-photo.webp"
+                alt="Test image"
+                width={1200}
+                height={800}
+                skipFade
+            />
+        );
+
+        const image = screen.getByRole('img', { name: 'Test image' });
+        expect(image).toBeInTheDocument();
+        expect(image).toHaveClass('opacity-100');
+    });
+});


### PR DESCRIPTION
## Summary
- restore the `skipFade` prop contract on `ProgressiveImage`
- fix the runtime `ReferenceError` that was shipped with the merged blog transition work
- add a regression test for the immediate-visible render path and update the draft release note

## Testing
- pnpm vitest run test/components/ProgressiveImage.test.tsx
- pnpm test:core
- pnpm exec vite build
- pnpm updates:validate
