### PR TITLE
Publish worker health and map reset release note

### DIFF
--- a/content/updates/2026-03-10-worker-health-tooltips-and-map-reset.md
+++ b/content/updates/2026-03-10-worker-health-tooltips-and-map-reset.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-03-10-worker-health-tooltips-and-map-reset
-version: v0.0.0
+version: v0.90.0
 title: "Worker health is easier to read and new trips open with a clean map"
 date: 2026-03-10
-published_at: 2026-03-10T20:30:00Z
-status: draft
+published_at: 2026-03-10T19:46:31Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Clarified async worker health signals in admin and reset the planner map when opening a different trip so stale routes and pins do not leak across trips."


### PR DESCRIPTION
## Summary
- publish the worker health and map reset release note after merge to main
- assign version v0.90.0
- set the published timestamp to the actual merge time for #274

## Testing
- pnpm updates:validate
