### PR TITLE
Fix marketing navigation fallback handoff

### DIFF
--- a/app/bootstrap/AppProviderShell.tsx
+++ b/app/bootstrap/AppProviderShell.tsx
@@ -12,7 +12,7 @@ interface AppProviderShellProps {
 
 export const AppProviderShell: React.FC<AppProviderShellProps> = ({ children }) => {
     return (
-        <Router history={appHistory} unstable_useTransitions={false}>
+        <Router history={appHistory}>
             <AuthProvider>
                 <AppDialogProvider>
                     <LoginModalProvider>

--- a/app/routes/AppRoutes.tsx
+++ b/app/routes/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useLayoutEffect, useRef } from 'react';
+import React, { Suspense, lazy, useEffect, useLayoutEffect, useRef } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { AppLanguage, ITrip, IViewSettings } from '../../types';
 import { useDbSync } from '../../hooks/useDbSync';
@@ -7,6 +7,7 @@ import { loadLazyComponentWithRecovery } from '../../services/lazyImportRecovery
 import { MarketingRouteLoadingShell } from '../../components/bootstrap/MarketingRouteLoadingShell';
 import { TripRouteLoadingShell } from '../../components/tripview/TripRouteLoadingShell';
 import { DeferredAppRoutes } from './DeferredAppRoutes';
+import { markInitialRouteHandoffCompleted } from '../../services/marketingRouteShellState';
 
 const lazyWithRecovery = <TModule extends { default: React.ComponentType<any> },>(
     moduleKey: string,
@@ -23,11 +24,17 @@ export const RouteLoadingFallback: React.FC = () => (
     <MarketingRouteLoadingShell />
 );
 
-const HandoffReadyBoundary: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <div data-tf-handoff-ready="true">
-        {children}
-    </div>
-);
+const HandoffReadyBoundary: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    useEffect(() => {
+        markInitialRouteHandoffCompleted();
+    }, []);
+
+    return (
+        <div data-tf-handoff-ready="true">
+            {children}
+        </div>
+    );
+};
 
 const renderWithSuspense = (
     node: React.ReactElement,

--- a/app/routes/DeferredAppRoutes.tsx
+++ b/app/routes/DeferredAppRoutes.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense, lazy, useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { AppLanguage, ITrip, IViewSettings } from '../../types';
 import { useAuth } from '../../hooks/useAuth';
@@ -8,6 +8,7 @@ import { loadLazyComponentWithRecovery } from '../../services/lazyImportRecovery
 import { MarketingRouteLoadingShell } from '../../components/bootstrap/MarketingRouteLoadingShell';
 import { MarketingHomePage } from '../../pages/MarketingHomePage';
 import '../../styles/deferred-routes.css';
+import { markInitialRouteHandoffCompleted } from '../../services/marketingRouteShellState';
 
 const lazyWithRecovery = <TModule extends { default: React.ComponentType<any> },>(
     moduleKey: string,
@@ -52,11 +53,17 @@ const RouteLoadingFallback: React.FC = () => (
     <MarketingRouteLoadingShell />
 );
 
-const HandoffReadyBoundary: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <div data-tf-handoff-ready="true">
-        {children}
-    </div>
-);
+const HandoffReadyBoundary: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    useEffect(() => {
+        markInitialRouteHandoffCompleted();
+    }, []);
+
+    return (
+        <div data-tf-handoff-ready="true">
+            {children}
+        </div>
+    );
+};
 
 const renderWithSuspense = (node: React.ReactElement) => (
     <Suspense fallback={<RouteLoadingFallback />}>

--- a/components/bootstrap/AppBootstrapShell.tsx
+++ b/components/bootstrap/AppBootstrapShell.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 
 type AppBootstrapShellVariant = 'marketing' | 'trip';
+type AppBootstrapShellChromeMode = 'skeleton' | 'ghost';
+type AppBootstrapShellSurfaceMode = 'default' | 'neutral';
 
 interface AppBootstrapShellProps {
   variant?: AppBootstrapShellVariant;
   testId?: string;
   shellState?: string;
   handoffReady?: boolean;
+  chromeMode?: AppBootstrapShellChromeMode;
+  surfaceMode?: AppBootstrapShellSurfaceMode;
 }
 
 const TRIP_DAYS = [0, 1, 2, 3, 4];
@@ -17,12 +21,16 @@ export const AppBootstrapShell: React.FC<AppBootstrapShellProps> = ({
   testId,
   shellState,
   handoffReady = false,
+  chromeMode = 'skeleton',
+  surfaceMode = 'default',
 }) => (
   <div
     className="tf-boot-shell"
     data-testid={testId}
     data-shell-variant={variant}
     data-shell-state={shellState}
+    data-tf-chrome-mode={chromeMode}
+    data-tf-surface-mode={surfaceMode}
     data-tf-handoff-ready={handoffReady ? 'true' : undefined}
     aria-hidden="true"
   >
@@ -35,23 +43,45 @@ export const AppBootstrapShell: React.FC<AppBootstrapShellProps> = ({
           <span className="tf-boot-wordmark">TravelFlow</span>
         </div>
         <nav className="tf-boot-nav" aria-hidden="true">
-          <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--features"></span></span>
-          <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--inspirations"></span></span>
-          <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--updates"></span></span>
-          <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--blog"></span></span>
-          <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--pricing"></span></span>
+          {chromeMode === 'skeleton' ? (
+            <>
+              <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--features"></span></span>
+              <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--inspirations"></span></span>
+              <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--updates"></span></span>
+              <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--blog"></span></span>
+              <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--pricing"></span></span>
+            </>
+          ) : chromeMode === 'ghost' ? (
+            <>
+              <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--features"></span></span>
+              <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--inspirations"></span></span>
+              <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--updates"></span></span>
+              <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--blog"></span></span>
+              <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--pricing"></span></span>
+            </>
+          ) : null}
         </nav>
         <div className="tf-boot-actions">
-          <span className="tf-boot-action-chip tf-boot-action-chip--locale">
-            <span className="tf-boot-control-flag" aria-hidden="true"></span>
-            <span className="tf-boot-control-skeleton tf-boot-control-skeleton--locale"></span>
-          </span>
-          <span className="tf-boot-action-chip tf-boot-action-chip--login">
-            <span className="tf-boot-control-skeleton tf-boot-control-skeleton--login"></span>
-          </span>
-          <span className="tf-boot-action-button">
-            <span className="tf-boot-control-skeleton tf-boot-control-skeleton--cta"></span>
-          </span>
+          {chromeMode === 'skeleton' ? (
+            <>
+              <span className="tf-boot-action-chip tf-boot-action-chip--locale">
+                <span className="tf-boot-control-flag" aria-hidden="true"></span>
+                <span className="tf-boot-control-skeleton tf-boot-control-skeleton--locale"></span>
+              </span>
+              <span className="tf-boot-action-chip tf-boot-action-chip--login">
+                <span className="tf-boot-control-skeleton tf-boot-control-skeleton--login"></span>
+              </span>
+              <span className="tf-boot-action-button">
+                <span className="tf-boot-control-skeleton tf-boot-control-skeleton--cta"></span>
+              </span>
+            </>
+          ) : chromeMode === 'ghost' ? (
+            <>
+              <span className="tf-boot-action-chip tf-boot-action-chip--locale tf-boot-action-chip--ghost" />
+              <span className="tf-boot-action-chip tf-boot-action-chip--login tf-boot-action-chip--ghost" />
+              <span className="tf-boot-action-button tf-boot-action-button--ghost" />
+            </>
+          ) : null}
           <span className="tf-boot-action-burger" aria-hidden="true">
             <svg className="tf-boot-action-burger-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
               <path d="M4 7h16" />

--- a/components/bootstrap/MarketingRouteLoadingShell.tsx
+++ b/components/bootstrap/MarketingRouteLoadingShell.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 
 import { AppBootstrapShell } from './AppBootstrapShell';
+import { hasCompletedInitialRouteHandoff } from '../../services/marketingRouteShellState';
 
-export const MarketingRouteLoadingShell: React.FC = () => (
-    <AppBootstrapShell
-        variant="marketing"
-        testId="route-loading-shell"
-    />
-);
+export const MarketingRouteLoadingShell: React.FC = () => {
+    const isInitialHandoff = !hasCompletedInitialRouteHandoff();
+
+    return (
+        <AppBootstrapShell
+            variant="marketing"
+            testId="route-loading-shell"
+            chromeMode={isInitialHandoff ? 'skeleton' : 'ghost'}
+            surfaceMode={isInitialHandoff ? 'default' : 'neutral'}
+        />
+    );
+};

--- a/content/updates/2026-03-07-bootstrap-shell-handoff.md
+++ b/content/updates/2026-03-07-bootstrap-shell-handoff.md
@@ -14,6 +14,8 @@ summary: "Kept the branded header visible through the React handoff and removed 
 - [x] [Improved] 🧭 First-load navigation now stays visible while the app hydrates, so opening a page feels faster and less blank.
 - [x] [Improved] ⚡ The homepage now loads its above-the-fold route path without the old nested chunk waterfall, so the first real content appears sooner after the initial shell.
 - [x] [Improved] 🧳 Trip, shared-trip, and example-trip loading now keep a route-aware top bar on screen until the first real planner view is ready.
+- [x] [Fixed] 🧭 Opening another page after the app is already ready no longer replays the first-load navigation skeleton.
+- [x] [Fixed] ✨ Follow-up page loads now keep the fallback header sizing and background closer to the live marketing layout, reducing the brief flash during route changes.
 - [ ] [Internal] 🧱 Replaced the marketing route fallback with the real React site header and matching brand icon so the bootstrap handoff no longer jumps between different header layouts.
 - [ ] [Internal] 🛠️ Fixed the bootstrap container markup so removing the pre-hydration shell no longer tears down the React root during the handoff.
 - [ ] [Internal] ⏱️ Moved the bootstrap handoff trigger to the actual resolved route content for marketing and create-trip flows, so the static shell stays in place until the real page is ready to replace it.

--- a/index.html
+++ b/index.html
@@ -63,6 +63,10 @@
         font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
       }
 
+      .tf-boot-shell[data-tf-surface-mode="neutral"] {
+        background: #f8fafc;
+      }
+
       .tf-boot-header {
         border-bottom: 1px solid rgba(226, 232, 240, 0.7);
         background: rgba(255, 255, 255, 0.9);
@@ -147,6 +151,7 @@
       }
 
       .tf-boot-nav-skeleton,
+      .tf-boot-nav-ghost,
       .tf-boot-control-skeleton,
       .tf-boot-control-flag {
         border-radius: 999px;
@@ -155,11 +160,16 @@
         animation: tf-boot-shimmer 1.4s linear infinite;
       }
 
-      .tf-boot-nav-skeleton--features { width: 64px; height: 12px; }
-      .tf-boot-nav-skeleton--inspirations { width: 78px; height: 12px; }
-      .tf-boot-nav-skeleton--updates { width: 110px; height: 12px; }
-      .tf-boot-nav-skeleton--blog { width: 34px; height: 12px; }
-      .tf-boot-nav-skeleton--pricing { width: 52px; height: 12px; }
+      .tf-boot-nav-skeleton--features,
+      .tf-boot-nav-ghost--features { width: 64px; height: 12px; }
+      .tf-boot-nav-skeleton--inspirations,
+      .tf-boot-nav-ghost--inspirations { width: 78px; height: 12px; }
+      .tf-boot-nav-skeleton--updates,
+      .tf-boot-nav-ghost--updates { width: 110px; height: 12px; }
+      .tf-boot-nav-skeleton--blog,
+      .tf-boot-nav-ghost--blog { width: 34px; height: 12px; }
+      .tf-boot-nav-skeleton--pricing,
+      .tf-boot-nav-ghost--pricing { width: 52px; height: 12px; }
 
       .tf-boot-control-flag {
         width: 18px;
@@ -223,6 +233,12 @@
         border-radius: 8px;
         white-space: nowrap;
         pointer-events: none;
+      }
+
+      .tf-boot-nav-link--ghost,
+      .tf-boot-action-chip--ghost,
+      .tf-boot-action-button--ghost {
+        visibility: hidden;
       }
 
       .tf-boot-action-chip {

--- a/services/marketingRouteShellState.ts
+++ b/services/marketingRouteShellState.ts
@@ -1,0 +1,11 @@
+let initialRouteHandoffCompleted = false;
+
+export const hasCompletedInitialRouteHandoff = (): boolean => initialRouteHandoffCompleted;
+
+export const markInitialRouteHandoffCompleted = (): void => {
+  initialRouteHandoffCompleted = true;
+};
+
+export const resetInitialRouteHandoffCompletedForTests = (): void => {
+  initialRouteHandoffCompleted = false;
+};

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,7 +1,9 @@
 import { afterEach, vi } from 'vitest';
+import { resetInitialRouteHandoffCompletedForTests } from '../services/marketingRouteShellState';
 
 afterEach(() => {
   vi.useRealTimers();
+  resetInitialRouteHandoffCompletedForTests();
   if (typeof window !== 'undefined') {
     window.localStorage.clear();
     window.sessionStorage.clear();

--- a/tests/unit/marketingRouteLoadingShell.test.ts
+++ b/tests/unit/marketingRouteLoadingShell.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+import { MarketingRouteLoadingShell } from '../../components/bootstrap/MarketingRouteLoadingShell';
+import {
+  markInitialRouteHandoffCompleted,
+  resetInitialRouteHandoffCompletedForTests,
+} from '../../services/marketingRouteShellState';
+
+describe('MarketingRouteLoadingShell', () => {
+  afterEach(() => {
+    cleanup();
+    resetInitialRouteHandoffCompletedForTests();
+  });
+
+  it('shows the navigation skeleton during the initial route handoff', () => {
+    const view = render(React.createElement(MarketingRouteLoadingShell));
+
+    expect(view.getByTestId('route-loading-shell')).toHaveAttribute('data-tf-chrome-mode', 'skeleton');
+    expect(view.container.querySelector('.tf-boot-nav-skeleton--features')).toBeTruthy();
+    expect(view.container.querySelector('.tf-boot-control-skeleton--cta')).toBeTruthy();
+  });
+
+  it('hides the navigation skeleton after the first route handoff completes', () => {
+    markInitialRouteHandoffCompleted();
+
+    const view = render(React.createElement(MarketingRouteLoadingShell));
+
+    expect(view.getByTestId('route-loading-shell')).toHaveAttribute('data-tf-chrome-mode', 'ghost');
+    expect(view.getByTestId('route-loading-shell')).toHaveAttribute('data-tf-surface-mode', 'neutral');
+    expect(view.container.querySelector('.tf-boot-nav-skeleton--features')).toBeNull();
+    expect(view.container.querySelector('.tf-boot-nav-ghost--features')).toBeTruthy();
+    expect(view.container.querySelector('.tf-boot-action-chip--ghost')).toBeTruthy();
+    expect(view.getByTestId('route-loading-shell').textContent).toContain('TravelFlow');
+  });
+});


### PR DESCRIPTION
## Summary
- stop forcing React Router transitions off in the app provider shell
- keep the navigation bootstrap shell first-load-only and switch follow-up route fallbacks to a ghost header footprint
- add regression coverage for the post-handoff marketing route shell behavior

## Root cause
The white flash came from forcing `unstable_useTransitions={false}` on the router. That made already-rendered marketing pages drop straight to the Suspense fallback during lazy route navigation.

## What changed
- removed the router override so the current page stays visible while the next lazy route resolves
- added a small handoff state to distinguish the initial bootstrap shell from later route fallbacks
- kept the fallback shell geometry aligned after first load without replaying visible nav skeleton bars
- updated the draft release note for this worktree

## Validation
- `pnpm exec vitest run tests/browser/routes/appRoutes.browser.test.ts tests/browser/routes/deferredAppRoutes.browser.test.ts tests/unit/marketingRouteLoadingShell.test.ts tests/services/bootstrapHandoffService.test.ts`
- `pnpm build:netlify`
- `npx -y react-doctor@latest . --verbose --diff`
- manual sanity pass:
  - desktop: `/` -> `/pricing` -> `/create-trip`
  - mobile menu: `/` -> `/pricing` -> `/create-trip`

