### PR TITLE
perf: suppress idle warmups on critical first-load paths

### DIFF
--- a/LIGHTHOUSE.md
+++ b/LIGHTHOUSE.md
@@ -1,0 +1,34 @@
+# Lighthouse Shared Plan
+
+Last updated: 2026-03-11
+Owner: Codex automation (`lighthouse-test`)
+
+## Threshold
+- Mobile Lighthouse Performance score target: `>= 90` on key entry pages.
+
+## Entry Page Status (latest recorded baselines in repo)
+| Page | Route | Latest recorded score | Recorded at | Threshold status |
+| --- | --- | --- | --- | --- |
+| Homepage | `/` | `95` | 2026-02-21 (`docs/PERFORMANCE_EXECUTION_TODO.md`) | Pass |
+| Create Trip | `/create-trip` | `92` | 2026-02-21 (`docs/PERFORMANCE_EXECUTION_TODO.md`) | Pass |
+| Trip | `/trip/<compressed-state>` | `93` | 2026-02-21 (`docs/PERFORMANCE_EXECUTION_TODO.md`) | Pass |
+| Example | `/example/thailand-islands` | `95` | 2026-02-21 (`docs/PERFORMANCE_EXECUTION_TODO.md`) | Pass |
+
+## Run Notes (2026-03-11)
+- Fresh Lighthouse runs are currently blocked in this sandbox:
+  - `lighthouse` is not installed locally.
+  - npm/pnpm install attempts fail with `ENOTFOUND registry.npmjs.org`.
+- Automation fallback for this run: compare thresholds against latest committed baselines and ship a low-risk perf guard.
+
+## Quick Wins Shipped This Run
+- [x] Skip idle route warmups while first-load-critical suppression is active (`/`, `/create-trip`, `/trip`, `/example`) to avoid extra chunk fetches during first paint/Lighthouse window.
+- [x] Added regression coverage to lock this behavior in `tests/browser/navigation/navigationPrefetchManager.browser.test.ts`.
+
+## Next Todo
+- [ ] Re-run fresh mobile Lighthouse once CLI/network is available for:
+  - `/`
+  - `/create-trip`
+  - `/trip/<compressed-state>`
+  - `/example/thailand-islands`
+- [ ] Capture JSON reports under `tmp/perf/` with timestamped filenames.
+- [ ] Update this table with fresh scores and add a short delta note versus 2026-02-21 baselines.

--- a/components/NavigationPrefetchManager.tsx
+++ b/components/NavigationPrefetchManager.tsx
@@ -233,10 +233,11 @@ export const NavigationPrefetchManager: React.FC<NavigationPrefetchManagerProps>
 
     useEffect(() => {
         if (!isPrefetchActive) return;
+        if (shouldSuppressPassiveWarmups) return;
         const extraCandidates = collectIdleCandidatesForPath(location.pathname);
         scheduleIdleWarmups(location.pathname, extraCandidates);
         publishPrefetchStats();
-    }, [isPrefetchActive, location.pathname]);
+    }, [isPrefetchActive, location.pathname, shouldSuppressPassiveWarmups]);
 
     return null;
 };

--- a/content/updates/2026-03-10-homepage-pagespeed-pass.md
+++ b/content/updates/2026-03-10-homepage-pagespeed-pass.md
@@ -14,3 +14,4 @@ summary: "Reduced homepage transfer weight by sending the hero artwork and examp
 - [x] [Improved] 🛫 The homepage hero now loads its decorative airplane artwork in production-friendly responsive formats, cutting the first desktop payload without changing the layout.
 - [x] [Improved] 🗺️ Example trip previews on the homepage now use optimized production image delivery instead of full-size source images, so the examples section is much lighter when it appears.
 - [ ] [Internal] 📊 Captured before-and-after homepage Lighthouse baselines for desktop and mobile so follow-up chunk work can target the remaining shared JavaScript cost with real measurements.
+- [ ] [Internal] 🧯 Added a guard that suppresses idle route warmups during first-load-critical handoff so homepage Lighthouse runs avoid non-essential prefetch work in the first render window.

--- a/tests/browser/navigation/navigationPrefetchManager.browser.test.ts
+++ b/tests/browser/navigation/navigationPrefetchManager.browser.test.ts
@@ -87,6 +87,13 @@ describe('components/NavigationPrefetchManager', () => {
     expect(mocks.scheduleHoverIntentWarmup).not.toHaveBeenCalled();
   });
 
+  it('suppresses idle warmups on first-load-critical homepage visits until route handoff completes', () => {
+    renderAtPath('/');
+
+    expect(mocks.scheduleIdleWarmups).not.toHaveBeenCalled();
+    expect(mocks.publishPrefetchStats).not.toHaveBeenCalled();
+  });
+
   it('re-enables passive hover warmups on critical routes after the initial handoff completes', () => {
     marketingRouteShellStateMocks.hasCompletedInitialRouteHandoff.mockReturnValue(true);
 
@@ -95,5 +102,14 @@ describe('components/NavigationPrefetchManager', () => {
     fireEvent.pointerEnter(screen.getByRole('link', { name: 'Pricing' }));
 
     expect(mocks.scheduleHoverIntentWarmup).toHaveBeenCalled();
+  });
+
+  it('re-enables idle warmups on critical routes after the initial handoff completes', () => {
+    marketingRouteShellStateMocks.hasCompletedInitialRouteHandoff.mockReturnValue(true);
+
+    renderAtPath('/');
+
+    expect(mocks.scheduleIdleWarmups).toHaveBeenCalledWith('/', []);
+    expect(mocks.publishPrefetchStats).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- suppress idle warmups while first-load-critical route handoff is still in progress
- keep pointer/touch intent warmups active so navigation prewarm behavior remains responsive
- add regression coverage for idle warmup suppression + re-enable behavior after handoff
- add/update Lighthouse shared tracking notes in `LIGHTHOUSE.md`

## Why
This avoids non-essential background prefetch work during the first render window on key entry pages (`/`, `/create-trip`, `/trip`, `/example`), which is a low-risk pagespeed optimization and keeps Lighthouse startup cleaner.

## Validation
- `pnpm vitest run tests/browser/navigation/navigationPrefetchManager.browser.test.ts`
- `pnpm updates:validate`
