### PR TITLE
Harden async trip generation with watchdog, worker health telemetry, and canary

### DIFF
--- a/components/admin/adminNavConfig.ts
+++ b/components/admin/adminNavConfig.ts
@@ -79,6 +79,13 @@ export const ADMIN_NAV_ITEMS: AdminNavItem[] = [
         icon: 'telemetry',
     },
     {
+        id: 'ai_worker_health',
+        label: 'Worker Health',
+        path: '/admin/ai-benchmark/worker-health',
+        section: 'tools',
+        icon: 'telemetry',
+    },
+    {
         id: 'og_tools',
         label: 'OG Tools',
         path: '/admin/og-tools',

--- a/content/updates/2026-03-10-async-worker-watchdog-worker-health.md
+++ b/content/updates/2026-03-10-async-worker-watchdog-worker-health.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-03-10-async-worker-watchdog-worker-health
+version: v0.0.0
+title: "Async trip generation now watches for stalled queues and self-recovers faster"
+date: 2026-03-10
+published_at: 2026-03-10T15:30:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Async trip generation now records worker heartbeats, auto-rekicks stale queued jobs, and runs a safe end-to-end canary so queue regressions are easier to catch before trips sit in limbo."
+---
+
+## Changes
+- [x] [Improved] 🛟 Queued trip generation now watches for stalled background work and auto-rekicks the worker when jobs have been sitting too long, so trips are less likely to stay stuck in limbo.
+- [ ] [Internal] 📈 Added durable async worker health rows for heartbeats, stale-queue incidents, and canary runs, plus a new admin worker-health dashboard for fast production triage.
+- [ ] [Internal] 🧪 Added a provider-free invalid-payload canary that continuously proves the cron-to-background-worker drain path without spending model tokens.

--- a/docs/open-issues/async-worker-watchdog-worker-health-and-canary.md
+++ b/docs/open-issues/async-worker-watchdog-worker-health-and-canary.md
@@ -1,0 +1,47 @@
+# Async Worker Watchdog, Worker Health, and Canary Hardening
+
+## Status
+Open issue: [#264](https://github.com/chrizzzly87/travelflow/issues/264)
+
+## Objective
+Detect, surface, and automatically mitigate async worker stalls before queued trip-generation jobs pile up in production.
+
+## Why
+The March 10, 2026 production incident showed two separate gaps:
+1. Queue drain regressions can leave jobs stuck in `queued` without a durable worker-health surface.
+2. Operators had to inspect raw queue rows and manually re-run worker logic to prove whether cron and background dispatch were still healthy.
+
+## Scope
+### 1) Durable worker health rows
+- Add `async_worker_health_checks` for:
+  - cron heartbeats
+  - stale-queue watchdog incidents
+  - end-to-end canary runs
+
+### 2) Scheduled watchdog
+- Inspect `trip_generation_jobs` for stale queued work:
+  - `state = 'queued'`
+  - `run_after <= now()`
+  - `updated_at` older than 5 minutes
+- Record counts and oldest queued age.
+- Reuse the existing worker dispatch path as the bounded self-heal action.
+
+### 3) Scheduled canary
+- Create a disposable invalid-payload job that should deterministically fail with `ASYNC_WORKER_PAYLOAD_INVALID`.
+- Run it through the real cron-to-background-worker drain path.
+- Record latency and pass/fail status.
+
+### 4) Admin surface
+- Add `/admin/ai-benchmark/worker-health`.
+- Show current status, latest heartbeat, stale queued count, latest self-heal, latest canary, and recent health rows.
+
+## Acceptance Criteria
+1. Stale queued jobs older than 5 minutes are visible in admin.
+2. Cron heartbeat health is visible within one refresh cycle.
+3. Canary success proves end-to-end worker drain at least every 15 minutes.
+4. Regressions create durable `warning` or `failed` worker-health rows.
+
+## Implementation Notes
+- Use one dedicated internal admin edge endpoint for worker-health reads.
+- Keep canary traffic provider-free by relying on the existing invalid-payload failure path.
+- Clean up successful canary artifacts so user trip tables do not accumulate synthetic rows.

--- a/docs/supabase.sql
+++ b/docs/supabase.sql
@@ -245,6 +245,23 @@ create table if not exists public.ai_generation_events (
   created_at timestamptz not null default now()
 );
 
+create table if not exists public.async_worker_health_checks (
+  id uuid primary key default gen_random_uuid(),
+  check_type text not null check (check_type in ('heartbeat', 'watchdog', 'canary')),
+  status text not null check (status in ('ok', 'warning', 'failed')),
+  started_at timestamptz not null default now(),
+  finished_at timestamptz,
+  stale_queued_count integer not null default 0,
+  oldest_queued_age_ms integer,
+  dispatch_attempted boolean not null default false,
+  dispatch_http_status integer,
+  canary_latency_ms integer,
+  failure_code text,
+  failure_message text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
 -- Forward-compatible schema upgrades
 alter table public.trips add column if not exists sharing_enabled boolean not null default true;
 alter table public.trips add column if not exists status text not null default 'active';
@@ -515,6 +532,9 @@ create index if not exists ai_generation_events_created_idx on public.ai_generat
 create index if not exists ai_generation_events_source_created_idx on public.ai_generation_events(source, created_at desc);
 create index if not exists ai_generation_events_provider_created_idx on public.ai_generation_events(provider, created_at desc);
 create index if not exists ai_generation_events_status_created_idx on public.ai_generation_events(status, created_at desc);
+create index if not exists async_worker_health_checks_started_idx on public.async_worker_health_checks(started_at desc);
+create index if not exists async_worker_health_checks_type_started_idx on public.async_worker_health_checks(check_type, started_at desc);
+create index if not exists async_worker_health_checks_status_started_idx on public.async_worker_health_checks(status, started_at desc);
 create unique index if not exists subscriptions_provider_subscription_uidx
   on public.subscriptions(provider_subscription_id)
   where provider_subscription_id is not null;
@@ -839,6 +859,7 @@ alter table public.ai_benchmark_sessions enable row level security;
 alter table public.ai_benchmark_runs enable row level security;
 alter table public.ai_benchmark_preferences enable row level security;
 alter table public.ai_generation_events enable row level security;
+alter table public.async_worker_health_checks enable row level security;
 
 -- Trips policies
 drop policy if exists "Trips are readable by owner or collaborators" on public.trips;

--- a/netlify.toml
+++ b/netlify.toml
@@ -92,6 +92,10 @@ exit 1
   function = "ai-generate-worker"
 
 [[edge_functions]]
+  path = "/api/internal/admin/ai-worker-health"
+  function = "admin-ai-worker-health"
+
+[[edge_functions]]
   path = "/api/internal/admin/iam"
   function = "admin-iam"
 

--- a/netlify/edge-functions/admin-ai-worker-health.ts
+++ b/netlify/edge-functions/admin-ai-worker-health.ts
@@ -1,0 +1,163 @@
+import {
+  buildAsyncWorkerHealthSummary,
+  getAsyncWorkerHealthConfig,
+  listRecentAsyncWorkerHealthChecks,
+} from "../edge-lib/async-worker-health.ts";
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "no-store",
+};
+
+const AUTH_HEADER = "authorization";
+
+const readEnv = (name: string): string => {
+  try {
+    return (globalThis as { Deno?: { env?: { get: (key: string) => string | undefined } } }).Deno?.env?.get(name) || "";
+  } catch {
+    return "";
+  }
+};
+
+const json = (status: number, payload: unknown): Response =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: JSON_HEADERS,
+  });
+
+const safeJsonParse = async (response: Response): Promise<unknown> => {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+};
+
+const extractServiceError = (payload: unknown, fallback: string): string => {
+  if (payload && typeof payload === "object") {
+    const typed = payload as Record<string, unknown>;
+    if (typeof typed.message === "string" && typed.message.trim()) return typed.message.trim();
+    if (typeof typed.error === "string" && typed.error.trim()) return typed.error.trim();
+  }
+  return fallback;
+};
+
+const getAuthToken = (request: Request): string | null => {
+  const raw = request.headers.get(AUTH_HEADER) || "";
+  const match = raw.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  const token = match[1].trim();
+  return token || null;
+};
+
+const getSupabaseConfig = () => {
+  const url = readEnv("VITE_SUPABASE_URL").replace(/\/+$/, "");
+  const anonKey = readEnv("VITE_SUPABASE_ANON_KEY");
+  if (!url || !anonKey) return null;
+  return { url, anonKey };
+};
+
+const buildAnonHeaders = (authToken: string, anonKey: string) => ({
+  "Content-Type": "application/json",
+  apikey: anonKey,
+  Authorization: `Bearer ${authToken}`,
+});
+
+const supabaseFetch = async (
+  config: { url: string; anonKey: string },
+  authToken: string,
+  path: string,
+  init: RequestInit,
+): Promise<Response> => {
+  return fetch(`${config.url}${path}`, {
+    ...init,
+    headers: {
+      ...buildAnonHeaders(authToken, config.anonKey),
+      ...(init.headers || {}),
+    },
+  });
+};
+
+const authorizeAdminRequest = async (
+  config: { url: string; anonKey: string },
+  authToken: string,
+): Promise<Response | null> => {
+  const response = await supabaseFetch(config, authToken, "/rest/v1/rpc/get_current_user_access", {
+    method: "POST",
+    headers: {
+      Prefer: "params=single-object",
+    },
+    body: "{}",
+  });
+
+  if (!response.ok) {
+    const payload = await safeJsonParse(response);
+    return json(403, {
+      ok: false,
+      error: extractServiceError(payload, "Admin role verification failed."),
+      code: "ADMIN_ACCESS_CHECK_FAILED",
+    });
+  }
+
+  const payload = await safeJsonParse(response);
+  const accessRow = Array.isArray(payload) ? payload[0] : payload;
+  if (!accessRow || typeof accessRow !== "object" || (accessRow as Record<string, unknown>).system_role !== "admin") {
+    return json(403, {
+      ok: false,
+      error: "Admin access is required.",
+      code: "ADMIN_ACCESS_REQUIRED",
+    });
+  }
+
+  return null;
+};
+
+export default async (request: Request) => {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: JSON_HEADERS });
+  }
+
+  if (request.method !== "GET") {
+    return json(405, {
+      ok: false,
+      error: "Method not allowed. Use GET.",
+    });
+  }
+
+  const authToken = getAuthToken(request);
+  if (!authToken) {
+    return json(401, {
+      ok: false,
+      error: "Missing Authorization bearer token.",
+      code: "AUTH_TOKEN_MISSING",
+    });
+  }
+
+  const supabaseConfig = getSupabaseConfig();
+  const healthConfig = getAsyncWorkerHealthConfig();
+  if (!supabaseConfig || !healthConfig) {
+    return json(503, {
+      ok: false,
+      error: "Worker health config is missing.",
+      code: "WORKER_HEALTH_CONFIG_MISSING",
+    });
+  }
+
+  const authError = await authorizeAdminRequest(supabaseConfig, authToken);
+  if (authError) return authError;
+
+  const url = new URL(request.url);
+  const limitRaw = Number(url.searchParams.get("limit"));
+  const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(50, Math.round(limitRaw))) : 25;
+
+  const checks = await listRecentAsyncWorkerHealthChecks(healthConfig, limit);
+  const summary = buildAsyncWorkerHealthSummary(checks);
+
+  return json(200, {
+    ok: true,
+    summary,
+    checks,
+  });
+};

--- a/netlify/edge-lib/async-worker-health.ts
+++ b/netlify/edge-lib/async-worker-health.ts
@@ -1,0 +1,590 @@
+import { readEnv } from "./ai-provider-runtime.ts";
+
+export type AsyncWorkerHealthCheckType = "heartbeat" | "watchdog" | "canary";
+export type AsyncWorkerHealthStatus = "ok" | "warning" | "failed";
+
+export interface AsyncWorkerHealthCheckRecord {
+  id: string;
+  checkType: AsyncWorkerHealthCheckType;
+  status: AsyncWorkerHealthStatus;
+  startedAt: string;
+  finishedAt: string | null;
+  staleQueuedCount: number;
+  oldestQueuedAgeMs: number | null;
+  dispatchAttempted: boolean;
+  dispatchHttpStatus: number | null;
+  canaryLatencyMs: number | null;
+  failureCode: string | null;
+  failureMessage: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface AsyncWorkerHealthSummary {
+  overallStatus: AsyncWorkerHealthStatus;
+  statusReason: string;
+  heartbeatFresh: boolean;
+  canaryFresh: boolean;
+  canaryDue: boolean;
+  staleQueuedCount: number;
+  oldestQueuedAgeMs: number | null;
+  lastHeartbeatAt: string | null;
+  lastHeartbeatStatus: AsyncWorkerHealthStatus | null;
+  lastSelfHealAt: string | null;
+  lastSelfHealStatus: AsyncWorkerHealthStatus | null;
+  lastCanaryAt: string | null;
+  lastCanaryStatus: AsyncWorkerHealthStatus | null;
+  lastCanaryLatencyMs: number | null;
+}
+
+export interface AsyncWorkerQueueSnapshot {
+  staleQueuedCount: number;
+  oldestQueuedAgeMs: number | null;
+  oldestQueuedUpdatedAt: string | null;
+  errorMessage?: string | null;
+}
+
+export interface AsyncWorkerCanaryContext {
+  tripId: string;
+  attemptId: string;
+  jobId: string;
+  ownerId: string;
+  requestId: string;
+  startedAt: string;
+}
+
+export interface AsyncWorkerCanaryEvaluation {
+  status: AsyncWorkerHealthStatus;
+  failureCode: string | null;
+  failureMessage: string | null;
+  latencyMs: number | null;
+  jobState: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+}
+
+export const ASYNC_WORKER_STALE_QUEUE_MS = 5 * 60 * 1000;
+export const ASYNC_WORKER_HEARTBEAT_STALE_MS = 3 * 60 * 1000;
+export const ASYNC_WORKER_CANARY_INTERVAL_MS = 15 * 60 * 1000;
+export const ASYNC_WORKER_CANARY_STALE_MS = 30 * 60 * 1000;
+export const ASYNC_WORKER_CANARY_CLEANUP_MS = 60 * 60 * 1000;
+export const ASYNC_WORKER_CANARY_SOURCE = "async_worker_canary";
+export const ASYNC_WORKER_CANARY_SOURCE_KIND = "internal_canary";
+const MAX_HEALTH_FAILURE_MESSAGE_LENGTH = 800;
+
+const asString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const asNumber = (value: unknown): number | null => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const asBoolean = (value: unknown): boolean => value === true;
+
+const asObject = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+};
+
+const asIsoMs = (value: string | null | undefined): number | null => {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const clipText = (value: string | null | undefined, max = MAX_HEALTH_FAILURE_MESSAGE_LENGTH): string | null => {
+  const normalized = asString(value);
+  if (!normalized) return null;
+  return normalized.length > max ? normalized.slice(0, max) : normalized;
+};
+
+const parseContentRangeCount = (value: string | null): number | null => {
+  if (!value) return null;
+  const match = value.match(/\/(\d+|\*)$/);
+  if (!match || match[1] === "*") return null;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const safeJsonParse = async (response: Response): Promise<unknown> => {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+};
+
+const buildServiceHeaders = (
+  serviceRoleKey: string,
+  extra?: Record<string, string>,
+): Record<string, string> => ({
+  "Content-Type": "application/json",
+  apikey: serviceRoleKey,
+  Authorization: `Bearer ${serviceRoleKey}`,
+  ...extra,
+});
+
+export const getAsyncWorkerHealthConfig = (): { url: string; serviceRoleKey: string } | null => {
+  const url = readEnv("VITE_SUPABASE_URL").replace(/\/+$/, "");
+  const serviceRoleKey = readEnv("SUPABASE_SERVICE_ROLE_KEY");
+  if (!url || !serviceRoleKey) return null;
+  return { url, serviceRoleKey };
+};
+
+const serviceFetch = async (
+  config: { url: string; serviceRoleKey: string },
+  path: string,
+  init: RequestInit,
+): Promise<Response> => {
+  return fetch(`${config.url}${path}`, {
+    ...init,
+    headers: {
+      ...buildServiceHeaders(config.serviceRoleKey),
+      ...(init.headers || {}),
+    },
+  });
+};
+
+const parseHealthCheckRecord = (value: unknown): AsyncWorkerHealthCheckRecord | null => {
+  const row = asObject(value);
+  if (!row) return null;
+
+  const id = asString(row.id);
+  const checkType = asString(row.check_type);
+  const status = asString(row.status);
+  const startedAt = asString(row.started_at);
+  const createdAt = asString(row.created_at);
+  if (!id || !startedAt || !createdAt) return null;
+  if (checkType !== "heartbeat" && checkType !== "watchdog" && checkType !== "canary") return null;
+  if (status !== "ok" && status !== "warning" && status !== "failed") return null;
+
+  return {
+    id,
+    checkType,
+    status,
+    startedAt,
+    finishedAt: asString(row.finished_at),
+    staleQueuedCount: Math.max(0, Math.round(asNumber(row.stale_queued_count) || 0)),
+    oldestQueuedAgeMs: asNumber(row.oldest_queued_age_ms),
+    dispatchAttempted: asBoolean(row.dispatch_attempted),
+    dispatchHttpStatus: asNumber(row.dispatch_http_status),
+    canaryLatencyMs: asNumber(row.canary_latency_ms),
+    failureCode: asString(row.failure_code),
+    failureMessage: asString(row.failure_message),
+    metadata: asObject(row.metadata),
+    createdAt,
+  };
+};
+
+export const shouldRunAsyncWorkerCanary = (
+  checks: AsyncWorkerHealthCheckRecord[],
+  nowMs = Date.now(),
+  intervalMs = ASYNC_WORKER_CANARY_INTERVAL_MS,
+): boolean => {
+  const lastCanary = checks.find((row) => row.checkType === "canary") || null;
+  const lastAttemptMs = asIsoMs(lastCanary?.finishedAt || lastCanary?.startedAt || null);
+  if (lastAttemptMs !== null && nowMs - lastAttemptMs < 5 * 60 * 1000) {
+    return false;
+  }
+
+  const lastSuccessfulCanary = checks.find((row) => row.checkType === "canary" && row.status === "ok") || null;
+  const lastSuccessMs = asIsoMs(lastSuccessfulCanary?.finishedAt || lastSuccessfulCanary?.startedAt || null);
+  if (lastSuccessMs === null) return true;
+  return nowMs - lastSuccessMs >= intervalMs;
+};
+
+export const buildAsyncWorkerHealthSummary = (
+  checks: AsyncWorkerHealthCheckRecord[],
+  nowMs = Date.now(),
+): AsyncWorkerHealthSummary => {
+  const lastHeartbeat = checks.find((row) => row.checkType === "heartbeat") || null;
+  const lastCanary = checks.find((row) => row.checkType === "canary") || null;
+  const lastSelfHeal = checks.find((row) => asBoolean(asObject(row.metadata)?.selfHealAttempted)) || null;
+
+  const lastHeartbeatMs = asIsoMs(lastHeartbeat?.startedAt || null);
+  const lastCanaryMs = asIsoMs(lastCanary?.finishedAt || lastCanary?.startedAt || null);
+  const heartbeatFresh = lastHeartbeatMs !== null && nowMs - lastHeartbeatMs <= ASYNC_WORKER_HEARTBEAT_STALE_MS;
+  const canaryFresh = lastCanaryMs !== null && nowMs - lastCanaryMs <= ASYNC_WORKER_CANARY_STALE_MS;
+
+  let overallStatus: AsyncWorkerHealthStatus = "ok";
+  let statusReason = "Worker heartbeat and canary are healthy.";
+
+  if (!lastHeartbeat || !heartbeatFresh) {
+    overallStatus = "failed";
+    statusReason = "Cron heartbeat is stale or missing.";
+  } else if (lastHeartbeat.status === "failed") {
+    overallStatus = "failed";
+    statusReason = lastHeartbeat.failureMessage || "Latest heartbeat failed.";
+  } else if (lastCanary && lastCanary.status === "failed" && canaryFresh) {
+    overallStatus = "failed";
+    statusReason = lastCanary.failureMessage || "Latest worker canary failed.";
+  } else if (!lastCanary || !canaryFresh) {
+    overallStatus = "warning";
+    statusReason = "Worker canary has not completed recently.";
+  } else if (lastHeartbeat.status === "warning" || lastHeartbeat.staleQueuedCount > 0) {
+    overallStatus = "warning";
+    statusReason = lastHeartbeat.failureMessage || "Stale queued jobs were detected and re-kicked.";
+  }
+
+  return {
+    overallStatus,
+    statusReason,
+    heartbeatFresh,
+    canaryFresh,
+    canaryDue: shouldRunAsyncWorkerCanary(checks, nowMs),
+    staleQueuedCount: lastHeartbeat?.staleQueuedCount || 0,
+    oldestQueuedAgeMs: lastHeartbeat?.oldestQueuedAgeMs ?? null,
+    lastHeartbeatAt: lastHeartbeat?.startedAt || null,
+    lastHeartbeatStatus: lastHeartbeat?.status || null,
+    lastSelfHealAt: lastSelfHeal?.finishedAt || lastSelfHeal?.startedAt || null,
+    lastSelfHealStatus: lastSelfHeal?.status || null,
+    lastCanaryAt: lastCanary?.finishedAt || lastCanary?.startedAt || null,
+    lastCanaryStatus: lastCanary?.status || null,
+    lastCanaryLatencyMs: lastCanary?.canaryLatencyMs ?? null,
+  };
+};
+
+export const insertAsyncWorkerHealthCheck = async (
+  config: { url: string; serviceRoleKey: string },
+  input: {
+    checkType: AsyncWorkerHealthCheckType;
+    status: AsyncWorkerHealthStatus;
+    startedAt: string;
+    finishedAt?: string | null;
+    staleQueuedCount?: number;
+    oldestQueuedAgeMs?: number | null;
+    dispatchAttempted?: boolean;
+    dispatchHttpStatus?: number | null;
+    canaryLatencyMs?: number | null;
+    failureCode?: string | null;
+    failureMessage?: string | null;
+    metadata?: Record<string, unknown> | null;
+  },
+): Promise<boolean> => {
+  const response = await serviceFetch(config, "/rest/v1/async_worker_health_checks", {
+    method: "POST",
+    headers: {
+      Prefer: "return=minimal",
+    },
+    body: JSON.stringify({
+      check_type: input.checkType,
+      status: input.status,
+      started_at: input.startedAt,
+      finished_at: input.finishedAt || null,
+      stale_queued_count: Math.max(0, Math.round(Number(input.staleQueuedCount || 0))),
+      oldest_queued_age_ms: input.oldestQueuedAgeMs ?? null,
+      dispatch_attempted: input.dispatchAttempted === true,
+      dispatch_http_status: input.dispatchHttpStatus ?? null,
+      canary_latency_ms: input.canaryLatencyMs ?? null,
+      failure_code: clipText(input.failureCode, 120),
+      failure_message: clipText(input.failureMessage),
+      metadata: input.metadata || {},
+    }),
+  });
+  return response.ok;
+};
+
+export const listRecentAsyncWorkerHealthChecks = async (
+  config: { url: string; serviceRoleKey: string },
+  limit = 25,
+): Promise<AsyncWorkerHealthCheckRecord[]> => {
+  const safeLimit = Math.max(1, Math.min(100, Math.round(limit)));
+  const response = await serviceFetch(
+    config,
+    `/rest/v1/async_worker_health_checks?select=id,check_type,status,started_at,finished_at,stale_queued_count,oldest_queued_age_ms,dispatch_attempted,dispatch_http_status,canary_latency_ms,failure_code,failure_message,metadata,created_at&order=started_at.desc&limit=${safeLimit}`,
+    {
+      method: "GET",
+    },
+  );
+  if (!response.ok) return [];
+  const payload = await safeJsonParse(response);
+  const rows = Array.isArray(payload) ? payload : [];
+  return rows
+    .map((row) => parseHealthCheckRecord(row))
+    .filter((row): row is AsyncWorkerHealthCheckRecord => Boolean(row));
+};
+
+export const readStaleQueuedJobSnapshot = async (
+  config: { url: string; serviceRoleKey: string },
+  options?: { now?: Date; staleThresholdMs?: number },
+): Promise<AsyncWorkerQueueSnapshot> => {
+  const now = options?.now || new Date();
+  const staleThresholdMs = Math.max(60_000, options?.staleThresholdMs || ASYNC_WORKER_STALE_QUEUE_MS);
+  const nowIso = now.toISOString();
+  const cutoffIso = new Date(now.getTime() - staleThresholdMs).toISOString();
+  const response = await serviceFetch(
+    config,
+    `/rest/v1/trip_generation_jobs?state=eq.queued&run_after=lte.${encodeURIComponent(nowIso)}&updated_at=lte.${encodeURIComponent(cutoffIso)}&select=id,updated_at&order=updated_at.asc&limit=1`,
+    {
+      method: "GET",
+      headers: {
+        Prefer: "count=exact",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const payload = await safeJsonParse(response);
+    const errorMessage = asString(asObject(payload)?.message) || `Stale queue snapshot failed (${response.status}).`;
+    return {
+      staleQueuedCount: 0,
+      oldestQueuedAgeMs: null,
+      oldestQueuedUpdatedAt: null,
+      errorMessage,
+    };
+  }
+
+  const payload = await safeJsonParse(response);
+  const rows = Array.isArray(payload) ? payload : [];
+  const firstRow = asObject(rows[0]);
+  const oldestQueuedUpdatedAt = asString(firstRow?.updated_at);
+  const oldestQueuedMs = asIsoMs(oldestQueuedUpdatedAt);
+  return {
+    staleQueuedCount: parseContentRangeCount(response.headers.get("content-range")) || rows.length,
+    oldestQueuedAgeMs: oldestQueuedMs === null ? null : Math.max(0, now.getTime() - oldestQueuedMs),
+    oldestQueuedUpdatedAt,
+    errorMessage: null,
+  };
+};
+
+const resolveCanaryOwnerId = async (
+  config: { url: string; serviceRoleKey: string },
+): Promise<string | null> => {
+  const explicit = asString(readEnv("AI_GENERATION_ASYNC_CANARY_OWNER_ID"));
+  if (explicit) return explicit;
+
+  const response = await serviceFetch(
+    config,
+    "/rest/v1/admin_user_roles?select=user_id&order=assigned_at.asc&limit=1",
+    {
+      method: "GET",
+    },
+  );
+  if (!response.ok) return null;
+  const payload = await safeJsonParse(response);
+  const row = Array.isArray(payload) ? asObject(payload[0]) : null;
+  return asString(row?.user_id);
+};
+
+export const cleanupStaleAsyncWorkerCanaries = async (
+  config: { url: string; serviceRoleKey: string },
+  now = new Date(),
+): Promise<boolean> => {
+  const cutoffIso = new Date(now.getTime() - ASYNC_WORKER_CANARY_CLEANUP_MS).toISOString();
+  const response = await serviceFetch(
+    config,
+    `/rest/v1/trips?source_kind=eq.${encodeURIComponent(ASYNC_WORKER_CANARY_SOURCE_KIND)}&created_at=lte.${encodeURIComponent(cutoffIso)}`,
+    {
+      method: "DELETE",
+      headers: {
+        Prefer: "return=minimal",
+      },
+    },
+  );
+  return response.ok;
+};
+
+export const createAsyncWorkerCanary = async (
+  config: { url: string; serviceRoleKey: string },
+  now = new Date(),
+): Promise<{ canary: AsyncWorkerCanaryContext | null; errorCode?: string; errorMessage?: string }> => {
+  const ownerId = await resolveCanaryOwnerId(config);
+  if (!ownerId) {
+    return {
+      canary: null,
+      errorCode: "WORKER_CANARY_OWNER_MISSING",
+      errorMessage: "No admin owner is available for async worker canary rows.",
+    };
+  }
+
+  const uuid = crypto.randomUUID();
+  const tripId = `internal-canary-${uuid}`;
+  const attemptId = crypto.randomUUID();
+  const jobId = crypto.randomUUID();
+  const requestId = `async-worker-canary-${uuid}`;
+  const startedAt = now.toISOString();
+
+  const tripResponse = await serviceFetch(config, "/rest/v1/trips", {
+    method: "POST",
+    headers: {
+      Prefer: "return=minimal",
+    },
+    body: JSON.stringify({
+      id: tripId,
+      owner_id: ownerId,
+      title: "Async Worker Canary",
+      status: "archived",
+      archived_at: startedAt,
+      source_kind: ASYNC_WORKER_CANARY_SOURCE_KIND,
+      data: {
+        canary: true,
+        createdAt: startedAt,
+      },
+      view_settings: {},
+    }),
+  });
+  if (!tripResponse.ok) {
+    return {
+      canary: null,
+      errorCode: "WORKER_CANARY_TRIP_INSERT_FAILED",
+      errorMessage: `Failed to insert canary trip (${tripResponse.status}).`,
+    };
+  }
+
+  const attemptResponse = await serviceFetch(config, "/rest/v1/trip_generation_attempts", {
+    method: "POST",
+    headers: {
+      Prefer: "return=minimal",
+    },
+    body: JSON.stringify({
+      id: attemptId,
+      trip_id: tripId,
+      owner_id: ownerId,
+      flow: "classic",
+      source: ASYNC_WORKER_CANARY_SOURCE,
+      state: "queued",
+      request_id: requestId,
+      started_at: startedAt,
+      metadata: {
+        canary: true,
+      },
+    }),
+  });
+  if (!attemptResponse.ok) {
+    await deleteAsyncWorkerCanaryTrip(config, tripId);
+    return {
+      canary: null,
+      errorCode: "WORKER_CANARY_ATTEMPT_INSERT_FAILED",
+      errorMessage: `Failed to insert canary attempt (${attemptResponse.status}).`,
+    };
+  }
+
+  const jobResponse = await serviceFetch(config, "/rest/v1/trip_generation_jobs", {
+    method: "POST",
+    headers: {
+      Prefer: "return=minimal",
+    },
+    body: JSON.stringify({
+      id: jobId,
+      trip_id: tripId,
+      owner_id: ownerId,
+      attempt_id: attemptId,
+      state: "queued",
+      priority: 0,
+      payload: {
+        canary: true,
+      },
+      run_after: startedAt,
+      max_retries: 0,
+    }),
+  });
+  if (!jobResponse.ok) {
+    await deleteAsyncWorkerCanaryTrip(config, tripId);
+    return {
+      canary: null,
+      errorCode: "WORKER_CANARY_JOB_INSERT_FAILED",
+      errorMessage: `Failed to insert canary job (${jobResponse.status}).`,
+    };
+  }
+
+  return {
+    canary: {
+      tripId,
+      attemptId,
+      jobId,
+      ownerId,
+      requestId,
+      startedAt,
+    },
+  };
+};
+
+export const readAsyncWorkerCanaryEvaluation = async (
+  config: { url: string; serviceRoleKey: string },
+  canary: AsyncWorkerCanaryContext,
+  now = new Date(),
+): Promise<AsyncWorkerCanaryEvaluation> => {
+  const response = await serviceFetch(
+    config,
+    `/rest/v1/trip_generation_jobs?id=eq.${encodeURIComponent(canary.jobId)}&select=id,state,last_error_code,last_error_message,leased_by,updated_at,finished_at&limit=1`,
+    {
+      method: "GET",
+    },
+  );
+
+  if (!response.ok) {
+    return {
+      status: "failed",
+      failureCode: "WORKER_CANARY_LOOKUP_FAILED",
+      failureMessage: `Canary lookup failed (${response.status}).`,
+      latencyMs: null,
+      jobState: null,
+      errorCode: null,
+      errorMessage: null,
+    };
+  }
+
+  const payload = await safeJsonParse(response);
+  const row = Array.isArray(payload) ? asObject(payload[0]) : null;
+  const jobState = asString(row?.state);
+  const errorCode = asString(row?.last_error_code);
+  const errorMessage = asString(row?.last_error_message);
+  const latencyMs = Math.max(0, now.getTime() - (asIsoMs(canary.startedAt) || now.getTime()));
+
+  if (jobState === "failed" && errorCode === "ASYNC_WORKER_PAYLOAD_INVALID") {
+    return {
+      status: "ok",
+      failureCode: null,
+      failureMessage: null,
+      latencyMs,
+      jobState,
+      errorCode,
+      errorMessage,
+    };
+  }
+
+  if (jobState === "queued" || jobState === "leased") {
+    return {
+      status: "failed",
+      failureCode: "WORKER_CANARY_NOT_TERMINAL",
+      failureMessage: `Canary job remained ${jobState} after cron dispatch.`,
+      latencyMs,
+      jobState,
+      errorCode,
+      errorMessage,
+    };
+  }
+
+  return {
+    status: "failed",
+    failureCode: "WORKER_CANARY_UNEXPECTED_RESULT",
+    failureMessage: `Canary resolved with unexpected state ${jobState || "unknown"}.`,
+    latencyMs,
+    jobState,
+    errorCode,
+    errorMessage,
+  };
+};
+
+export const deleteAsyncWorkerCanaryTrip = async (
+  config: { url: string; serviceRoleKey: string },
+  tripId: string,
+): Promise<boolean> => {
+  const response = await serviceFetch(
+    config,
+    `/rest/v1/trips?id=eq.${encodeURIComponent(tripId)}`,
+    {
+      method: "DELETE",
+      headers: {
+        Prefer: "return=minimal",
+      },
+    },
+  );
+  return response.ok;
+};

--- a/netlify/functions/ai-generate-worker-cron.js
+++ b/netlify/functions/ai-generate-worker-cron.js
@@ -1,3 +1,15 @@
+import {
+  cleanupStaleAsyncWorkerCanaries,
+  createAsyncWorkerCanary,
+  deleteAsyncWorkerCanaryTrip,
+  getAsyncWorkerHealthConfig,
+  insertAsyncWorkerHealthCheck,
+  listRecentAsyncWorkerHealthChecks,
+  readAsyncWorkerCanaryEvaluation,
+  readStaleQueuedJobSnapshot,
+  shouldRunAsyncWorkerCanary,
+} from "../edge-lib/async-worker-health.ts";
+
 const JSON_HEADERS = {
   "Content-Type": "application/json; charset=utf-8",
   "Cache-Control": "no-store",
@@ -88,6 +100,71 @@ const invokeBackgroundWorker = async (params) => {
   }
 };
 
+const extractDispatchAccepted = (invoked) => {
+  if (invoked.statusCode < 200 || invoked.statusCode >= 300) return false;
+  if (!invoked.payload || typeof invoked.payload !== "object") return false;
+  if (invoked.payload.ok === false) return false;
+  if (invoked.payload.accepted === false) return false;
+  return true;
+};
+
+const summarizeDispatchFailure = (invoked) => {
+  if (!invoked?.payload || typeof invoked.payload !== "object") {
+    return {
+      code: "WORKER_CRON_DISPATCH_FAILED",
+      message: "Background worker dispatch failed.",
+    };
+  }
+  const payload = invoked.payload;
+  return {
+    code: typeof payload.code === "string" && payload.code.trim()
+      ? payload.code.trim()
+      : "WORKER_CRON_DISPATCH_FAILED",
+    message: typeof payload.error === "string" && payload.error.trim()
+      ? payload.error.trim()
+      : (typeof payload.details === "string" && payload.details.trim()
+        ? payload.details.trim()
+        : "Background worker dispatch failed."),
+  };
+};
+
+const buildHeartbeatOutcome = (params) => {
+  if (params.snapshotError) {
+    return {
+      status: "failed",
+      failureCode: "WORKER_STALE_QUEUE_LOOKUP_FAILED",
+      failureMessage: params.snapshotError,
+    };
+  }
+  if (!params.dispatchAccepted) {
+    const failure = summarizeDispatchFailure(params.invoked);
+    return {
+      status: "failed",
+      failureCode: failure.code,
+      failureMessage: failure.message,
+    };
+  }
+  if (params.preDispatchStaleCount > 0) {
+    return {
+      status: "warning",
+      failureCode: "WORKER_STALE_QUEUE_DETECTED",
+      failureMessage: `Detected ${params.preDispatchStaleCount} stale queued job${params.preDispatchStaleCount === 1 ? "" : "s"} and re-kicked the worker.`,
+    };
+  }
+  return {
+    status: "ok",
+    failureCode: null,
+    failureMessage: null,
+  };
+};
+
+const buildResponseStatus = (invoked, heartbeatStatus) => {
+  if (heartbeatStatus === "failed") {
+    return invoked.statusCode >= 400 ? invoked.statusCode : 500;
+  }
+  return invoked.statusCode;
+};
+
 export const config = {
   schedule: "*/1 * * * *",
 };
@@ -103,7 +180,8 @@ export const handler = async () => {
 
   const adminKey = (process.env.TF_ADMIN_API_KEY || "").trim();
   const baseUrl = resolveBaseUrl();
-  if (!adminKey || !baseUrl) {
+  const healthConfig = getAsyncWorkerHealthConfig();
+  if (!adminKey || !baseUrl || !healthConfig) {
     return jsonResponse(200, {
       ok: true,
       skipped: true,
@@ -111,14 +189,182 @@ export const handler = async () => {
     });
   }
 
-  const workerLimit = resolveInteger(process.env.AI_GENERATION_ASYNC_WORKER_BATCH || "1", 1, 1, 5);
+  const cronStartedAt = new Date();
+  const cronStartedAtIso = cronStartedAt.toISOString();
+  const workerLimitBase = resolveInteger(process.env.AI_GENERATION_ASYNC_WORKER_BATCH || "1", 1, 1, 5);
   const triggerTimeoutMs = resolveInteger(process.env.AI_GENERATION_ASYNC_TRIGGER_TIMEOUT_MS || "180000", 180_000, 5_000, 240_000);
+
+  const recentChecks = await listRecentAsyncWorkerHealthChecks(healthConfig, 25);
+  await cleanupStaleAsyncWorkerCanaries(healthConfig, cronStartedAt);
+
+  const preDispatchSnapshot = await readStaleQueuedJobSnapshot(healthConfig, { now: cronStartedAt });
+  const shouldScheduleCanary = !preDispatchSnapshot.errorMessage && shouldRunAsyncWorkerCanary(recentChecks, cronStartedAt.getTime());
+
+  let canaryContext = null;
+  let canaryCreateError = null;
+  if (shouldScheduleCanary) {
+    const canaryResult = await createAsyncWorkerCanary(healthConfig, cronStartedAt);
+    canaryContext = canaryResult.canary;
+    if (!canaryResult.canary) {
+      canaryCreateError = {
+        code: canaryResult.errorCode || "WORKER_CANARY_CREATE_FAILED",
+        message: canaryResult.errorMessage || "Failed to create async worker canary rows.",
+      };
+    }
+  }
+
+  const dispatchLimit = Math.min(workerLimitBase + (canaryContext ? 1 : 0), 5);
   const invoked = await invokeBackgroundWorker({
     baseUrl,
     adminKey,
-    limit: workerLimit,
+    limit: dispatchLimit,
     timeoutMs: triggerTimeoutMs,
   });
+  const dispatchAccepted = extractDispatchAccepted(invoked);
 
-  return jsonResponse(invoked.statusCode, invoked.payload);
+  const postDispatchSnapshot = preDispatchSnapshot.staleQueuedCount > 0
+    ? await readStaleQueuedJobSnapshot(healthConfig, { now: new Date() })
+    : preDispatchSnapshot;
+
+  const heartbeatOutcome = buildHeartbeatOutcome({
+    snapshotError: preDispatchSnapshot.errorMessage,
+    dispatchAccepted,
+    invoked,
+    preDispatchStaleCount: preDispatchSnapshot.staleQueuedCount,
+  });
+  const cronFinishedAtIso = new Date().toISOString();
+
+  const heartbeatMetadata = {
+    workerLimitBase,
+    dispatchLimit,
+    selfHealAttempted: preDispatchSnapshot.staleQueuedCount > 0,
+    selfHealSucceeded: preDispatchSnapshot.staleQueuedCount > 0 ? dispatchAccepted : null,
+    staleQueuedCountBefore: preDispatchSnapshot.staleQueuedCount,
+    staleQueuedCountAfter: postDispatchSnapshot.staleQueuedCount,
+    canaryScheduled: shouldScheduleCanary,
+    canaryCreated: Boolean(canaryContext),
+    canaryJobId: canaryContext?.jobId || null,
+  };
+
+  await insertAsyncWorkerHealthCheck(healthConfig, {
+    checkType: "heartbeat",
+    status: heartbeatOutcome.status,
+    startedAt: cronStartedAtIso,
+    finishedAt: cronFinishedAtIso,
+    staleQueuedCount: preDispatchSnapshot.staleQueuedCount,
+    oldestQueuedAgeMs: preDispatchSnapshot.oldestQueuedAgeMs,
+    dispatchAttempted: true,
+    dispatchHttpStatus: invoked.statusCode,
+    failureCode: heartbeatOutcome.failureCode,
+    failureMessage: heartbeatOutcome.failureMessage,
+    metadata: heartbeatMetadata,
+  });
+
+  if (preDispatchSnapshot.staleQueuedCount > 0 || preDispatchSnapshot.errorMessage) {
+    await insertAsyncWorkerHealthCheck(healthConfig, {
+      checkType: "watchdog",
+      status: heartbeatOutcome.status,
+      startedAt: cronStartedAtIso,
+      finishedAt: cronFinishedAtIso,
+      staleQueuedCount: preDispatchSnapshot.staleQueuedCount,
+      oldestQueuedAgeMs: preDispatchSnapshot.oldestQueuedAgeMs,
+      dispatchAttempted: true,
+      dispatchHttpStatus: invoked.statusCode,
+      failureCode: heartbeatOutcome.failureCode,
+      failureMessage: heartbeatOutcome.failureMessage,
+      metadata: {
+        ...heartbeatMetadata,
+        preDispatchSnapshotError: preDispatchSnapshot.errorMessage || null,
+        postDispatchSnapshotError: postDispatchSnapshot.errorMessage || null,
+      },
+    });
+  }
+
+  let canaryPayload = null;
+  if (shouldScheduleCanary) {
+    if (canaryCreateError) {
+      canaryPayload = {
+        status: "failed",
+        code: canaryCreateError.code,
+        error: canaryCreateError.message,
+        latencyMs: null,
+      };
+      await insertAsyncWorkerHealthCheck(healthConfig, {
+        checkType: "canary",
+        status: "failed",
+        startedAt: cronStartedAtIso,
+        finishedAt: cronFinishedAtIso,
+        failureCode: canaryCreateError.code,
+        failureMessage: canaryCreateError.message,
+        metadata: {
+          dispatchLimit,
+        },
+      });
+    } else if (canaryContext) {
+      if (!dispatchAccepted) {
+        const dispatchFailure = summarizeDispatchFailure(invoked);
+        canaryPayload = {
+          status: "failed",
+          code: "WORKER_CANARY_DISPATCH_FAILED",
+          error: dispatchFailure.message,
+          latencyMs: null,
+        };
+        await insertAsyncWorkerHealthCheck(healthConfig, {
+          checkType: "canary",
+          status: "failed",
+          startedAt: canaryContext.startedAt,
+          finishedAt: cronFinishedAtIso,
+          failureCode: "WORKER_CANARY_DISPATCH_FAILED",
+          failureMessage: dispatchFailure.message,
+          metadata: {
+            tripId: canaryContext.tripId,
+            attemptId: canaryContext.attemptId,
+            jobId: canaryContext.jobId,
+          },
+        });
+      } else {
+        const evaluation = await readAsyncWorkerCanaryEvaluation(healthConfig, canaryContext, new Date());
+        const cleanedUp = evaluation.status === "ok"
+          ? await deleteAsyncWorkerCanaryTrip(healthConfig, canaryContext.tripId)
+          : false;
+        canaryPayload = {
+          status: evaluation.status,
+          code: evaluation.failureCode || evaluation.errorCode || "ASYNC_WORKER_PAYLOAD_INVALID",
+          error: evaluation.failureMessage || evaluation.errorMessage || null,
+          latencyMs: evaluation.latencyMs,
+        };
+        await insertAsyncWorkerHealthCheck(healthConfig, {
+          checkType: "canary",
+          status: evaluation.status,
+          startedAt: canaryContext.startedAt,
+          finishedAt: cronFinishedAtIso,
+          canaryLatencyMs: evaluation.latencyMs,
+          failureCode: evaluation.failureCode,
+          failureMessage: evaluation.failureMessage,
+          metadata: {
+            tripId: canaryContext.tripId,
+            attemptId: canaryContext.attemptId,
+            jobId: canaryContext.jobId,
+            jobState: evaluation.jobState,
+            errorCode: evaluation.errorCode,
+            errorMessage: evaluation.errorMessage,
+            cleanedUp,
+          },
+        });
+      }
+    }
+  }
+
+  return jsonResponse(buildResponseStatus(invoked, heartbeatOutcome.status), {
+    ...invoked.payload,
+    health: {
+      status: heartbeatOutcome.status,
+      staleQueuedCount: preDispatchSnapshot.staleQueuedCount,
+      oldestQueuedAgeMs: preDispatchSnapshot.oldestQueuedAgeMs,
+      selfHealAttempted: preDispatchSnapshot.staleQueuedCount > 0,
+      selfHealSucceeded: preDispatchSnapshot.staleQueuedCount > 0 ? dispatchAccepted : null,
+      postDispatchStaleQueuedCount: postDispatchSnapshot.staleQueuedCount,
+      canary: canaryPayload,
+    },
+  });
 };

--- a/pages/AdminAiWorkerHealthPage.tsx
+++ b/pages/AdminAiWorkerHealthPage.tsx
@@ -1,0 +1,219 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AdminShell } from '../components/admin/AdminShell';
+import { AdminReloadButton } from '../components/admin/AdminReloadButton';
+import { AdminSurfaceCard } from '../components/admin/AdminSurfaceCard';
+import {
+    adminGetAiWorkerHealth,
+    type AdminAsyncWorkerHealthCheckRecord,
+    type AdminAsyncWorkerHealthResponse,
+    type AdminAsyncWorkerHealthStatus,
+} from '../services/adminService';
+
+const formatTimestamp = (value?: string | null): string => {
+    if (!value) return '—';
+    const parsed = Date.parse(value);
+    if (!Number.isFinite(parsed)) return '—';
+    return new Date(parsed).toLocaleString();
+};
+
+const formatDuration = (value?: number | null): string => {
+    if (!Number.isFinite(value)) return '—';
+    const normalized = Number(value);
+    if (normalized < 1000) return `${Math.round(normalized)} ms`;
+    if (normalized < 60_000) return `${(normalized / 1000).toFixed(1)} s`;
+    return `${(normalized / 60_000).toFixed(1)} min`;
+};
+
+const formatDispatchStatus = (row: AdminAsyncWorkerHealthCheckRecord): string => {
+    if (!row.dispatchAttempted) return 'No dispatch';
+    if (!Number.isFinite(row.dispatchHttpStatus)) return 'Triggered';
+    return `HTTP ${Math.round(Number(row.dispatchHttpStatus))}`;
+};
+
+const STATUS_META: Record<AdminAsyncWorkerHealthStatus, { label: string; className: string }> = {
+    ok: {
+        label: 'Healthy',
+        className: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    },
+    warning: {
+        label: 'Warning',
+        className: 'border-amber-200 bg-amber-50 text-amber-700',
+    },
+    failed: {
+        label: 'Failed',
+        className: 'border-rose-200 bg-rose-50 text-rose-700',
+    },
+};
+
+const StatusBadge: React.FC<{
+    status: AdminAsyncWorkerHealthStatus;
+}> = ({ status }) => (
+    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${STATUS_META[status].className}`}>
+        {STATUS_META[status].label}
+    </span>
+);
+
+const SummaryCard: React.FC<{
+    label: string;
+    value: React.ReactNode;
+    hint?: React.ReactNode;
+}> = ({ label, value, hint }) => (
+    <AdminSurfaceCard className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">{label}</p>
+        <div className="text-2xl font-black tracking-tight text-slate-900">{value}</div>
+        {hint ? <p className="text-sm text-slate-500">{hint}</p> : null}
+    </AdminSurfaceCard>
+);
+
+export const AdminAiWorkerHealthPage: React.FC = () => {
+    const [data, setData] = useState<AdminAsyncWorkerHealthResponse | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const loadWorkerHealth = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const next = await adminGetAiWorkerHealth({ limit: 25 });
+            setData(next);
+        } catch (loadError) {
+            setError(loadError instanceof Error ? loadError.message : 'Failed to load worker health.');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void loadWorkerHealth();
+    }, [loadWorkerHealth]);
+
+    const summary = data?.summary || null;
+    const checks = data?.checks || [];
+
+    return (
+        <AdminShell
+            title="Worker Health"
+            description="Operational heartbeat for async trip generation. Use this to spot stale queued jobs, recent self-heals, and canary regressions before user trips pile up."
+            actions={(
+                <div className="flex items-center gap-2">
+                    <Link
+                        to="/admin/ai-benchmark/telemetry"
+                        className="inline-flex h-9 items-center rounded-lg border border-slate-300 bg-white px-3 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-400 hover:text-slate-900"
+                    >
+                        Open AI Telemetry
+                    </Link>
+                    <AdminReloadButton onClick={() => void loadWorkerHealth()} isLoading={loading} label="Reload health" />
+                </div>
+            )}
+        >
+            <div className="space-y-5">
+                {error ? (
+                    <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                        {error}
+                    </div>
+                ) : null}
+
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                    <SummaryCard
+                        label="Overall status"
+                        value={summary ? <StatusBadge status={summary.overallStatus} /> : '—'}
+                        hint={summary?.statusReason || (loading ? 'Loading worker status...' : 'No worker health rows yet.')}
+                    />
+                    <SummaryCard
+                        label="Last heartbeat"
+                        value={summary ? formatTimestamp(summary.lastHeartbeatAt) : '—'}
+                        hint={summary?.heartbeatFresh ? 'Cron heartbeat is fresh.' : 'Cron heartbeat is stale or missing.'}
+                    />
+                    <SummaryCard
+                        label="Stale queued jobs"
+                        value={summary ? summary.staleQueuedCount.toLocaleString() : '—'}
+                        hint={summary?.oldestQueuedAgeMs != null ? `Oldest queued age: ${formatDuration(summary.oldestQueuedAgeMs)}` : 'No stale queued jobs recorded in the latest heartbeat.'}
+                    />
+                    <SummaryCard
+                        label="Last self-heal"
+                        value={summary?.lastSelfHealStatus ? <StatusBadge status={summary.lastSelfHealStatus} /> : '—'}
+                        hint={summary?.lastSelfHealAt ? formatTimestamp(summary.lastSelfHealAt) : 'No bounded re-kick recorded yet.'}
+                    />
+                    <SummaryCard
+                        label="Last canary"
+                        value={summary?.lastCanaryStatus ? <StatusBadge status={summary.lastCanaryStatus} /> : '—'}
+                        hint={summary?.lastCanaryAt ? formatTimestamp(summary.lastCanaryAt) : 'No canary run recorded yet.'}
+                    />
+                    <SummaryCard
+                        label="Canary latency"
+                        value={summary ? formatDuration(summary.lastCanaryLatencyMs) : '—'}
+                        hint={summary?.canaryDue ? 'Another canary is due soon.' : 'Recent successful canary is still within the target window.'}
+                    />
+                </div>
+
+                <AdminSurfaceCard className="space-y-4">
+                    <div className="flex items-center justify-between gap-3">
+                        <div>
+                            <h2 className="text-lg font-bold text-slate-900">Recent checks</h2>
+                            <p className="text-sm text-slate-500">Newest rows first. Heartbeats show cron health, watchdog rows capture stale-queue incidents, and canaries prove the drain path end to end.</p>
+                        </div>
+                        <div className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
+                            {checks.length.toLocaleString()} rows
+                        </div>
+                    </div>
+
+                    <div className="overflow-x-auto">
+                        <table className="min-w-full divide-y divide-slate-200 text-sm">
+                            <thead>
+                                <tr className="text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <th className="px-3 py-2">Type</th>
+                                    <th className="px-3 py-2">Status</th>
+                                    <th className="px-3 py-2">Started</th>
+                                    <th className="px-3 py-2">Stale queued</th>
+                                    <th className="px-3 py-2">Dispatch</th>
+                                    <th className="px-3 py-2">Failure</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-slate-100">
+                                {checks.length === 0 ? (
+                                    <tr>
+                                        <td colSpan={6} className="px-3 py-6 text-center text-sm text-slate-500">
+                                            {loading ? 'Loading worker health...' : 'No worker health rows yet.'}
+                                        </td>
+                                    </tr>
+                                ) : checks.map((row) => (
+                                    <tr key={row.id} className="align-top">
+                                        <td className="px-3 py-3 font-semibold capitalize text-slate-900">{row.checkType}</td>
+                                        <td className="px-3 py-3"><StatusBadge status={row.status} /></td>
+                                        <td className="px-3 py-3 text-slate-700">
+                                            <div>{formatTimestamp(row.startedAt)}</div>
+                                            <div className="text-xs text-slate-500">
+                                                Finished: {formatTimestamp(row.finishedAt)}
+                                            </div>
+                                        </td>
+                                        <td className="px-3 py-3 text-slate-700">
+                                            <div>{row.staleQueuedCount.toLocaleString()}</div>
+                                            <div className="text-xs text-slate-500">
+                                                Oldest: {formatDuration(row.oldestQueuedAgeMs)}
+                                            </div>
+                                        </td>
+                                        <td className="px-3 py-3 text-slate-700">
+                                            <div>{formatDispatchStatus(row)}</div>
+                                            {row.canaryLatencyMs != null ? (
+                                                <div className="text-xs text-slate-500">
+                                                    Canary latency: {formatDuration(row.canaryLatencyMs)}
+                                                </div>
+                                            ) : null}
+                                        </td>
+                                        <td className="px-3 py-3 text-slate-700">
+                                            <div>{row.failureCode || '—'}</div>
+                                            <div className="max-w-[340px] text-xs text-slate-500">
+                                                {row.failureMessage || 'No failure recorded.'}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </AdminSurfaceCard>
+            </div>
+        </AdminShell>
+    );
+};

--- a/pages/AdminWorkspaceRouter.tsx
+++ b/pages/AdminWorkspaceRouter.tsx
@@ -10,6 +10,7 @@ const lazyWithRecovery = <TModule extends { default: React.ComponentType<any> },
 const AdminDashboardPage = lazyWithRecovery('AdminDashboardPage', () => import('./AdminDashboardPage').then((module) => ({ default: module.AdminDashboardPage })));
 const AdminAiBenchmarkPage = lazyWithRecovery('AdminAiBenchmarkPage', () => import('./AdminAiBenchmarkPage').then((module) => ({ default: module.AdminAiBenchmarkPage })));
 const AdminAiTelemetryPage = lazyWithRecovery('AdminAiTelemetryPage', () => import('./AdminAiTelemetryPage').then((module) => ({ default: module.AdminAiTelemetryPage })));
+const AdminAiWorkerHealthPage = lazyWithRecovery('AdminAiWorkerHealthPage', () => import('./AdminAiWorkerHealthPage').then((module) => ({ default: module.AdminAiWorkerHealthPage })));
 const AdminUsersPage = lazyWithRecovery('AdminUsersPage', () => import('./AdminUsersPage').then((module) => ({ default: module.AdminUsersPage })));
 const AdminTripsPage = lazyWithRecovery('AdminTripsPage', () => import('./AdminTripsPage').then((module) => ({ default: module.AdminTripsPage })));
 const AdminTiersPage = lazyWithRecovery('AdminTiersPage', () => import('./AdminTiersPage').then((module) => ({ default: module.AdminTiersPage })));
@@ -36,6 +37,7 @@ export const AdminWorkspaceRouter: React.FC = () => (
             <Route path="legal" element={<AdminLegalTermsPage />} />
             <Route path="ai-benchmark" element={<AdminAiBenchmarkPage />} />
             <Route path="ai-benchmark/telemetry" element={<AdminAiTelemetryPage />} />
+            <Route path="ai-benchmark/worker-health" element={<AdminAiWorkerHealthPage />} />
             <Route path="og-tools" element={<AdminOgToolsPage />} />
             <Route path="design-system-playground" element={<AdminDesignSystemPlaygroundPage />} />
             <Route path="access" element={<Navigate to="/admin/users" replace />} />

--- a/services/adminService.ts
+++ b/services/adminService.ts
@@ -128,6 +128,48 @@ export interface AdminBillingPaddleReconcileResult {
     }>;
 }
 
+export type AdminAsyncWorkerHealthCheckType = 'heartbeat' | 'watchdog' | 'canary';
+export type AdminAsyncWorkerHealthStatus = 'ok' | 'warning' | 'failed';
+
+export interface AdminAsyncWorkerHealthCheckRecord {
+    id: string;
+    checkType: AdminAsyncWorkerHealthCheckType;
+    status: AdminAsyncWorkerHealthStatus;
+    startedAt: string;
+    finishedAt: string | null;
+    staleQueuedCount: number;
+    oldestQueuedAgeMs: number | null;
+    dispatchAttempted: boolean;
+    dispatchHttpStatus: number | null;
+    canaryLatencyMs: number | null;
+    failureCode: string | null;
+    failureMessage: string | null;
+    metadata: Record<string, unknown> | null;
+    createdAt: string;
+}
+
+export interface AdminAsyncWorkerHealthSummary {
+    overallStatus: AdminAsyncWorkerHealthStatus;
+    statusReason: string;
+    heartbeatFresh: boolean;
+    canaryFresh: boolean;
+    canaryDue: boolean;
+    staleQueuedCount: number;
+    oldestQueuedAgeMs: number | null;
+    lastHeartbeatAt: string | null;
+    lastHeartbeatStatus: AdminAsyncWorkerHealthStatus | null;
+    lastSelfHealAt: string | null;
+    lastSelfHealStatus: AdminAsyncWorkerHealthStatus | null;
+    lastCanaryAt: string | null;
+    lastCanaryStatus: AdminAsyncWorkerHealthStatus | null;
+    lastCanaryLatencyMs: number | null;
+}
+
+export interface AdminAsyncWorkerHealthResponse {
+    summary: AdminAsyncWorkerHealthSummary;
+    checks: AdminAsyncWorkerHealthCheckRecord[];
+}
+
 export interface AdminAuditRecord {
     id: string;
     actor_user_id: string | null;
@@ -1061,9 +1103,37 @@ export const adminSetCurrentTermsVersion = async (
     return row;
 };
 
-const callAdminInternalApi = async <T extends Record<string, unknown>>(
+const resolveInternalApiDevMessages = (path: string): { notFound: string; proxyFailure: string } | null => {
+    if (path === '/api/internal/admin/iam') {
+        return {
+            notFound: 'Admin identity route is unavailable in Vite-only dev. Run `pnpm dev:netlify` (or run it in a second terminal while `pnpm dev` is active) to test admin delete/invite/create actions.',
+            proxyFailure: 'Vite could not reach Netlify dev for admin identity actions (connection refused on localhost:8888). Start `pnpm dev:netlify` before testing delete/invite/create.',
+        };
+    }
+    if (path === '/api/internal/admin/audit/replay-export') {
+        return {
+            notFound: 'Admin audit export route is unavailable in Vite-only dev. Run `pnpm dev:netlify` (or run it in a second terminal while `pnpm dev` is active) to test replay exports.',
+            proxyFailure: 'Vite could not reach Netlify dev for admin audit export actions (connection refused on localhost:8888). Start `pnpm dev:netlify` before testing replay export.',
+        };
+    }
+    if (path === '/api/internal/admin/billing/paddle/reconcile') {
+        return {
+            notFound: 'Admin billing reconcile route is unavailable in Vite-only dev. Run `pnpm dev:netlify` (or run it in a second terminal while `pnpm dev` is active) to test Paddle reconciliation.',
+            proxyFailure: 'Vite could not reach Netlify dev for admin billing reconciliation (connection refused on localhost:8888). Start `pnpm dev:netlify` before testing Paddle reconciliation.',
+        };
+    }
+    if (path.startsWith('/api/internal/admin/ai-worker-health')) {
+        return {
+            notFound: 'Admin worker health route is unavailable in Vite-only dev. Run `pnpm dev:netlify` (or keep it running alongside `pnpm dev`) to test worker watchdog dashboards.',
+            proxyFailure: 'Vite could not reach Netlify dev for worker health requests (connection refused on localhost:8888). Start `pnpm dev:netlify` before testing worker health.',
+        };
+    }
+    return null;
+};
+
+const callAdminInternalApiRequest = async <T extends Record<string, unknown>>(
     path: string,
-    body: Record<string, unknown>
+    options: { method: 'GET' | 'POST'; body?: Record<string, unknown> | null }
 ): Promise<T> => {
     await ensureExistingDbSession();
     const token = await dbGetAccessToken();
@@ -1072,12 +1142,12 @@ const callAdminInternalApi = async <T extends Record<string, unknown>>(
     }
 
     const response = await fetch(path, {
-        method: 'POST',
+        method: options.method,
         headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify(body),
+        body: options.method === 'POST' ? JSON.stringify(options.body || {}) : undefined,
     });
 
     const responseText = await response.text().catch(() => '');
@@ -1103,22 +1173,7 @@ const callAdminInternalApi = async <T extends Record<string, unknown>>(
                         : null;
         const fallbackText = responseText.trim();
         const normalizedFallback = fallbackText && fallbackText.length <= 280 ? fallbackText : null;
-        const pathMessages = path === '/api/internal/admin/iam'
-            ? {
-                notFound: 'Admin identity route is unavailable in Vite-only dev. Run `pnpm dev:netlify` (or run it in a second terminal while `pnpm dev` is active) to test admin delete/invite/create actions.',
-                proxyFailure: 'Vite could not reach Netlify dev for admin identity actions (connection refused on localhost:8888). Start `pnpm dev:netlify` before testing delete/invite/create.',
-            }
-            : path === '/api/internal/admin/audit/replay-export'
-                ? {
-                    notFound: 'Admin audit export route is unavailable in Vite-only dev. Run `pnpm dev:netlify` (or run it in a second terminal while `pnpm dev` is active) to test replay exports.',
-                    proxyFailure: 'Vite could not reach Netlify dev for admin audit export actions (connection refused on localhost:8888). Start `pnpm dev:netlify` before testing replay export.',
-                }
-                : path === '/api/internal/admin/billing/paddle/reconcile'
-                    ? {
-                        notFound: 'Admin billing reconcile route is unavailable in Vite-only dev. Run `pnpm dev:netlify` (or run it in a second terminal while `pnpm dev` is active) to test Paddle reconciliation.',
-                        proxyFailure: 'Vite could not reach Netlify dev for admin billing reconciliation (connection refused on localhost:8888). Start `pnpm dev:netlify` before testing Paddle reconciliation.',
-                    }
-                    : null;
+        const pathMessages = resolveInternalApiDevMessages(path);
         const devNotFoundMessage = looksLikeViteNotFoundPage && import.meta.env.DEV
             ? pathMessages?.notFound ?? null
             : null;
@@ -1140,6 +1195,20 @@ const callAdminInternalApi = async <T extends Record<string, unknown>>(
     }
     return payload as T;
 };
+
+const callAdminInternalApi = async <T extends Record<string, unknown>>(
+    path: string,
+    body: Record<string, unknown>
+): Promise<T> => callAdminInternalApiRequest<T>(path, {
+    method: 'POST',
+    body,
+});
+
+const callAdminInternalApiGet = async <T extends Record<string, unknown>>(
+    path: string,
+): Promise<T> => callAdminInternalApiRequest<T>(path, {
+    method: 'GET',
+});
 
 export const adminCreateUserInvite = async (payload: {
     email: string;
@@ -1304,4 +1373,37 @@ export const adminReconcilePaddleSubscriptions = async (
     }
 
     return response.data;
+};
+
+export const adminGetAiWorkerHealth = async (
+    options?: { limit?: number | null }
+): Promise<AdminAsyncWorkerHealthResponse> => {
+    const limit = Number.isFinite(Number(options?.limit))
+        ? Math.max(1, Math.min(50, Math.round(Number(options?.limit))))
+        : 25;
+    const payload = await callAdminInternalApiGet<{
+        ok?: boolean;
+        summary?: AdminAsyncWorkerHealthSummary;
+        checks?: AdminAsyncWorkerHealthCheckRecord[];
+    }>(`/api/internal/admin/ai-worker-health?limit=${limit}`);
+
+    return {
+        summary: payload.summary || {
+            overallStatus: 'warning',
+            statusReason: 'Worker health summary is unavailable.',
+            heartbeatFresh: false,
+            canaryFresh: false,
+            canaryDue: true,
+            staleQueuedCount: 0,
+            oldestQueuedAgeMs: null,
+            lastHeartbeatAt: null,
+            lastHeartbeatStatus: null,
+            lastSelfHealAt: null,
+            lastSelfHealStatus: null,
+            lastCanaryAt: null,
+            lastCanaryStatus: null,
+            lastCanaryLatencyMs: null,
+        },
+        checks: Array.isArray(payload.checks) ? payload.checks : [],
+    };
 };

--- a/services/pageTitleService.ts
+++ b/services/pageTitleService.ts
@@ -125,7 +125,8 @@ export const resolvePageTitle = ({
         if (normalizedPath === '/admin/billing') return titleWithAppName(`${labels.admin} · Billing`, appName);
         if (normalizedPath === '/admin/audit') return titleWithAppName(`${labels.admin} · Audit`, appName);
         if (normalizedPath === '/admin/ai-benchmark') return titleWithAppName(`${labels.admin} · AI Benchmark`, appName);
-        if (normalizedPath === '/admin/ai-telemetry') return titleWithAppName(`${labels.admin} · AI Telemetry`, appName);
+        if (normalizedPath === '/admin/ai-benchmark/telemetry') return titleWithAppName(`${labels.admin} · AI Telemetry`, appName);
+        if (normalizedPath === '/admin/ai-benchmark/worker-health') return titleWithAppName(`${labels.admin} · Worker Health`, appName);
         return titleWithAppName(labels.admin, appName);
     }
 

--- a/tests/browser/admin/adminAiWorkerHealthPage.browser.test.ts
+++ b/tests/browser/admin/adminAiWorkerHealthPage.browser.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mocks = vi.hoisted(() => ({
+  adminGetAiWorkerHealth: vi.fn(),
+}));
+
+vi.mock('../../../components/admin/AdminShell', () => ({
+  AdminShell: ({ title, description, actions, children }: { title: string; description?: string; actions?: React.ReactNode; children: React.ReactNode }) => (
+    React.createElement(
+      'div',
+      null,
+      React.createElement('h1', null, title),
+      description ? React.createElement('p', null, description) : null,
+      actions,
+      children,
+    )
+  ),
+}));
+
+vi.mock('../../../components/admin/AdminReloadButton', () => ({
+  AdminReloadButton: ({ onClick, label }: { onClick: () => void; label: string }) => React.createElement('button', { type: 'button', onClick }, label),
+}));
+
+vi.mock('../../../components/admin/AdminSurfaceCard', () => ({
+  AdminSurfaceCard: ({ children }: { children: React.ReactNode }) => React.createElement('section', null, children),
+}));
+
+vi.mock('../../../services/adminService', () => ({
+  adminGetAiWorkerHealth: mocks.adminGetAiWorkerHealth,
+}));
+
+import { AdminAiWorkerHealthPage } from '../../../pages/AdminAiWorkerHealthPage';
+
+const renderPage = () => render(
+  React.createElement(
+    MemoryRouter,
+    { initialEntries: ['/admin/ai-benchmark/worker-health'] },
+    React.createElement(AdminAiWorkerHealthPage),
+  ),
+);
+
+describe('pages/AdminAiWorkerHealthPage', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mocks.adminGetAiWorkerHealth.mockResolvedValue({
+      summary: {
+        overallStatus: 'warning',
+        statusReason: 'Detected stale queued jobs and re-kicked the worker.',
+        heartbeatFresh: true,
+        canaryFresh: true,
+        canaryDue: false,
+        staleQueuedCount: 2,
+        oldestQueuedAgeMs: 360000,
+        lastHeartbeatAt: '2026-03-10T10:10:00.000Z',
+        lastHeartbeatStatus: 'warning',
+        lastSelfHealAt: '2026-03-10T10:10:05.000Z',
+        lastSelfHealStatus: 'warning',
+        lastCanaryAt: '2026-03-10T10:00:01.000Z',
+        lastCanaryStatus: 'ok',
+        lastCanaryLatencyMs: 180,
+      },
+      checks: [
+        {
+          id: '00000000-0000-4000-8000-000000000001',
+          checkType: 'watchdog',
+          status: 'warning',
+          startedAt: '2026-03-10T10:10:00.000Z',
+          finishedAt: '2026-03-10T10:10:05.000Z',
+          staleQueuedCount: 2,
+          oldestQueuedAgeMs: 360000,
+          dispatchAttempted: true,
+          dispatchHttpStatus: 202,
+          canaryLatencyMs: null,
+          failureCode: 'WORKER_STALE_QUEUE_DETECTED',
+          failureMessage: 'Detected stale queued jobs and re-kicked the worker.',
+          metadata: {
+            selfHealAttempted: true,
+          },
+          createdAt: '2026-03-10T10:10:05.000Z',
+        },
+      ],
+    });
+  });
+
+  it('renders worker health summary cards and recent checks', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(mocks.adminGetAiWorkerHealth).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByRole('heading', { name: 'Worker Health' })).toBeInTheDocument();
+    expect(screen.getAllByText('Detected stale queued jobs and re-kicked the worker.').length).toBeGreaterThan(0);
+    expect(screen.getByText('Recent checks')).toBeInTheDocument();
+    expect(screen.getByText('watchdog')).toBeInTheDocument();
+    expect(screen.getByText('WORKER_STALE_QUEUE_DETECTED')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open AI Telemetry' })).toHaveAttribute('href', '/admin/ai-benchmark/telemetry');
+  });
+
+  it('reloads worker health on demand', async () => {
+    const { userEvent } = await import('@testing-library/user-event');
+    renderPage();
+
+    await waitFor(() => {
+      expect(mocks.adminGetAiWorkerHealth).toHaveBeenCalledTimes(1);
+    });
+
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Reload health' }));
+
+    await waitFor(() => {
+      expect(mocks.adminGetAiWorkerHealth).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tests/unit/adminNavConfig.test.ts
+++ b/tests/unit/adminNavConfig.test.ts
@@ -15,4 +15,11 @@ describe('admin navigation config', () => {
     expect(designPlayground?.path).toBe('/admin/design-system-playground');
     expect(designPlayground?.section).toBe('tools');
   });
+
+  it('includes worker health entry in tools section', () => {
+    const workerHealth = ADMIN_NAV_ITEMS.find((item) => item.id === 'ai_worker_health');
+    expect(workerHealth).toBeTruthy();
+    expect(workerHealth?.path).toBe('/admin/ai-benchmark/worker-health');
+    expect(workerHealth?.section).toBe('tools');
+  });
 });

--- a/tests/unit/aiGenerateWorkerCron.test.ts
+++ b/tests/unit/aiGenerateWorkerCron.test.ts
@@ -4,9 +4,19 @@ import { config, handler } from '../../netlify/functions/ai-generate-worker-cron
 
 const ORIGINAL_ENV = { ...process.env };
 
+const jsonResponse = (payload: unknown, init?: ResponseInit) => new Response(JSON.stringify(payload), {
+  status: init?.status ?? 200,
+  headers: {
+    'Content-Type': 'application/json',
+    ...(init?.headers || {}),
+  },
+});
+
 describe('netlify/functions/ai-generate-worker-cron', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
     process.env = { ...ORIGINAL_ENV };
   });
 
@@ -27,33 +37,161 @@ describe('netlify/functions/ai-generate-worker-cron', () => {
     });
   });
 
-  it('triggers the background worker endpoint with admin auth', async () => {
+  it('triggers the background worker and persists a healthy heartbeat when no stale queue is detected', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T10:10:00.000Z'));
     process.env.AI_GENERATION_ASYNC_WORKER_ENABLED = 'true';
     process.env.TF_ADMIN_API_KEY = 'secret';
     process.env.URL = 'https://travelflowapp.netlify.app';
+    process.env.VITE_SUPABASE_URL = 'https://supabase.example';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-secret';
     process.env.AI_GENERATION_ASYNC_WORKER_BATCH = '3';
 
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ok: true, accepted: true }), {
-        status: 202,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse([{
+        id: '00000000-0000-4000-8000-000000000010',
+        check_type: 'canary',
+        status: 'ok',
+        started_at: '2026-03-10T10:00:00.000Z',
+        finished_at: '2026-03-10T10:00:10.000Z',
+        stale_queued_count: 0,
+        oldest_queued_age_ms: null,
+        dispatch_attempted: false,
+        dispatch_http_status: null,
+        canary_latency_ms: 180,
+        failure_code: null,
+        failure_message: null,
+        metadata: {},
+        created_at: '2026-03-10T10:00:10.000Z',
+      }], { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(new Response('[]', {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'content-range': '0-0/0',
+        },
+      }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true, accepted: true }, { status: 202 }))
+      .mockResolvedValueOnce(new Response(null, { status: 201 }));
     vi.stubGlobal('fetch', fetchMock);
 
     const response = await handler();
     const payload = JSON.parse(String(response.body));
 
     expect(response.statusCode).toBe(202);
-    expect(payload).toEqual({ ok: true, accepted: true });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://travelflowapp.netlify.app/.netlify/functions/ai-generate-worker-background');
-    expect(init.method).toBe('POST');
-    expect(init.headers).toMatchObject({
+    expect(payload).toMatchObject({
+      ok: true,
+      accepted: true,
+      health: {
+        status: 'ok',
+        staleQueuedCount: 0,
+        selfHealAttempted: false,
+      },
+    });
+
+    const backgroundCall = fetchMock.mock.calls[3] as [string, RequestInit];
+    expect(backgroundCall[0]).toBe('https://travelflowapp.netlify.app/.netlify/functions/ai-generate-worker-background');
+    expect(backgroundCall[1].headers).toMatchObject({
       'x-tf-admin-key': 'secret',
       'x-tf-worker-cron': '1',
     });
-    expect(init.body).toBe(JSON.stringify({ limit: 3 }));
+    expect(backgroundCall[1].body).toBe(JSON.stringify({ limit: 3 }));
+
+    const heartbeatInsert = fetchMock.mock.calls[4] as [string, RequestInit];
+    expect(heartbeatInsert[0]).toBe('https://supabase.example/rest/v1/async_worker_health_checks');
+    expect(JSON.parse(String(heartbeatInsert[1].body))).toMatchObject({
+      check_type: 'heartbeat',
+      status: 'ok',
+      stale_queued_count: 0,
+      dispatch_attempted: true,
+      dispatch_http_status: 202,
+    });
+  });
+
+  it('records watchdog and canary rows when stale queued jobs are detected', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T10:10:00.000Z'));
+    process.env.AI_GENERATION_ASYNC_WORKER_ENABLED = 'true';
+    process.env.TF_ADMIN_API_KEY = 'secret';
+    process.env.URL = 'https://travelflowapp.netlify.app';
+    process.env.VITE_SUPABASE_URL = 'https://supabase.example';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-secret';
+    process.env.AI_GENERATION_ASYNC_WORKER_BATCH = '1';
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse([], { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([{ id: 'job-1', updated_at: '2026-03-10T10:00:00.000Z' }]), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'content-range': '0-0/2',
+        },
+      }))
+      .mockResolvedValueOnce(jsonResponse([{ user_id: '00000000-0000-4000-8000-000000000099' }], { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 201 }))
+      .mockResolvedValueOnce(new Response(null, { status: 201 }))
+      .mockResolvedValueOnce(new Response(null, { status: 201 }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true, accepted: true }, { status: 202 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([{ id: 'job-1', updated_at: '2026-03-10T10:04:00.000Z' }]), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'content-range': '0-0/1',
+        },
+      }))
+      .mockResolvedValueOnce(new Response(null, { status: 201 }))
+      .mockResolvedValueOnce(new Response(null, { status: 201 }))
+      .mockResolvedValueOnce(jsonResponse([{
+        id: 'job-canary',
+        state: 'failed',
+        last_error_code: 'ASYNC_WORKER_PAYLOAD_INVALID',
+        last_error_message: 'Job payload is invalid for async generation worker.',
+      }], { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(new Response(null, { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await handler();
+    const payload = JSON.parse(String(response.body));
+
+    expect(response.statusCode).toBe(202);
+    expect(payload.health).toMatchObject({
+      status: 'warning',
+      staleQueuedCount: 2,
+      selfHealAttempted: true,
+      selfHealSucceeded: true,
+      postDispatchStaleQueuedCount: 1,
+      canary: {
+        status: 'ok',
+        code: 'ASYNC_WORKER_PAYLOAD_INVALID',
+      },
+    });
+
+    const backgroundCall = fetchMock.mock.calls[7] as [string, RequestInit];
+    expect(backgroundCall[0]).toBe('https://travelflowapp.netlify.app/.netlify/functions/ai-generate-worker-background');
+    expect(backgroundCall[1].body).toBe(JSON.stringify({ limit: 2 }));
+
+    const heartbeatInsert = fetchMock.mock.calls[9] as [string, RequestInit];
+    const watchdogInsert = fetchMock.mock.calls[10] as [string, RequestInit];
+    const canaryInsert = fetchMock.mock.calls[13] as [string, RequestInit];
+
+    expect(JSON.parse(String(heartbeatInsert[1].body))).toMatchObject({
+      check_type: 'heartbeat',
+      status: 'warning',
+      stale_queued_count: 2,
+      dispatch_http_status: 202,
+    });
+    expect(JSON.parse(String(watchdogInsert[1].body))).toMatchObject({
+      check_type: 'watchdog',
+      status: 'warning',
+      stale_queued_count: 2,
+    });
+    expect(JSON.parse(String(canaryInsert[1].body))).toMatchObject({
+      check_type: 'canary',
+      status: 'ok',
+      canary_latency_ms: expect.any(Number),
+    });
   });
 });

--- a/tests/unit/asyncWorkerHealth.test.ts
+++ b/tests/unit/asyncWorkerHealth.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAsyncWorkerHealthSummary,
+  shouldRunAsyncWorkerCanary,
+  type AsyncWorkerHealthCheckRecord,
+} from '../../netlify/edge-lib/async-worker-health';
+
+const buildCheck = (overrides: Partial<AsyncWorkerHealthCheckRecord>): AsyncWorkerHealthCheckRecord => ({
+  id: overrides.id || '00000000-0000-4000-8000-000000000001',
+  checkType: overrides.checkType || 'heartbeat',
+  status: overrides.status || 'ok',
+  startedAt: overrides.startedAt || '2026-03-10T10:00:00.000Z',
+  finishedAt: overrides.finishedAt ?? '2026-03-10T10:00:15.000Z',
+  staleQueuedCount: overrides.staleQueuedCount ?? 0,
+  oldestQueuedAgeMs: overrides.oldestQueuedAgeMs ?? null,
+  dispatchAttempted: overrides.dispatchAttempted ?? true,
+  dispatchHttpStatus: overrides.dispatchHttpStatus ?? 202,
+  canaryLatencyMs: overrides.canaryLatencyMs ?? null,
+  failureCode: overrides.failureCode ?? null,
+  failureMessage: overrides.failureMessage ?? null,
+  metadata: overrides.metadata ?? null,
+  createdAt: overrides.createdAt || '2026-03-10T10:00:15.000Z',
+});
+
+describe('async worker health helpers', () => {
+  it('does not schedule a canary when a successful one completed inside the cadence window', () => {
+    const recentSuccess = buildCheck({
+      checkType: 'canary',
+      status: 'ok',
+      startedAt: '2026-03-10T10:00:00.000Z',
+      finishedAt: '2026-03-10T10:00:30.000Z',
+    });
+
+    expect(shouldRunAsyncWorkerCanary([recentSuccess], Date.parse('2026-03-10T10:10:00.000Z'))).toBe(false);
+  });
+
+  it('marks summary as failed when the latest heartbeat is stale', () => {
+    const summary = buildAsyncWorkerHealthSummary([
+      buildCheck({
+        checkType: 'heartbeat',
+        status: 'ok',
+        startedAt: '2026-03-10T10:00:00.000Z',
+      }),
+      buildCheck({
+        id: '00000000-0000-4000-8000-000000000002',
+        checkType: 'canary',
+        status: 'ok',
+        startedAt: '2026-03-10T10:01:00.000Z',
+        finishedAt: '2026-03-10T10:01:10.000Z',
+        canaryLatencyMs: 250,
+      }),
+    ], Date.parse('2026-03-10T10:05:30.000Z'));
+
+    expect(summary.overallStatus).toBe('failed');
+    expect(summary.statusReason).toContain('heartbeat');
+  });
+
+  it('marks summary as warning when stale queued jobs were re-kicked successfully', () => {
+    const summary = buildAsyncWorkerHealthSummary([
+      buildCheck({
+        checkType: 'heartbeat',
+        status: 'warning',
+        startedAt: '2026-03-10T10:00:00.000Z',
+        staleQueuedCount: 3,
+        oldestQueuedAgeMs: 420000,
+        failureMessage: 'Detected stale queued jobs and re-kicked the worker.',
+        metadata: {
+          selfHealAttempted: true,
+          selfHealSucceeded: true,
+        },
+      }),
+      buildCheck({
+        id: '00000000-0000-4000-8000-000000000003',
+        checkType: 'canary',
+        status: 'ok',
+        startedAt: '2026-03-10T09:55:00.000Z',
+        finishedAt: '2026-03-10T09:55:01.000Z',
+        canaryLatencyMs: 120,
+      }),
+    ], Date.parse('2026-03-10T10:01:00.000Z'));
+
+    expect(summary.overallStatus).toBe('warning');
+    expect(summary.staleQueuedCount).toBe(3);
+    expect(summary.lastSelfHealStatus).toBe('warning');
+  });
+});


### PR DESCRIPTION
## Summary
- add durable async worker health rows for heartbeats, stale-queue watchdog incidents, and canary runs
- extend the scheduled worker cron with stale-queue detection, bounded self-heal recording, and a provider-free invalid-payload canary
- add an admin Worker Health page plus internal edge endpoint for recent checks and summary status

## Testing
- [x] `pnpm vitest run tests/unit/asyncWorkerHealth.test.ts tests/unit/aiGenerateWorkerCron.test.ts tests/unit/adminNavConfig.test.ts tests/browser/admin/adminAiWorkerHealthPage.browser.test.ts`
- [x] `pnpm test:core`
- [x] `pnpm updates:validate`
- [x] `pnpm supabase:validate`
- [x] `pnpm edge:validate`
- [x] `npx -y react-doctor@latest . --verbose --diff`

Closes #264
