### PR TITLE
Optimize homepage media delivery

### DIFF
--- a/components/marketing/ExampleTripCard.tsx
+++ b/components/marketing/ExampleTripCard.tsx
@@ -151,7 +151,6 @@ export const ExampleTripCard: React.FC<ExampleTripCardProps> = ({
                         className="h-full w-full object-cover"
                         loading="lazy"
                         fetchPriority="low"
-                        disableCdn={Boolean(card.mapImagePath && mapImageSrc?.includes(card.mapImagePath))}
                         onError={handleMapImageError}
                     />
                 ) : (

--- a/components/marketing/PlaneWindowAnimation.tsx
+++ b/components/marketing/PlaneWindowAnimation.tsx
@@ -1,10 +1,27 @@
 import React from 'react';
+import { buildImageCdnUrl } from '../../utils/imageDelivery';
+
+const CLOUDS_SRC = '/images/clouds.png';
+const PLANE_WINDOW_SRC = '/images/plane-window.png';
+const PLANE_WINDOW_IMAGE_WIDTH = 640;
+const CLOUDS_IMAGE_WIDTH = 512;
 
 /**
  * Animated plane window with clouds scrolling behind it,
  * simulating an in-flight view.
  */
 export const PlaneWindowAnimation: React.FC = () => {
+    const cloudImageSrc = buildImageCdnUrl(CLOUDS_SRC, {
+        width: CLOUDS_IMAGE_WIDTH,
+        format: 'webp',
+        quality: 60,
+    });
+    const planeWindowSrc = buildImageCdnUrl(PLANE_WINDOW_SRC, {
+        width: PLANE_WINDOW_IMAGE_WIDTH,
+        format: 'webp',
+        quality: 68,
+    });
+
     return (
         <div
             className="plane-window-wrapper relative select-none"
@@ -15,26 +32,35 @@ export const PlaneWindowAnimation: React.FC = () => {
             <div className="plane-window-clouds-mask absolute overflow-hidden">
                 <div className="flex h-full animate-clouds-scroll">
                     <img
-                        src="/images/clouds.png"
+                        src={cloudImageSrc}
                         alt=""
                         draggable={false}
                         className="h-full w-auto max-w-none shrink-0 object-cover"
+                        loading="lazy"
+                        decoding="async"
+                        fetchPriority="low"
                     />
                     <img
-                        src="/images/clouds.png"
+                        src={cloudImageSrc}
                         alt=""
                         draggable={false}
                         className="h-full w-auto max-w-none shrink-0 object-cover"
+                        loading="lazy"
+                        decoding="async"
+                        fetchPriority="low"
                     />
                 </div>
             </div>
 
             {/* Window frame sits on top */}
             <img
-                src="/images/plane-window.png"
+                src={planeWindowSrc}
                 alt="Airplane window"
                 draggable={false}
                 className="relative z-10 h-full w-full object-contain drop-shadow-xl"
+                loading="lazy"
+                decoding="async"
+                fetchPriority="low"
             />
         </div>
     );

--- a/content/updates/2026-03-10-homepage-pagespeed-pass.md
+++ b/content/updates/2026-03-10-homepage-pagespeed-pass.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-03-10-homepage-pagespeed-pass
+version: v0.0.0
+title: "Homepage media now ships through the production image pipeline"
+date: 2026-03-10
+published_at: 2026-03-10T14:30:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Reduced homepage transfer weight by sending the hero artwork and example trip maps through the production image pipeline instead of the full original PNGs."
+---
+
+## Changes
+- [x] [Improved] 🛫 The homepage hero now loads its decorative airplane artwork in production-friendly responsive formats, cutting the first desktop payload without changing the layout.
+- [x] [Improved] 🗺️ Example trip previews on the homepage now use optimized production image delivery instead of full-size source images, so the examples section is much lighter when it appears.
+- [ ] [Internal] 📊 Captured before-and-after homepage Lighthouse baselines for desktop and mobile so follow-up chunk work can target the remaining shared JavaScript cost with real measurements.


### PR DESCRIPTION
## Summary
- route the homepage hero plane artwork through Netlify image transforms instead of shipping the original PNGs
- stop bypassing the production image pipeline for example-trip map previews on the homepage
- keep this PR scoped to homepage first-load transfer weight and document the remaining shared-chunk follow-up work

## Root cause
The homepage was still paying for large raw image assets on first load:
- the hero plane artwork loaded `/images/plane-window.png` and `/images/clouds.png` directly on desktop
- example-trip cards explicitly disabled CDN delivery for local map preview assets, so the browser fetched the original PNGs instead of optimized AVIF/WebP variants

## Measured impact
Homepage Lighthouse against local production preview (`http://127.0.0.1:4174/`):

### Desktop before
- performance: 76
- total byte weight: 2,254 KiB
- FCP: 0.7 s
- LCP: 1.1 s
- TBT: 500 ms

### Desktop after
- performance: 99
- total byte weight: 739 KiB
- FCP: 0.5 s
- LCP: 0.8 s
- TBT: 70 ms

### Mobile before
- performance: 82
- total byte weight: 448 KiB
- FCP: 2.7 s
- LCP: 4.0 s

### Mobile after
- performance: 84
- total byte weight: 448 KiB
- FCP: 2.4 s
- LCP: 3.9 s

## Validation
- `pnpm exec vitest run tests/browser/routes/deferredAppRoutes.browser.test.ts`
- `pnpm build:netlify`
- `npx -y react-doctor@latest . --verbose --diff`
- local Lighthouse desktop/mobile baseline before and after against Vite preview

## Follow-up plan
This PR intentionally does not try to solve the remaining large production chunks. The next pass should stay focused on homepage JavaScript coupling:
1. audit why `/` still pulls the large shared entry chunk plus auth/profile support chunks through the marketing layout and header path
2. inspect the static route graph around `DeferredAppRoutes`, `prefetchTargets`, and `criticalRoutePreload` so homepage-only entry does not inherit avoidable shared app code
3. verify whether any non-critical marketing UI can move behind idle or intent boundaries without reintroducing navigation regressions
4. remeasure after each chunk-boundary change and only keep changes that improve homepage first-load metrics without affecting route responsiveness
