### PR TITLE
Wait for async worker canary completion

### DIFF
--- a/content/updates/2026-03-10-server-owned-async-dispatch.md
+++ b/content/updates/2026-03-10-server-owned-async-dispatch.md
@@ -15,3 +15,4 @@ summary: "Async trip generation now hands the first worker kickoff to a server-o
 - [x] [Improved] 👀 Returning to a trip later now has a better chance of loading the finished itinerary immediately because the first worker start no longer depends on the open tab staying alive.
 - [ ] [Internal] 🧱 Added a dedicated authenticated enqueue endpoint that queues the job and immediately dispatches the background worker in one server-owned step, while leaving cron/watchdog recovery as a backup.
 - [ ] [Internal] 🧪 Hardened the async worker cron canary tests so production deploys stay stable when a dedicated canary owner is configured.
+- [ ] [Internal] ⏱️ Taught the async worker canary to wait briefly for terminal worker results so healthy background processing no longer reports false failures.

--- a/netlify/edge-lib/async-worker-health.ts
+++ b/netlify/edge-lib/async-worker-health.ts
@@ -68,6 +68,8 @@ export const ASYNC_WORKER_HEARTBEAT_STALE_MS = 3 * 60 * 1000;
 export const ASYNC_WORKER_CANARY_INTERVAL_MS = 15 * 60 * 1000;
 export const ASYNC_WORKER_CANARY_STALE_MS = 30 * 60 * 1000;
 export const ASYNC_WORKER_CANARY_CLEANUP_MS = 60 * 60 * 1000;
+export const ASYNC_WORKER_CANARY_POLL_INTERVAL_MS = 1000;
+export const ASYNC_WORKER_CANARY_MAX_WAIT_MS = 12 * 1000;
 export const ASYNC_WORKER_CANARY_SOURCE = "async_worker_canary";
 export const ASYNC_WORKER_CANARY_SOURCE_KIND = "internal_canary";
 const MAX_HEALTH_FAILURE_MESSAGE_LENGTH = 800;
@@ -119,6 +121,10 @@ const safeJsonParse = async (response: Response): Promise<unknown> => {
     return null;
   }
 };
+
+const sleep = (delayMs: number): Promise<void> => new Promise((resolve) => {
+  setTimeout(resolve, delayMs);
+});
 
 const buildServiceHeaders = (
   serviceRoleKey: string,
@@ -570,6 +576,35 @@ export const readAsyncWorkerCanaryEvaluation = async (
     errorCode,
     errorMessage,
   };
+};
+
+export const waitForAsyncWorkerCanaryEvaluation = async (
+  config: { url: string; serviceRoleKey: string },
+  canary: AsyncWorkerCanaryContext,
+  options?: {
+    maxWaitMs?: number;
+    pollIntervalMs?: number;
+    now?: () => Date;
+  },
+): Promise<AsyncWorkerCanaryEvaluation> => {
+  const now = options?.now || (() => new Date());
+  const maxWaitMs = Math.max(0, Math.round(options?.maxWaitMs ?? ASYNC_WORKER_CANARY_MAX_WAIT_MS));
+  const pollIntervalMs = Math.max(0, Math.round(options?.pollIntervalMs ?? ASYNC_WORKER_CANARY_POLL_INTERVAL_MS));
+  const deadlineMs = now().getTime() + maxWaitMs;
+
+  let evaluation = await readAsyncWorkerCanaryEvaluation(config, canary, now());
+  while (
+    evaluation.failureCode === "WORKER_CANARY_NOT_TERMINAL" &&
+    now().getTime() < deadlineMs
+  ) {
+    const remainingMs = deadlineMs - now().getTime();
+    const delayMs = Math.max(0, Math.min(pollIntervalMs, remainingMs));
+    if (delayMs <= 0) break;
+    await sleep(delayMs);
+    evaluation = await readAsyncWorkerCanaryEvaluation(config, canary, now());
+  }
+
+  return evaluation;
 };
 
 export const deleteAsyncWorkerCanaryTrip = async (

--- a/netlify/functions/ai-generate-worker-cron.js
+++ b/netlify/functions/ai-generate-worker-cron.js
@@ -5,9 +5,9 @@ import {
   getAsyncWorkerHealthConfig,
   insertAsyncWorkerHealthCheck,
   listRecentAsyncWorkerHealthChecks,
-  readAsyncWorkerCanaryEvaluation,
   readStaleQueuedJobSnapshot,
   shouldRunAsyncWorkerCanary,
+  waitForAsyncWorkerCanaryEvaluation,
 } from "../edge-lib/async-worker-health.ts";
 
 const JSON_HEADERS = {
@@ -193,6 +193,8 @@ export const handler = async () => {
   const cronStartedAtIso = cronStartedAt.toISOString();
   const workerLimitBase = resolveInteger(process.env.AI_GENERATION_ASYNC_WORKER_BATCH || "1", 1, 1, 5);
   const triggerTimeoutMs = resolveInteger(process.env.AI_GENERATION_ASYNC_TRIGGER_TIMEOUT_MS || "180000", 180_000, 5_000, 240_000);
+  const canaryPollIntervalMs = resolveInteger(process.env.AI_GENERATION_ASYNC_CANARY_POLL_INTERVAL_MS || "1000", 1000, 0, 5000);
+  const canaryMaxWaitMs = resolveInteger(process.env.AI_GENERATION_ASYNC_CANARY_MAX_WAIT_MS || "12000", 12_000, 0, 30_000);
 
   const recentChecks = await listRecentAsyncWorkerHealthChecks(healthConfig, 25);
   await cleanupStaleAsyncWorkerCanaries(healthConfig, cronStartedAt);
@@ -323,7 +325,10 @@ export const handler = async () => {
           },
         });
       } else {
-        const evaluation = await readAsyncWorkerCanaryEvaluation(healthConfig, canaryContext, new Date());
+        const evaluation = await waitForAsyncWorkerCanaryEvaluation(healthConfig, canaryContext, {
+          maxWaitMs: canaryMaxWaitMs,
+          pollIntervalMs: canaryPollIntervalMs,
+        });
         const cleanedUp = evaluation.status === "ok"
           ? await deleteAsyncWorkerCanaryTrip(healthConfig, canaryContext.tripId)
           : false;
@@ -348,6 +353,8 @@ export const handler = async () => {
             jobState: evaluation.jobState,
             errorCode: evaluation.errorCode,
             errorMessage: evaluation.errorMessage,
+            canaryMaxWaitMs,
+            canaryPollIntervalMs,
             cleanedUp,
           },
         });

--- a/tests/unit/aiGenerateWorkerCron.test.ts
+++ b/tests/unit/aiGenerateWorkerCron.test.ts
@@ -119,6 +119,7 @@ describe('netlify/functions/ai-generate-worker-cron', () => {
     process.env.VITE_SUPABASE_URL = 'https://supabase.example';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-secret';
     process.env.AI_GENERATION_ASYNC_WORKER_BATCH = '1';
+    process.env.AI_GENERATION_ASYNC_CANARY_MAX_WAIT_MS = '0';
 
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(jsonResponse([], { status: 200 }))
@@ -206,6 +207,7 @@ describe('netlify/functions/ai-generate-worker-cron', () => {
     process.env.VITE_SUPABASE_URL = 'https://supabase.example';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-secret';
     process.env.AI_GENERATION_ASYNC_WORKER_BATCH = '1';
+    process.env.AI_GENERATION_ASYNC_CANARY_MAX_WAIT_MS = '0';
 
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(jsonResponse([], { status: 200 }))

--- a/tests/unit/asyncWorkerHealth.test.ts
+++ b/tests/unit/asyncWorkerHealth.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildAsyncWorkerHealthSummary,
   shouldRunAsyncWorkerCanary,
+  waitForAsyncWorkerCanaryEvaluation,
+  type AsyncWorkerCanaryContext,
   type AsyncWorkerHealthCheckRecord,
 } from '../../netlify/edge-lib/async-worker-health';
 
@@ -23,7 +25,30 @@ const buildCheck = (overrides: Partial<AsyncWorkerHealthCheckRecord>): AsyncWork
   createdAt: overrides.createdAt || '2026-03-10T10:00:15.000Z',
 });
 
+const jsonResponse = (payload: unknown, init?: ResponseInit) => new Response(JSON.stringify(payload), {
+  status: init?.status ?? 200,
+  headers: {
+    'Content-Type': 'application/json',
+    ...(init?.headers || {}),
+  },
+});
+
+const buildCanary = (overrides: Partial<AsyncWorkerCanaryContext> = {}): AsyncWorkerCanaryContext => ({
+  tripId: overrides.tripId || 'internal-canary-trip',
+  attemptId: overrides.attemptId || 'internal-canary-attempt',
+  jobId: overrides.jobId || 'internal-canary-job',
+  ownerId: overrides.ownerId || '00000000-0000-4000-8000-000000000001',
+  requestId: overrides.requestId || 'async-worker-canary-request',
+  startedAt: overrides.startedAt || '2026-03-10T10:00:00.000Z',
+});
+
 describe('async worker health helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
   it('does not schedule a canary when a successful one completed inside the cadence window', () => {
     const recentSuccess = buildCheck({
       checkType: 'canary',
@@ -83,5 +108,47 @@ describe('async worker health helpers', () => {
     expect(summary.overallStatus).toBe('warning');
     expect(summary.staleQueuedCount).toBe(3);
     expect(summary.lastSelfHealStatus).toBe('warning');
+  });
+
+  it('waits for a queued canary to become terminal before marking it failed', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T10:10:00.000Z'));
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse([{
+        id: 'internal-canary-job',
+        state: 'queued',
+        last_error_code: null,
+        last_error_message: null,
+        leased_by: null,
+        updated_at: '2026-03-10T10:10:00.000Z',
+        finished_at: null,
+      }], { status: 200 }))
+      .mockResolvedValueOnce(jsonResponse([{
+        id: 'internal-canary-job',
+        state: 'failed',
+        last_error_code: 'ASYNC_WORKER_PAYLOAD_INVALID',
+        last_error_message: 'Job payload is invalid for async generation worker.',
+        leased_by: 'worker-1',
+        updated_at: '2026-03-10T10:10:01.000Z',
+        finished_at: '2026-03-10T10:10:01.000Z',
+      }], { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const evaluationPromise = waitForAsyncWorkerCanaryEvaluation(
+      { url: 'https://supabase.example', serviceRoleKey: 'service-role-secret' },
+      buildCanary(),
+      { maxWaitMs: 2_000, pollIntervalMs: 1_000 },
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const evaluation = await evaluationPromise;
+
+    expect(evaluation).toMatchObject({
+      status: 'ok',
+      failureCode: null,
+      errorCode: 'ASYNC_WORKER_PAYLOAD_INVALID',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- make async worker canary evaluation poll briefly for a terminal worker result after dispatch
- add regression coverage for queued-to-terminal canary completion and keep cron tests deterministic
- capture the internal canary false-failure fix in the existing draft release note

## Testing
- `pnpm vitest run tests/unit/asyncWorkerHealth.test.ts tests/unit/aiGenerateWorkerCron.test.ts`
- `pnpm test:core`
- `pnpm edge:validate`
- `pnpm updates:validate`
