### PR TITLE
fix(blog): add safari-friendly view transition fallbacks

### DIFF
--- a/content/updates/2026-03-09-blog-transition-merge-followup.md
+++ b/content/updates/2026-03-09-blog-transition-merge-followup.md
@@ -7,9 +7,11 @@ published_at: 2026-03-09T20:45:00Z
 status: draft
 notify_in_app: false
 in_app_hours: 24
-summary: "Refines the merged blog view-transition geometry so card and detail images animate without the extra scale drift introduced by later merge-time tweaks."
+summary: "Refines the merged blog view-transition geometry and adds simpler Safari-friendly fallbacks so blog transitions stay visible even when nested View Transitions features are unavailable."
 ---
 
 ## Changes
 - [x] [Improved] 🖼️ Blog list and detail images now share calmer card/hero geometry again so the transition no longer picks up the extra scale drift from hover-state transforms.
+- [x] [Improved] 🧭 Blog article opens now keep a clearer shared transition on browsers that support basic View Transitions but not the newer nested grouping APIs, including Safari-friendly fallback behavior.
 - [ ] [Internal] 🧭 Audited the merged GH-109 blog transition files, restored the stable card and hero image frames, and revalidated the merged flow with build, tests, and browser checks.
+- [ ] [Internal] 🧪 Split the blog transition support checks between base shared-element support and richer nested/class support so unsupported browsers can fall back cleanly instead of losing the effect.

--- a/pages/BlogPage.tsx
+++ b/pages/BlogPage.tsx
@@ -15,6 +15,7 @@ import { AppLanguage } from '../types';
 import {
     BLOG_VIEW_TRANSITION_CLASSES,
     createBlogTransitionNavigationState,
+    getBlogTransitionStyle,
     getBlogTransitionNavigationState,
     getPendingBlogTransitionTarget,
     getBlogPostViewTransitionNames,
@@ -52,17 +53,6 @@ const ensureBlogPostRouteModule = (): Promise<unknown> => {
     }
     return blogPostRouteModulePromise;
 };
-
-const getBlogTransitionStyle = (
-    transitionName: string,
-    transitionClass: string,
-    transitionGroup?: string
-): React.CSSProperties =>
-    ({
-        viewTransitionName: transitionName,
-        ['viewTransitionClass' as any]: transitionClass,
-        ...(transitionGroup ? { ['viewTransitionGroup' as any]: transitionGroup } : {}),
-    } as React.CSSProperties);
 
 const BlogCard: React.FC<{
     post: BlogPost;

--- a/pages/BlogPostPage.tsx
+++ b/pages/BlogPostPage.tsx
@@ -25,6 +25,7 @@ import type { Components } from 'react-markdown';
 import {
     BLOG_VIEW_TRANSITION_CLASSES,
     createBlogTransitionNavigationState,
+    getBlogTransitionStyle,
     getBlogPostViewTransitionNames,
     isPendingBlogTransitionTarget,
     isPrimaryUnmodifiedClick,
@@ -58,17 +59,6 @@ const ensureBlogListRouteModule = (): Promise<unknown> => {
     }
     return blogListRouteModulePromise;
 };
-
-const getBlogTransitionStyle = (
-    transitionName: string,
-    transitionClass: string,
-    transitionGroup?: string
-): React.CSSProperties =>
-    ({
-        viewTransitionName: transitionName,
-        ['viewTransitionClass' as any]: transitionClass,
-        ...(transitionGroup ? { ['viewTransitionGroup' as any]: transitionGroup } : {}),
-    } as React.CSSProperties);
 
 const toSlug = (text: string): string =>
     text

--- a/shared/blogViewTransitions.ts
+++ b/shared/blogViewTransitions.ts
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import { buildImageCdnUrl, buildImageSrcSet } from '../utils/imageDelivery';
 
 type BlogViewTransitionPart = 'card' | 'image' | 'title';
@@ -82,6 +83,17 @@ export const BLOG_VIEW_TRANSITION_CLASSES = {
     image: 'blog-image-transition',
     title: 'blog-title-transition',
 } as const;
+
+const supportsCssFeature = (query: string): boolean => {
+    if (typeof window === 'undefined' || typeof window.CSS === 'undefined') return false;
+    if (typeof window.CSS.supports !== 'function') return false;
+
+    try {
+        return window.CSS.supports(query);
+    } catch {
+        return false;
+    }
+};
 
 let pendingBlogTransitionTarget: BlogTransitionTarget | null = null;
 let currentBlogPostTransitionTarget: BlogTransitionTarget | null = null;
@@ -235,7 +247,7 @@ export const markBlogRouteKindSeen = (kind: SeenBlogRouteKind): void => {
 
 export const shouldUseColdBlogTransitionFallbackForKind = (
     kind: SeenBlogRouteKind
-): boolean => !seenBlogRouteKinds.has(kind);
+): boolean => supportsNestedBlogViewTransitionGroups() && !seenBlogRouteKinds.has(kind);
 
 export const setPendingBlogTransitionMode = (
     mode: PendingBlogTransitionMode
@@ -276,6 +288,32 @@ export const supportsBlogViewTransitions = (): boolean => {
     if (typeof window.matchMedia !== 'function') return true;
     return !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 };
+
+const supportsBlogViewTransitionClasses = (): boolean =>
+    supportsBlogViewTransitions() &&
+    supportsCssFeature('view-transition-class: blog-card-transition') &&
+    supportsCssFeature('selector(::view-transition-group(.blog-card-transition))');
+
+const supportsNestedBlogViewTransitionGroups = (): boolean =>
+    supportsBlogViewTransitionClasses() &&
+    supportsCssFeature('view-transition-group: contain') &&
+    supportsCssFeature('view-transition-group: nearest') &&
+    supportsCssFeature('selector(::view-transition-group-children(blog-card-transition))');
+
+export const getBlogTransitionStyle = (
+    transitionName: string,
+    transitionClass?: string,
+    transitionGroup?: string
+): CSSProperties =>
+    ({
+        viewTransitionName: transitionName,
+        ...(transitionClass && supportsBlogViewTransitionClasses()
+            ? { ['viewTransitionClass' as any]: transitionClass }
+            : {}),
+        ...(transitionGroup && supportsNestedBlogViewTransitionGroups()
+            ? { ['viewTransitionGroup' as any]: transitionGroup }
+            : {}),
+    } as CSSProperties);
 
 export const warmResponsiveBlogImage = ({
     src,

--- a/tests/unit/blogViewTransitions.test.ts
+++ b/tests/unit/blogViewTransitions.test.ts
@@ -5,6 +5,7 @@ import {
     BLOG_VIEW_TRANSITION_CLASSES,
     BLOG_VIEW_TRANSITION_DURATION,
     createBlogTransitionNavigationState,
+    getBlogTransitionStyle,
     getBlogRouteKindFromPath,
     getBlogTransitionNavigationState,
     getBlogTransitionStateVersion,
@@ -38,6 +39,7 @@ import {
 let originalStartViewTransition: unknown;
 let originalMatchMedia: typeof window.matchMedia;
 let originalImage: typeof window.Image;
+let originalCss: typeof window.CSS;
 
 const createReducedMotionMediaQueryList = (matches: boolean): MediaQueryList => ({
     matches,
@@ -54,6 +56,7 @@ beforeEach(() => {
     originalStartViewTransition = (document as Document & { startViewTransition?: unknown }).startViewTransition;
     originalMatchMedia = window.matchMedia;
     originalImage = window.Image;
+    originalCss = window.CSS;
 });
 
 afterEach(() => {
@@ -64,11 +67,36 @@ afterEach(() => {
     });
     window.matchMedia = originalMatchMedia;
     window.Image = originalImage;
+    Object.defineProperty(window, 'CSS', {
+        configurable: true,
+        writable: true,
+        value: originalCss,
+    });
     document.body.innerHTML = '';
     setPendingBlogTransitionTarget(null);
     setCurrentBlogPostTransitionTarget(null);
     resetBlogTransitionWarmStateForTests();
 });
+
+const mockCssSupports = (supportedQueries: string[] | null): void => {
+    if (!supportedQueries) {
+        Object.defineProperty(window, 'CSS', {
+            configurable: true,
+            writable: true,
+            value: undefined,
+        });
+        return;
+    }
+
+    const supported = new Set(supportedQueries);
+    Object.defineProperty(window, 'CSS', {
+        configurable: true,
+        writable: true,
+        value: {
+            supports: vi.fn((query: string) => supported.has(query)),
+        },
+    });
+};
 
 describe('shared/blogViewTransitions', () => {
     it('creates stable view transition names with language + slug tokens', () => {
@@ -241,6 +269,54 @@ describe('shared/blogViewTransitions', () => {
         expect(supportsBlogViewTransitions()).toBe(false);
     });
 
+    it('degrades transition styles and cold-start fallback when only the base API is available', () => {
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            writable: true,
+            value: vi.fn(),
+        });
+        window.matchMedia = vi.fn().mockReturnValue(createReducedMotionMediaQueryList(false)) as unknown as typeof window.matchMedia;
+
+        mockCssSupports([
+            'view-transition-class: blog-card-transition',
+            'selector(::view-transition-group(.blog-card-transition))',
+        ]);
+        expect(supportsBlogViewTransitions()).toBe(true);
+        expect(getBlogTransitionStyle('blog-post-card-en-weekend-getaway', BLOG_VIEW_TRANSITION_CLASSES.card, 'contain')).toEqual({
+            viewTransitionName: 'blog-post-card-en-weekend-getaway',
+            viewTransitionClass: BLOG_VIEW_TRANSITION_CLASSES.card,
+        });
+        expect(shouldUseColdBlogTransitionFallbackForKind('post')).toBe(false);
+
+        mockCssSupports([
+            'view-transition-class: blog-card-transition',
+            'selector(::view-transition-group(.blog-card-transition))',
+            'view-transition-group: contain',
+            'view-transition-group: nearest',
+            'selector(::view-transition-group-children(blog-card-transition))',
+        ]);
+        expect(getBlogTransitionStyle('blog-post-image-en-weekend-getaway', BLOG_VIEW_TRANSITION_CLASSES.image, 'nearest')).toEqual({
+            viewTransitionName: 'blog-post-image-en-weekend-getaway',
+            viewTransitionClass: BLOG_VIEW_TRANSITION_CLASSES.image,
+            viewTransitionGroup: 'nearest',
+        });
+        expect(shouldUseColdBlogTransitionFallbackForKind('post')).toBe(true);
+    });
+
+    it('builds transition styles that degrade cleanly when transition CSS features are unavailable', () => {
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            writable: true,
+            value: vi.fn(),
+        });
+        window.matchMedia = vi.fn().mockReturnValue(createReducedMotionMediaQueryList(false)) as unknown as typeof window.matchMedia;
+
+        mockCssSupports(null);
+        expect(getBlogTransitionStyle('blog-post-title-en-weekend-getaway', BLOG_VIEW_TRANSITION_CLASSES.title, 'nearest')).toEqual({
+            viewTransitionName: 'blog-post-title-en-weekend-getaway',
+        });
+    });
+
     it('warms responsive blog images once per image configuration', () => {
         const uniqueSrc = `/images/blog/japan-card-${Math.random().toString(36).slice(2)}.webp`;
         const createdImages: Array<{
@@ -290,6 +366,20 @@ describe('shared/blogViewTransitions', () => {
     });
 
     it('falls back to title-only transitions when the destination blog route kind has not been seen yet', () => {
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            writable: true,
+            value: vi.fn(),
+        });
+        window.matchMedia = vi.fn().mockReturnValue(createReducedMotionMediaQueryList(false)) as unknown as typeof window.matchMedia;
+        mockCssSupports([
+            'view-transition-class: blog-card-transition',
+            'selector(::view-transition-group(.blog-card-transition))',
+            'view-transition-group: contain',
+            'view-transition-group: nearest',
+            'selector(::view-transition-group-children(blog-card-transition))',
+        ]);
+
         expect(shouldUseColdBlogTransitionFallbackForKind('list')).toBe(true);
         expect(shouldUseColdBlogTransitionFallbackForKind('post')).toBe(true);
 
@@ -304,6 +394,22 @@ describe('shared/blogViewTransitions', () => {
 
         setPendingBlogTransitionTarget(null);
         expect(shouldUseTitleOnlyBlogTransition('en', 'best-time-visit-japan')).toBe(false);
+    });
+
+    it('skips the title-only cold fallback when nested groups are unavailable', () => {
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            writable: true,
+            value: vi.fn(),
+        });
+        window.matchMedia = vi.fn().mockReturnValue(createReducedMotionMediaQueryList(false)) as unknown as typeof window.matchMedia;
+        mockCssSupports([
+            'view-transition-class: blog-card-transition',
+            'selector(::view-transition-group(.blog-card-transition))',
+        ]);
+
+        expect(shouldUseColdBlogTransitionFallbackForKind('list')).toBe(false);
+        expect(shouldUseColdBlogTransitionFallbackForKind('post')).toBe(false);
     });
 
     it('starts a view transition with typed options when supported and falls back otherwise', async () => {


### PR DESCRIPTION
## Summary
- make blog view transition styling capability-aware so partial-support browsers like Safari use the simpler shared-element path instead of the nested-only path
- centralize blog transition style assignment in the shared helper used by both blog list and post pages
- add regression coverage for partial CSS feature support and cold-start fallback behavior
- update the draft release note with the Safari-friendly fallback change

## Verification
- pnpm test:core
- pnpm updates:validate
- pnpm dlx react-doctor@latest . --verbose --diff
