### PR TITLE
Fix nav profile label and English locale handoff

### DIFF
--- a/components/navigation/AccountMenu.tsx
+++ b/components/navigation/AccountMenu.tsx
@@ -16,7 +16,7 @@ interface AccountMenuProps {
     showLabel?: boolean;
     fullWidth?: boolean;
     menuPlacement?: 'bottom-end' | 'right-end';
-    labelMode?: 'route' | 'identity';
+    labelMode?: 'route' | 'identity' | 'profile';
     showRecentTripsSection?: boolean;
     showCurrentPageSummary?: boolean;
     className?: string;
@@ -153,7 +153,11 @@ export const AccountMenu: React.FC<AccountMenuProps> = ({
         () => buildAccountTriggerName(profile, email, userId),
         [email, profile, userId]
     );
-    const triggerLabel = labelMode === 'identity' ? accountTriggerName : accountLabel;
+    const triggerLabel = labelMode === 'identity'
+        ? accountTriggerName
+        : labelMode === 'profile'
+            ? 'Profile'
+            : accountLabel;
     const shouldShowLabel = showLabel ?? !compact;
 
     useEffect(() => {

--- a/components/navigation/MobileMenu.tsx
+++ b/components/navigation/MobileMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { X, SpinnerGap as Loader2 } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
@@ -41,6 +41,7 @@ const isPlainLeftClick = (event: React.MouseEvent<HTMLAnchorElement>): boolean =
 );
 
 export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTripsClick, onMyTripsIntent }) => {
+    const [pendingLocale, setPendingLocale] = useState<AppLanguage | null>(null);
     const hasTrips = useHasSavedTrips();
     const { t, i18n } = useTranslation('common');
     const location = useLocation();
@@ -61,6 +62,19 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTri
         if (routeLocale) return routeLocale;
         return normalizeLocale(i18n.resolvedLanguage ?? i18n.language ?? DEFAULT_LOCALE);
     }, [i18n.language, i18n.resolvedLanguage, location.pathname]);
+    const selectedLocale = pendingLocale ?? activeLocale;
+
+    useEffect(() => {
+        if (!pendingLocale) return;
+        if (pendingLocale === activeLocale) {
+            setPendingLocale(null);
+            return;
+        }
+        const timeoutId = window.setTimeout(() => {
+            setPendingLocale(null);
+        }, 1500);
+        return () => window.clearTimeout(timeoutId);
+    }, [activeLocale, pendingLocale]);
 
     useEffect(() => {
         if (isOpen) {
@@ -131,10 +145,12 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTri
     const handleLocaleChange = (nextLocaleRaw: string) => {
         const nextLocale = normalizeLocale(nextLocaleRaw);
         if (nextLocale === activeLocale) {
+            setPendingLocale(null);
             onClose();
             return;
         }
 
+        setPendingLocale(nextLocale);
         onClose();
 
         if (!isToolRoute(location.pathname)) {
@@ -230,7 +246,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTri
                     <div className="border-b border-slate-100 px-4 py-3">
                         <LanguageSelect
                             ariaLabel={t('language.label')}
-                            value={activeLocale}
+                            value={selectedLocale}
                             onChange={handleLocaleChange}
                             triggerClassName="h-10 w-full rounded-xl border-slate-200 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 shadow-sm focus:border-accent-400 focus:ring-2 focus:ring-accent-200"
                             contentAlign="start"

--- a/components/navigation/SiteHeader.tsx
+++ b/components/navigation/SiteHeader.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useMemo, useState } from 'react';
+import React, { Suspense, lazy, useEffect, useMemo, useState } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { List, Folder, SpinnerGap as Loader2 } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
@@ -64,6 +64,7 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
     hideCreateTrip = false,
 }) => {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const [pendingLocale, setPendingLocale] = useState<AppLanguage | null>(null);
     const hasTrips = useHasSavedTrips();
     const location = useLocation();
     const navigate = useNavigate();
@@ -76,10 +77,28 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
         if (routeLocale) return routeLocale;
         return normalizeLocale(i18n.resolvedLanguage ?? i18n.language ?? DEFAULT_LOCALE);
     }, [i18n.language, i18n.resolvedLanguage, location.pathname]);
+    const selectedLocale = pendingLocale ?? activeLocale;
+
+    useEffect(() => {
+        if (!pendingLocale) return;
+        if (pendingLocale === activeLocale) {
+            setPendingLocale(null);
+            return;
+        }
+        const timeoutId = window.setTimeout(() => {
+            setPendingLocale(null);
+        }, 1500);
+        return () => window.clearTimeout(timeoutId);
+    }, [activeLocale, pendingLocale]);
 
     const handleLocaleChange = (nextLocaleRaw: string) => {
         const nextLocale = normalizeLocale(nextLocaleRaw);
-        if (nextLocale === activeLocale) return;
+        if (nextLocale === activeLocale) {
+            setPendingLocale(null);
+            return;
+        }
+
+        setPendingLocale(nextLocale);
 
         if (!isToolRoute(location.pathname)) {
             void preloadLocaleNamespaces(nextLocale, getNamespacesForMarketingPath(location.pathname));
@@ -125,7 +144,7 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
         getAnalyticsDebugAttributes(`navigation__${target}`);
 
     const prewarmCreateTripRoute = () => {
-        void warmRouteAssets(buildLocalizedCreateTripPath(activeLocale), 'manual');
+        void warmRouteAssets(buildLocalizedCreateTripPath(selectedLocale), 'manual');
     };
 
     const isGlass = variant === 'glass';
@@ -170,7 +189,7 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
                         <div className="relative hidden md:block">
                             <LanguageSelect
                                 ariaLabel={t('language.label')}
-                                value={activeLocale}
+                                value={selectedLocale}
                                 onChange={handleLocaleChange}
                                 triggerClassName="h-9 rounded-lg border-slate-200 bg-white py-2 pl-3 pr-3 text-sm font-semibold text-slate-700 shadow-sm transition-colors hover:border-slate-300 focus:border-accent-400 focus:ring-2 focus:ring-accent-200"
                             />
@@ -188,6 +207,7 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
                                     email={access?.email || null}
                                     userId={access?.userId || null}
                                     isAdmin={isAdmin}
+                                    labelMode="profile"
                                     className="hidden lg:block"
                                 />
                             </Suspense>

--- a/content/updates/2026-03-07-bootstrap-shell-handoff.md
+++ b/content/updates/2026-03-07-bootstrap-shell-handoff.md
@@ -20,6 +20,8 @@ summary: "Kept the branded header visible through the React handoff and removed 
 - [x] [Fixed] ⚡ First clicks from the homepage now restore direct route warmup on user interaction, reducing the cold blink when jumping into create-trip and other pages.
 - [x] [Fixed] 🧭 Moving from create-trip into a marketing page now warms the deferred route loader too, reducing the first-time blink on pages you have not opened yet.
 - [x] [Fixed] 🪄 Switching between the homepage, create-trip, and other marketing pages now keeps the current page visible until the next route is ready, removing the short loading-shell blink on cold clicks.
+- [x] [Fixed] 👤 Signed-in navigation now keeps the account trigger short as “Profile” instead of swapping to usernames or email addresses.
+- [x] [Fixed] 🌐 Switching a translated page back to English now sticks on the first try instead of snapping back to the previous locale during the route handoff.
 - [ ] [Internal] 🧱 Replaced the marketing route fallback with the real React site header and matching brand icon so the bootstrap handoff no longer jumps between different header layouts.
 - [ ] [Internal] 🛠️ Fixed the bootstrap container markup so removing the pre-hydration shell no longer tears down the React root during the handoff.
 - [ ] [Internal] ⏱️ Moved the bootstrap handoff trigger to the actual resolved route content for marketing and create-trip flows, so the static shell stays in place until the real page is ready to replace it.
@@ -32,6 +34,7 @@ summary: "Kept the branded header visible through the React handoff and removed 
 - [ ] [Internal] 🧩 Added the deferred route-table chunk to marketing/profile prefetch targets so first-time navigations warm both the destination page and the lazy router module it depends on.
 - [ ] [Internal] 🪄 Re-enabled passive hover warmups on critical routes after the first real handoff and added direct CTA warmups for create-trip intent on the homepage and header.
 - [ ] [Internal] 🧱 Re-grouped marketing and create-trip routes under a shared suspense boundary in the main router while letting deferred routes opt out of their own inner fallback, so cross-route transitions no longer flash the bootstrap shell for short chunk waits.
+- [ ] [Internal] 🧭 Added a temporary pending-locale selection state to the desktop and mobile nav controls so the locale picker stays aligned with the user’s choice while the route locale catches up.
 - [ ] [Internal] 🎨 Tuned the brand badge padding and wordmark gap so the bootstrap shell and live header now match the published logo proportions more closely.
 - [ ] [Internal] 🛫 Swapped the scaled favicon for a dedicated white plane glyph inside an explicit indigo badge, so the live header and bootstrap shell now use the same cleaner logo geometry.
 - [ ] [Internal] 📱 Matched the bootstrap shell to the live mobile header by keeping the brand badge radius consistent at small sizes and showing the burger control until the desktop navigation breakpoint.

--- a/tests/browser/navigation/accountMenu.browser.test.ts
+++ b/tests/browser/navigation/accountMenu.browser.test.ts
@@ -158,6 +158,18 @@ describe('components/navigation/AccountMenu recent trips', () => {
     expect(screen.queryByText(/Current page:/i)).not.toBeInTheDocument();
   });
 
+  it('renders a stable Profile trigger label when requested', () => {
+    render(React.createElement(AccountMenu, {
+      email: 'traveler@example.com',
+      userId: 'user-1',
+      isAdmin: false,
+      labelMode: 'profile',
+    }));
+
+    expect(screen.getByRole('button', { name: /profile/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /traveler/i })).toBeNull();
+  });
+
   it('uses profile first/last-name initials for avatar when available', () => {
     mocks.profile = {
       firstName: 'Chris',

--- a/tests/browser/navigation/siteHeader.localeSwitch.browser.test.ts
+++ b/tests/browser/navigation/siteHeader.localeSwitch.browser.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  location: {
+    pathname: '/es/pricing',
+    search: '',
+    hash: '',
+  },
+  changeLanguage: vi.fn().mockResolvedValue(undefined),
+  openLoginModal: vi.fn(),
+  trackEvent: vi.fn(),
+  onClose: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  NavLink: ({
+    to,
+    children,
+    onClick,
+    className,
+    ...props
+  }: {
+    to: string;
+    children: React.ReactNode;
+    onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+    className?: string | ((state: { isActive: boolean }) => string);
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => React.createElement('a', {
+    href: to,
+    onClick,
+    className: typeof className === 'function' ? className({ isActive: false }) : className,
+    ...props,
+  }, children),
+  useLocation: () => mocks.location,
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock('../../../hooks/useHasSavedTrips', () => ({
+  useHasSavedTrips: () => false,
+}));
+
+vi.mock('../../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    isAuthenticated: false,
+    isAdmin: false,
+    access: null,
+    isLoading: false,
+    logout: vi.fn().mockResolvedValue(undefined),
+    profile: null,
+  }),
+}));
+
+vi.mock('../../../hooks/useLoginModal', () => ({
+  useLoginModal: () => ({
+    openLoginModal: mocks.openLoginModal,
+  }),
+}));
+
+vi.mock('../../../hooks/useFocusTrap', () => ({
+  useFocusTrap: () => undefined,
+}));
+
+vi.mock('../../../services/analyticsService', () => ({
+  trackEvent: mocks.trackEvent,
+  getAnalyticsDebugAttributes: () => ({}),
+}));
+
+vi.mock('../../../components/navigation/AppBrand', () => ({
+  AppBrand: () => React.createElement('span', null, 'TravelFlow'),
+}));
+
+vi.mock('../../../components/navigation/LanguageSelect', () => ({
+  LanguageSelect: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (nextLocale: string) => void;
+  }) => React.createElement(
+    'div',
+    { 'data-testid': 'language-select', 'data-value': value },
+    React.createElement('span', null, value),
+    React.createElement('button', { type: 'button', onClick: () => onChange('en') }, 'Switch to English'),
+    React.createElement('button', { type: 'button', onClick: () => onChange('es') }, 'Switch to Spanish')
+  ),
+}));
+
+vi.mock('../../../components/navigation/AccountMenu', () => ({
+  AccountMenu: () => React.createElement('div', { 'data-testid': 'account-menu' }, 'Account'),
+}));
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => {
+        const dictionary: Record<string, string> = {
+          'nav.features': 'Features',
+          'nav.inspirations': 'Inspirations',
+          'nav.updates': 'News & Updates',
+          'nav.blog': 'Blog',
+          'nav.pricing': 'Pricing',
+          'nav.login': 'Login',
+          'nav.createTrip': 'Create Trip',
+          'nav.openMenu': 'Open menu',
+          'nav.myTrips': 'My Trips',
+          'language.label': 'Language',
+          'footer.imprint': 'Imprint',
+          'footer.privacy': 'Privacy',
+          'footer.terms': 'Terms',
+          'footer.cookies': 'Cookies',
+        };
+        return dictionary[key] ?? key;
+      },
+      i18n: {
+        language: 'es',
+        resolvedLanguage: 'es',
+        changeLanguage: mocks.changeLanguage,
+      },
+    }),
+  };
+});
+
+import { SiteHeader } from '../../../components/navigation/SiteHeader';
+import { MobileMenu } from '../../../components/navigation/MobileMenu';
+
+describe('navigation locale switch handoff', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mocks.location.pathname = '/es/pricing';
+    mocks.location.search = '';
+    mocks.location.hash = '';
+  });
+
+  it('keeps the header locale selection on English while the route handoff is still pending', async () => {
+    const user = userEvent.setup();
+    render(React.createElement(SiteHeader));
+
+    expect(screen.getByTestId('language-select')).toHaveAttribute('data-value', 'es');
+
+    await user.click(screen.getByRole('button', { name: 'Switch to English' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('language-select')).toHaveAttribute('data-value', 'en');
+    });
+    expect(mocks.navigate).toHaveBeenCalledWith('/pricing');
+    expect(mocks.changeLanguage).toHaveBeenCalledWith('en');
+  });
+
+  it('keeps the mobile locale selection on English while the route handoff is still pending', async () => {
+    const user = userEvent.setup();
+    render(React.createElement(MobileMenu, {
+      isOpen: true,
+      onClose: mocks.onClose,
+    }));
+
+    expect(screen.getByTestId('language-select')).toHaveAttribute('data-value', 'es');
+
+    await user.click(screen.getByRole('button', { name: 'Switch to English' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('language-select')).toHaveAttribute('data-value', 'en');
+    });
+    expect(mocks.onClose).toHaveBeenCalledTimes(1);
+    expect(mocks.navigate).toHaveBeenCalledWith('/pricing');
+    expect(mocks.changeLanguage).toHaveBeenCalledWith('en');
+  });
+});


### PR DESCRIPTION
## Summary
- keep the signed-in header trigger short and stable as `Profile`
- keep the selected locale pinned during route handoff so switching back to English works on the first try
- cover both behaviors with focused navigation regression tests and update the draft release note

## Root Cause
Two smaller navigation regressions were still separate from the blink fix:
- the signed-in trigger was still using identity-driven labels in the marketing header, which could expand to username or email
- locale switching was controlled by the current route locale first, so when switching from `/es/...` back to English the picker could snap back to the old locale before the unprefixed route finished navigating

## Changes
- add a `profile` trigger-label mode to `AccountMenu` and use it from `SiteHeader`
- add a temporary pending-locale selection state in `SiteHeader` and `MobileMenu`
- keep the draft release note updated in `content/updates/2026-03-07-bootstrap-shell-handoff.md`

## Testing
- `pnpm exec vitest run tests/browser/navigation/accountMenu.browser.test.ts tests/browser/navigation/siteHeader.localeSwitch.browser.test.ts tests/browser/navigation/siteHeader.authHint.browser.test.ts tests/browser/navigation/mobileMenu.browser.test.ts`
- `pnpm test:core`
- `pnpm dlx react-doctor@latest . --verbose --diff`
- `pnpm updates:validate`

## Checklist
- [x] Behavioral change includes regression coverage
- [x] Release note updated in `content/updates/2026-03-07-bootstrap-shell-handoff.md`
