### PR TITLE
Polish public profile loading and trip route shell

### DIFF
--- a/app/routes/DeferredAppRoutes.tsx
+++ b/app/routes/DeferredAppRoutes.tsx
@@ -7,6 +7,8 @@ import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '../../config/locales';
 import { loadLazyComponentWithRecovery } from '../../services/lazyImportRecovery';
 import { MarketingRouteLoadingShell } from '../../components/bootstrap/MarketingRouteLoadingShell';
 import { MarketingHomePage } from '../../pages/MarketingHomePage';
+import { PublicProfilePage } from '../../pages/PublicProfilePage';
+import { PublicProfileStampsPage } from '../../pages/PublicProfileStampsPage';
 import '../../styles/deferred-routes.css';
 import { suspendUntilAuthBootstrapSettles } from '../../services/authBootstrapSuspense';
 import { markInitialRouteHandoffCompleted } from '../../services/marketingRouteShellState';
@@ -36,8 +38,6 @@ const TermsPage = lazyWithRecovery('TermsPage', () => import('../../pages/TermsP
 const CookiesPage = lazyWithRecovery('CookiesPage', () => import('../../pages/CookiesPage').then((module) => ({ default: module.CookiesPage })));
 const ProfilePage = lazyWithRecovery('ProfilePage', () => import('../../pages/ProfilePage').then((module) => ({ default: module.ProfilePage })));
 const ProfileStampsPage = lazyWithRecovery('ProfileStampsPage', () => import('../../pages/ProfileStampsPage').then((module) => ({ default: module.ProfileStampsPage })));
-const PublicProfilePage = lazyWithRecovery('PublicProfilePage', () => import('../../pages/PublicProfilePage').then((module) => ({ default: module.PublicProfilePage })));
-const PublicProfileStampsPage = lazyWithRecovery('PublicProfileStampsPage', () => import('../../pages/PublicProfileStampsPage').then((module) => ({ default: module.PublicProfileStampsPage })));
 const ProfileSettingsPage = lazyWithRecovery('ProfileSettingsPage', () => import('../../pages/ProfileSettingsPage').then((module) => ({ default: module.ProfileSettingsPage })));
 const ProfileOnboardingPage = lazyWithRecovery('ProfileOnboardingPage', () => import('../../pages/ProfileOnboardingPage').then((module) => ({ default: module.ProfileOnboardingPage })));
 const CheckoutPage = lazyWithRecovery('CheckoutPage', () => import('../../pages/CheckoutPage').then((module) => ({ default: module.CheckoutPage })));

--- a/components/bootstrap/AppBootstrapShell.tsx
+++ b/components/bootstrap/AppBootstrapShell.tsx
@@ -34,64 +34,91 @@ export const AppBootstrapShell: React.FC<AppBootstrapShellProps> = ({
     data-tf-handoff-ready={handoffReady ? 'true' : undefined}
     aria-hidden="true"
   >
-    <header className="tf-boot-header">
-      <div className="tf-boot-header-inner">
-        <div className="tf-boot-brand">
-          <span className="tf-boot-logo-frame">
-            <img className="tf-boot-logo-image" src="/favicon.svg" alt="" />
-          </span>
-          <span className="tf-boot-wordmark">TravelFlow</span>
+    {variant === 'trip' ? (
+      <header className="tf-boot-trip-header tf-boot-header--trip">
+        <div className="tf-boot-trip-header-inner">
+          <div className="tf-boot-trip-header-start">
+            <div className="tf-boot-trip-brand">
+              <span className="tf-boot-logo-frame">
+                <img className="tf-boot-logo-image" src="/brand-plane.svg" alt="" />
+              </span>
+              <span className="tf-boot-wordmark">TravelFlow</span>
+            </div>
+            <div className="tf-boot-trip-divider" aria-hidden="true" />
+            <div className="tf-boot-trip-copy" aria-hidden="true">
+              <div className="tf-boot-line tf-boot-line--trip-title" />
+              <div className="tf-boot-line tf-boot-line--trip-meta" />
+            </div>
+          </div>
+          <div className="tf-boot-trip-header-actions" aria-hidden="true">
+            <span className="tf-boot-trip-action-pill" />
+            <span className="tf-boot-trip-action-square" />
+            <span className="tf-boot-trip-action-square" />
+            <span className="tf-boot-trip-action-square" />
+            <span className="tf-boot-trip-action-primary" />
+          </div>
         </div>
-        <nav className="tf-boot-nav" aria-hidden="true">
-          {chromeMode === 'skeleton' ? (
-            <>
-              <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--features"></span></span>
-              <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--inspirations"></span></span>
-              <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--updates"></span></span>
-              <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--blog"></span></span>
-              <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--pricing"></span></span>
-            </>
-          ) : chromeMode === 'ghost' ? (
-            <>
-              <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--features"></span></span>
-              <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--inspirations"></span></span>
-              <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--updates"></span></span>
-              <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--blog"></span></span>
-              <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--pricing"></span></span>
-            </>
-          ) : null}
-        </nav>
-        <div className="tf-boot-actions">
-          {chromeMode === 'skeleton' ? (
-            <>
-              <span className="tf-boot-action-chip tf-boot-action-chip--locale">
-                <span className="tf-boot-control-flag" aria-hidden="true"></span>
-                <span className="tf-boot-control-skeleton tf-boot-control-skeleton--locale"></span>
-              </span>
-              <span className="tf-boot-action-chip tf-boot-action-chip--login">
-                <span className="tf-boot-control-skeleton tf-boot-control-skeleton--login"></span>
-              </span>
-              <span className="tf-boot-action-button">
-                <span className="tf-boot-control-skeleton tf-boot-control-skeleton--cta"></span>
-              </span>
-            </>
-          ) : chromeMode === 'ghost' ? (
-            <>
-              <span className="tf-boot-action-chip tf-boot-action-chip--locale tf-boot-action-chip--ghost" />
-              <span className="tf-boot-action-chip tf-boot-action-chip--login tf-boot-action-chip--ghost" />
-              <span className="tf-boot-action-button tf-boot-action-button--ghost" />
-            </>
-          ) : null}
-          <span className="tf-boot-action-burger" aria-hidden="true">
-            <svg className="tf-boot-action-burger-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
-              <path d="M4 7h16" />
-              <path d="M4 12h16" />
-              <path d="M4 17h16" />
-            </svg>
-          </span>
+      </header>
+    ) : (
+      <header className="tf-boot-header tf-boot-header--marketing">
+        <div className="tf-boot-header-inner">
+          <div className="tf-boot-brand">
+            <span className="tf-boot-logo-frame">
+              <img className="tf-boot-logo-image" src="/brand-plane.svg" alt="" />
+            </span>
+            <span className="tf-boot-wordmark">TravelFlow</span>
+          </div>
+          <nav className="tf-boot-nav" aria-hidden="true">
+            {chromeMode === 'skeleton' ? (
+              <>
+                <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--features"></span></span>
+                <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--inspirations"></span></span>
+                <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--updates"></span></span>
+                <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--blog"></span></span>
+                <span className="tf-boot-nav-link"><span className="tf-boot-nav-skeleton tf-boot-nav-skeleton--pricing"></span></span>
+              </>
+            ) : chromeMode === 'ghost' ? (
+              <>
+                <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--features"></span></span>
+                <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--inspirations"></span></span>
+                <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--updates"></span></span>
+                <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--blog"></span></span>
+                <span className="tf-boot-nav-link tf-boot-nav-link--ghost"><span className="tf-boot-nav-ghost tf-boot-nav-ghost--pricing"></span></span>
+              </>
+            ) : null}
+          </nav>
+          <div className="tf-boot-actions">
+            {chromeMode === 'skeleton' ? (
+              <>
+                <span className="tf-boot-action-chip tf-boot-action-chip--locale">
+                  <span className="tf-boot-control-flag" aria-hidden="true"></span>
+                  <span className="tf-boot-control-skeleton tf-boot-control-skeleton--locale"></span>
+                </span>
+                <span className="tf-boot-action-chip tf-boot-action-chip--login">
+                  <span className="tf-boot-control-skeleton tf-boot-control-skeleton--login"></span>
+                </span>
+                <span className="tf-boot-action-button">
+                  <span className="tf-boot-control-skeleton tf-boot-control-skeleton--cta"></span>
+                </span>
+              </>
+            ) : chromeMode === 'ghost' ? (
+              <>
+                <span className="tf-boot-action-chip tf-boot-action-chip--locale tf-boot-action-chip--ghost" />
+                <span className="tf-boot-action-chip tf-boot-action-chip--login tf-boot-action-chip--ghost" />
+                <span className="tf-boot-action-button tf-boot-action-button--ghost" />
+              </>
+            ) : null}
+            <span className="tf-boot-action-burger" aria-hidden="true">
+              <svg className="tf-boot-action-burger-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
+                <path d="M4 7h16" />
+                <path d="M4 12h16" />
+                <path d="M4 17h16" />
+              </svg>
+            </span>
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
+    )}
     {variant === 'trip' ? (
       <main className="tf-boot-main">
         <section className="tf-boot-page tf-boot-page--trip tf-boot-page--trip-react">

--- a/content/updates/2026-03-07-bootstrap-shell-handoff.md
+++ b/content/updates/2026-03-07-bootstrap-shell-handoff.md
@@ -22,9 +22,13 @@ summary: "Kept the branded header visible through the React handoff and removed 
 - [x] [Fixed] 🪄 Switching between the homepage, create-trip, and other marketing pages now keeps the current page visible until the next route is ready, removing the short loading-shell blink on cold clicks.
 - [x] [Fixed] 👤 Signed-in navigation now keeps the account trigger short as “Profile” instead of swapping to usernames or email addresses.
 - [x] [Fixed] 🌐 Switching a translated page back to English now sticks on the first try instead of snapping back to the previous locale during the route handoff.
+- [x] [Fixed] 🛂 Public traveler pages now open straight into the real page chrome instead of a mismatched loading skeleton, so missing handles feel faster and cleaner to resolve.
+- [x] [Improved] 🧳 Trip loading now mirrors the live planner header more closely, reducing the visual jump before the itinerary workspace is ready.
 - [ ] [Internal] 🧱 Replaced the marketing route fallback with the real React site header and matching brand icon so the bootstrap handoff no longer jumps between different header layouts.
 - [ ] [Internal] 🛠️ Fixed the bootstrap container markup so removing the pre-hydration shell no longer tears down the React root during the handoff.
 - [ ] [Internal] ⏱️ Moved the bootstrap handoff trigger to the actual resolved route content for marketing and create-trip flows, so the static shell stays in place until the real page is ready to replace it.
+- [ ] [Internal] 🚪 Moved the public traveler routes onto the eager deferred path so direct visits no longer suspend into the generic marketing shell before the actual profile state resolves.
+- [ ] [Internal] 🎛️ Replaced the public-profile shimmer placeholders with a neutral hold state and synced the React trip fallback header to the planner shell markup already shipped in `index.html`.
 - [ ] [Internal] 🚀 Started route-aware chunk preloading before React mounts and moved the homepage route module into the eager path to reduce direct-entry latency without adding more fake skeleton UI.
 - [ ] [Internal] 🎛️ Matched the React route fallback to the static bootstrap shell with disabled-looking controls, skeleton nav bars, and a single-logo treatment so the header no longer flips between different visual states during first load.
 - [ ] [Internal] 🧵 Swapped protected-route auth loading from direct shell rendering to suspense-driven handoff so router transitions can keep the current screen visible until auth settles.

--- a/pages/PublicProfilePage.tsx
+++ b/pages/PublicProfilePage.tsx
@@ -370,20 +370,11 @@ export const PublicProfilePage: React.FC = () => {
             <SiteHeader />
             <main className="mx-auto w-full max-w-7xl flex-1 space-y-8 px-5 pb-14 pt-12 md:px-8 md:pt-14">
                 {state.status === 'loading' && (
-                    <>
-                        <section className="rounded-2xl border border-slate-200 bg-white px-5 py-8">
-                            <div className="animate-pulse space-y-4">
-                                <div className="h-8 w-1/3 rounded bg-slate-200" />
-                                <div className="h-4 w-2/3 rounded bg-slate-100" />
-                                <div className="h-4 w-1/2 rounded bg-slate-100" />
-                            </div>
-                        </section>
-                        <section className="grid grid-cols-2 gap-4 xl:grid-cols-3" aria-hidden="true">
-                            {Array.from({ length: 3 }).map((_, index) => (
-                                <ProfileTripCardSkeleton key={`public-profile-loading-skeleton-${index}`} />
-                            ))}
-                        </section>
-                    </>
+                    <section
+                        data-testid="public-profile-loading-placeholder"
+                        className="min-h-[62vh]"
+                        aria-hidden="true"
+                    />
                 )}
 
                 {state.status === 'private' && (

--- a/tests/browser/publicProfilePage.browser.test.ts
+++ b/tests/browser/publicProfilePage.browser.test.ts
@@ -331,6 +331,16 @@ describe('pages/PublicProfilePage', () => {
     ).toBe('noindex, nofollow');
   });
 
+  it('keeps the public profile loading state visually neutral while the handle lookup is pending', () => {
+    mocks.resolvePublicProfileByHandle.mockImplementation(() => new Promise(() => {}));
+
+    const view = renderPublicProfilePage('/u/unknown-handle');
+
+    expect(screen.getByTestId('public-profile-loading-placeholder')).toBeInTheDocument();
+    expect(view.container.querySelector('.animate-pulse')).toBeNull();
+    expect(screen.queryByText('publicProfile.notFoundInvalidPassportTitle')).toBeNull();
+  });
+
   it('shows the same public CTAs for authenticated users on not found state', async () => {
     mocks.resolvePublicProfileByHandle.mockResolvedValue({
       status: 'not_found',

--- a/tests/browser/routes/appRoutes.browser.test.ts
+++ b/tests/browser/routes/appRoutes.browser.test.ts
@@ -47,7 +47,11 @@ describe('app/routes/AppRoutes suspense fallbacks', () => {
       )
     );
 
-    expect(view.getByTestId('trip-route-loading-shell')).toHaveAttribute('data-shell-state', 'loadingTrip');
+    const shell = view.getByTestId('trip-route-loading-shell');
+    expect(shell).toHaveAttribute('data-shell-state', 'loadingTrip');
+    expect(shell.querySelector('.tf-boot-trip-header')).toBeTruthy();
+    expect(shell.querySelector('.tf-boot-trip-action-primary')).toBeTruthy();
+    expect(shell.querySelector('.tf-boot-nav')).toBeNull();
     expect(view.container.querySelector('.min-h-screen.w-full.bg-white')).toBeNull();
     view.unmount();
   });

--- a/tests/browser/routes/deferredAppRoutes.browser.test.ts
+++ b/tests/browser/routes/deferredAppRoutes.browser.test.ts
@@ -123,12 +123,36 @@ describe('app/routes/DeferredAppRoutes root auth gate', () => {
     });
   });
 
+  it('keeps public profile routes eager even when their old lazy key is marked pending', async () => {
+    mocks.pendingModules.add('PublicProfilePage');
+
+    const { getByTestId, queryByTestId } = renderDeferredRoutes('/u/traveler');
+
+    await waitFor(() => {
+      expect(getByTestId('mock-public-profile-page')).toBeInTheDocument();
+    });
+    expect(getByTestId('location-probe').textContent).toBe('/u/traveler');
+    expect(queryByTestId('route-loading-shell')).toBeNull();
+  });
+
   it('supports public profile stamps routes', async () => {
     const { getByTestId } = renderDeferredRoutes('/u/traveler/stamps');
 
     await waitFor(() => {
       expect(getByTestId('location-probe').textContent).toBe('/u/traveler/stamps');
     });
+  });
+
+  it('keeps public profile stamps routes eager even when their old lazy key is marked pending', async () => {
+    mocks.pendingModules.add('PublicProfileStampsPage');
+
+    const { getByTestId, queryByTestId } = renderDeferredRoutes('/u/traveler/stamps');
+
+    await waitFor(() => {
+      expect(getByTestId('mock-public-profile-stamps-page')).toBeInTheDocument();
+    });
+    expect(getByTestId('location-probe').textContent).toBe('/u/traveler/stamps');
+    expect(queryByTestId('route-loading-shell')).toBeNull();
   });
 
   it('supports profile stamps route for authenticated users', async () => {


### PR DESCRIPTION
## Summary
- make public profile routes eager so direct `/u/*` visits no longer suspend into the generic marketing shell
- replace the public profile shimmer skeleton with a neutral hold state while the handle resolves
- align the trip route loading shell with the live planner header so the transition feels closer to the real trip page

## Testing
- `pnpm test:core`
- `pnpm updates:validate`
- `pnpm dlx react-doctor@latest . --verbose --diff`
