### PR TITLE
Make marketing auth bootstrap route-aware

### DIFF
--- a/content/updates/2026-03-10-homepage-shared-chunk-pass.md
+++ b/content/updates/2026-03-10-homepage-shared-chunk-pass.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-03-10-homepage-shared-chunk-pass
+version: v0.0.0
+title: "Homepage auth bootstrap now stays off the first-load critical path when possible"
+date: 2026-03-10
+published_at: 2026-03-10T16:15:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Made homepage auth bootstrap more route-aware and documented that the remaining homepage speed bottleneck is the large shared entry chunk rather than eager profile hydration."
+---
+
+## Changes
+- [ ] [Internal] 🔐 Non-critical marketing routes now defer auth bootstrap until idle and avoid eager profile hydration unless the route actually renders account details.
+- [ ] [Internal] 📊 Captured a follow-up homepage Lighthouse pass showing that the remaining mobile bottleneck is still the shared entry chunk, which keeps the next optimization step focused on bundle decomposition instead of more auth churn.

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -62,6 +62,8 @@ const hasAuthCallbackPayload = (): boolean => {
 const DEV_ADMIN_BYPASS_DISABLED_STORAGE_KEY = 'tf_dev_admin_bypass_disabled';
 const DEV_ADMIN_BYPASS_USER_ID = 'dev-admin-id';
 const OPTIMISTIC_AUTH_HINT_SESSION_LIFETIME_SECONDS = 300;
+const NON_CRITICAL_AUTH_BOOTSTRAP_IDLE_TIMEOUT_MS = 1800;
+const NON_CRITICAL_AUTH_BOOTSTRAP_FALLBACK_DELAY_MS = 250;
 const FREE_ENTITLEMENTS = getFreePlanEntitlements();
 
 export const shouldEnableDevAdminBypass = (
@@ -94,6 +96,22 @@ export const shouldUseDevAdminBypassSession = (
 
 export const shouldUseOptimisticMarketingAuthHint = (pathname: string): boolean =>
     !isAuthBootstrapCriticalPath(pathname);
+
+export const shouldDeferAuthBootstrap = (
+    pathname: string,
+    hasCallbackPayload: boolean
+): boolean => !hasCallbackPayload && !isAuthBootstrapCriticalPath(pathname);
+
+export const shouldEagerlyLoadAuthProfile = (pathname: string): boolean => {
+    const normalizedPath = stripLocalePrefix(pathname || '/');
+    if (normalizedPath.startsWith('/profile')) return true;
+    if (normalizedPath.startsWith('/checkout')) return true;
+    if (normalizedPath.startsWith('/admin')) return true;
+    if (normalizedPath.startsWith('/trip')) return true;
+    if (normalizedPath.startsWith('/create-trip')) return true;
+    if (normalizedPath.startsWith('/u/')) return true;
+    return false;
+};
 
 export const createOptimisticAccessFromSessionHint = (
     hint: PersistedSupabaseSessionHint
@@ -303,11 +321,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         const nextAccess = await authService.getCurrentAccessContext();
         setAccess(nextAccess);
         if (nextAccess?.userId && !nextAccess.isAnonymous) {
-            await refreshProfile();
+            if (shouldEagerlyLoadAuthProfile(location.pathname)) {
+                await refreshProfile();
+            } else {
+                resetProfileState();
+            }
             return;
         }
         resetProfileState();
-    }, [refreshProfile, resetProfileState]);
+    }, [location.pathname, refreshProfile, resetProfileState]);
 
     useEffect(() => {
         let cancelled = false;
@@ -496,20 +518,94 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             };
         }
 
-        const shouldBootstrapImmediately = hasAuthCallbackPayload() || isAuthBootstrapCriticalPath(window.location.pathname);
-        if (!shouldBootstrapImmediately) {
+        const shouldUseDeferredBootstrap = shouldDeferAuthBootstrap(
+            window.location.pathname,
+            hasAuthCallbackPayload()
+        );
+        if (shouldUseDeferredBootstrap) {
             appendAuthTraceEntry({
                 ts: new Date().toISOString(),
                 flowId: 'auth-bootstrap',
-                attemptId: 'immediate-bootstrap',
+                attemptId: 'deferred-bootstrap',
                 step: 'bootstrap_non_critical_path',
                 result: 'success',
                 provider: 'supabase',
                 metadata: {
                     pathname: window.location.pathname,
-                    reason: 'always_initialize_on_page_load',
+                    reason: 'defer_until_idle',
                 },
             });
+
+            let fallbackTimeoutId: number | null = null;
+            let idleCallbackId: number | null = null;
+            let hasScheduledBootstrap = false;
+
+            const cancelDeferredBootstrap = () => {
+                if (fallbackTimeoutId !== null) {
+                    window.clearTimeout(fallbackTimeoutId);
+                    fallbackTimeoutId = null;
+                }
+                if (idleCallbackId !== null && 'cancelIdleCallback' in window) {
+                    (window as typeof window & {
+                        cancelIdleCallback: (id: number) => void;
+                    }).cancelIdleCallback(idleCallbackId);
+                    idleCallbackId = null;
+                }
+            };
+
+            const scheduleBootstrapWhenIdle = () => {
+                if (cancelled || hasScheduledBootstrap) return;
+                hasScheduledBootstrap = true;
+
+                if ('requestIdleCallback' in window) {
+                    idleCallbackId = (window as typeof window & {
+                        requestIdleCallback: (cb: IdleRequestCallback, options?: IdleRequestOptions) => number;
+                    }).requestIdleCallback(() => {
+                        idleCallbackId = null;
+                        triggerBootstrap();
+                    }, { timeout: NON_CRITICAL_AUTH_BOOTSTRAP_IDLE_TIMEOUT_MS });
+                    return;
+                }
+
+                fallbackTimeoutId = window.setTimeout(() => {
+                    fallbackTimeoutId = null;
+                    triggerBootstrap();
+                }, NON_CRITICAL_AUTH_BOOTSTRAP_FALLBACK_DELAY_MS);
+            };
+
+            if (document.readyState === 'complete') {
+                scheduleBootstrapWhenIdle();
+            } else {
+                const handleLoad = () => {
+                    window.removeEventListener('load', handleLoad);
+                    scheduleBootstrapWhenIdle();
+                };
+
+                window.addEventListener('load', handleLoad, { once: true });
+                fallbackTimeoutId = window.setTimeout(() => {
+                    window.removeEventListener('load', handleLoad);
+                    scheduleBootstrapWhenIdle();
+                }, NON_CRITICAL_AUTH_BOOTSTRAP_IDLE_TIMEOUT_MS);
+
+                return () => {
+                    cancelled = true;
+                    window.removeEventListener('load', handleLoad);
+                    cancelDeferredBootstrap();
+                    if (!hasBootstrappedRef.current) {
+                        isBootstrappingRef.current = false;
+                    }
+                    unsubscribe();
+                };
+            }
+
+            return () => {
+                cancelled = true;
+                cancelDeferredBootstrap();
+                if (!hasBootstrappedRef.current) {
+                    isBootstrappingRef.current = false;
+                }
+                unsubscribe();
+            };
         }
         triggerBootstrap();
 

--- a/tests/unit/authContext.test.ts
+++ b/tests/unit/authContext.test.ts
@@ -3,6 +3,8 @@ import {
   isAuthBootstrapCriticalPath,
   resolveAuthContextValue,
   shouldAutoClearSimulatedLoginOnRealSession,
+  shouldDeferAuthBootstrap,
+  shouldEagerlyLoadAuthProfile,
   shouldEnableDevAdminBypass,
   shouldUseDevAdminBypassSession,
 } from '../../contexts/AuthContext';
@@ -24,6 +26,35 @@ describe('contexts/AuthContext auth bootstrap critical paths', () => {
   it('treats public profile routes as critical bootstrap paths', () => {
     expect(isAuthBootstrapCriticalPath('/u/traveler')).toBe(true);
     expect(isAuthBootstrapCriticalPath('/de/u/traveler')).toBe(true);
+  });
+});
+
+describe('contexts/AuthContext deferred bootstrap rules', () => {
+  it('defers non-critical marketing routes when no auth callback payload is present', () => {
+    expect(shouldDeferAuthBootstrap('/', false)).toBe(true);
+    expect(shouldDeferAuthBootstrap('/pricing', false)).toBe(true);
+  });
+
+  it('keeps bootstrap immediate for auth-critical routes and callbacks', () => {
+    expect(shouldDeferAuthBootstrap('/create-trip', false)).toBe(false);
+    expect(shouldDeferAuthBootstrap('/profile', false)).toBe(false);
+    expect(shouldDeferAuthBootstrap('/login', false)).toBe(false);
+    expect(shouldDeferAuthBootstrap('/', true)).toBe(false);
+  });
+});
+
+describe('contexts/AuthContext eager profile hydration rules', () => {
+  it('loads the signed-in profile immediately for routes that render account details', () => {
+    expect(shouldEagerlyLoadAuthProfile('/profile')).toBe(true);
+    expect(shouldEagerlyLoadAuthProfile('/checkout')).toBe(true);
+    expect(shouldEagerlyLoadAuthProfile('/create-trip')).toBe(true);
+    expect(shouldEagerlyLoadAuthProfile('/u/traveler')).toBe(true);
+  });
+
+  it('skips eager profile loading on non-critical marketing routes', () => {
+    expect(shouldEagerlyLoadAuthProfile('/')).toBe(false);
+    expect(shouldEagerlyLoadAuthProfile('/pricing')).toBe(false);
+    expect(shouldEagerlyLoadAuthProfile('/blog')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- defer auth bootstrap on non-critical marketing routes until idle instead of always starting it on first paint
- skip eager profile hydration on routes that do not render account details immediately
- document the measured follow-up finding: the remaining homepage bottleneck is still the large shared entry chunk, not eager profile hydration

## What changed
- added route-aware `shouldDeferAuthBootstrap(...)` and `shouldEagerlyLoadAuthProfile(...)` guards in `AuthProvider`
- kept auth bootstrap immediate for auth-critical routes (`/login`, `/profile`, `/create-trip`, `/trip`, `/admin`, public profiles) and OAuth callback payloads
- added unit coverage for the new routing rules

## Why
The previous homepage media pass removed the big raw-image transfer cost, but the next homepage Lighthouse runs still showed small auth/profile-related follow-up requests on marketing entry. This pass tightens that behavior so the provider only does urgent auth/profile work on routes that actually need it immediately.

## Measured outcome
Homepage Lighthouse against local production preview:

### Prior merged baseline
- desktop: 99, total byte weight 739 KiB
- mobile: 84, total byte weight 448 KiB

### This branch
- desktop: 100, total byte weight 740 KiB
- mobile: 85, total byte weight 448 KiB

## Key finding
This did not materially reduce homepage transfer weight. The mobile audit still shows the homepage dominated by the large shared `index-*.js` entry chunk, with auth/profile follow-up requests being secondary. That means the next real win should target bundle decomposition around the homepage entry graph rather than more auth-specific tuning.

## Validation
- `pnpm exec vitest run tests/unit/authContext.test.ts tests/browser/navigation/siteHeader.authHint.browser.test.ts`
- `pnpm build:netlify`
- `npx -y react-doctor@latest . --verbose --diff`
- local Lighthouse desktop/mobile against a Vite production preview

## Next step
The next PR should focus on the large shared entry chunk directly:
1. inspect what keeps the homepage coupled to `index-*.js`
2. isolate non-homepage marketing/header concerns that can move behind route or intent boundaries
3. remeasure after each bundle-boundary change and drop any refactor that does not improve `/` meaningfully
