### PR TITLE
fix: polish trip view controls and modal styling

### DIFF
--- a/components/ItineraryMap.tsx
+++ b/components/ItineraryMap.tsx
@@ -3001,14 +3001,16 @@ export const ItineraryMap: React.FC<ItineraryMapProps> = ({
                         </button>
                     )}
                     {showLayoutControls && onLayoutChange && (
-                        <div className="inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur">
+                        <div className="inline-flex flex-col items-center gap-1 rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur">
                             <button
+                                type="button"
                                 onClick={() => onLayoutChange('vertical')}
                                 className={`rounded-md p-2 transition-colors ${layoutMode === 'vertical' ? 'bg-accent-600 text-white' : 'text-gray-600 hover:bg-gray-100 hover:text-accent-600'}`} aria-label="Vertical layout"
                                 aria-pressed={layoutMode === 'vertical'}
                                 {...getAnalyticsDebugAttributes('trip_view__layout_direction--vertical', { surface: 'map_controls' })}
                             ><ArrowUpDown size={18} /></button>
                             <button
+                                type="button"
                                 onClick={() => onLayoutChange('horizontal')}
                                 className={`rounded-md p-2 transition-colors ${layoutMode === 'horizontal' ? 'bg-accent-600 text-white' : 'text-gray-600 hover:bg-gray-100 hover:text-accent-600'}`} aria-label="Horizontal layout"
                                 aria-pressed={layoutMode === 'horizontal'}

--- a/components/TripInfoModal.tsx
+++ b/components/TripInfoModal.tsx
@@ -125,10 +125,12 @@ interface SummaryCardProps {
     wide?: boolean;
 }
 
-const modalInputClassName = 'w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:ring-2 focus:ring-accent-500';
-const modalSecondaryButtonClassName = 'inline-flex items-center justify-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
-const modalPrimaryButtonClassName = 'inline-flex items-center justify-center gap-2 rounded-xl bg-accent-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-accent-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
-const tabClassName = 'relative -mb-px flex-none rounded-none border-b-2 border-transparent px-0 py-3 text-sm font-semibold text-slate-500 transition-colors hover:text-slate-900 data-[state=active]:border-accent-600 data-[state=active]:text-accent-700 data-[state=active]:after:opacity-0 data-[state=active]:[&_svg]:text-accent-600 [&_svg]:text-slate-400';
+const modalInputClassName = 'h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 shadow-sm transition-colors placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+const modalSecondaryButtonClassName = 'inline-flex h-11 items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-700 shadow-sm transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+const modalPrimaryButtonClassName = 'inline-flex h-11 items-center justify-center gap-2 rounded-md bg-accent-600 px-4 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+const modalSectionClassName = 'space-y-4 border-t border-slate-200 pt-6';
+const modalSubtlePanelClassName = 'rounded-md bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-600';
+const tabClassName = 'relative flex-none gap-2 px-0 text-sm font-semibold text-slate-500 transition-colors hover:text-slate-900 data-[state=active]:bg-transparent data-[state=active]:text-accent-700 data-[state=active]:[&_svg]:text-accent-600 [&_svg]:text-slate-400';
 
 const SummaryCard: React.FC<SummaryCardProps> = ({ label, value, wide = false }) => (
     <div className={`space-y-1 ${wide ? 'sm:col-span-2' : ''}`}>
@@ -152,7 +154,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
     onAction,
     actionAttributes,
 }) => (
-    <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0 flex-1">
             <h4 className="text-sm font-semibold text-slate-900">{title}</h4>
             <p className="mt-1 text-sm leading-6 text-slate-600">{description}</p>
@@ -391,8 +393,8 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                 </div>
 
                 <div className="min-h-0 flex-1 overflow-y-auto p-5">
-                    <TabsContent value="general" className="space-y-4">
-                        <section className="rounded-2xl border border-slate-200 bg-white p-5">
+                    <TabsContent value="general" className="space-y-8">
+                        <section className="space-y-4">
                             <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                                 <div className="min-w-0 flex-1">
                                     <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
@@ -430,7 +432,7 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                                             </button>
                                         </div>
                                     ) : (
-                                        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-lg font-bold text-slate-900">
+                                        <div className="flex min-h-11 items-center rounded-md border border-slate-300 bg-white px-3 text-lg font-bold text-slate-900 shadow-sm">
                                             {tripTitle}
                                         </div>
                                     )}
@@ -445,7 +447,7 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                             </div>
                         </section>
 
-                        <section className="rounded-2xl border border-slate-200 bg-white p-5">
+                        <section className={modalSectionClassName}>
                             <div className="mb-3 flex items-center justify-between gap-2">
                                 <h3 className="text-base font-semibold text-slate-900">{t('tripView.infoDialog.general.sections.meta')}</h3>
                                 {generationPill && (
@@ -472,7 +474,7 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                         </section>
 
                         {(aiMeta || generationPill || latestAttempt || recentAttempts.length > 0) && (
-                            <section className="rounded-2xl border border-slate-200 bg-white p-5">
+                            <section className={modalSectionClassName}>
                                 <div className="mb-3 flex items-center gap-2">
                                     <Sparkles size={16} className="text-accent-600" />
                                     <h3 className="text-base font-semibold text-slate-900">{t('tripView.generation.tripInfo.title')}</h3>
@@ -488,9 +490,9 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                                         <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">
                                             {t('tripView.generation.tripInfo.recentAttempts')}
                                         </p>
-                                        <ul className="space-y-2">
+                                        <ul className="divide-y divide-slate-200 border-y border-slate-200">
                                             {recentAttempts.map((attempt) => (
-                                                <li key={attempt.id} className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-600">
+                                                <li key={attempt.id} className="flex flex-wrap items-center justify-between gap-2 py-3 text-sm text-slate-600">
                                                     <span className="font-semibold text-slate-900">{attempt.state}</span>
                                                     <span>{attempt.model || t('tripView.generation.tripInfo.modelFallback')}</span>
                                                     <span>{formatDurationMs(attempt.durationMs)}</span>
@@ -507,7 +509,7 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                                                     {t('tripView.generation.tripInfo.model')}
                                                 </p>
                                                 <Select value={selectedRetryModelId} onValueChange={onRetryModelIdChange}>
-                                                    <SelectTrigger className="h-11 rounded-xl border-slate-300 text-sm">
+                                                    <SelectTrigger className="h-11 rounded-md border-slate-300 text-sm">
                                                         <SelectValue placeholder={t('tripView.generation.tripInfo.modelFallback')} />
                                                     </SelectTrigger>
                                                     <SelectContent>
@@ -564,7 +566,7 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                         )}
 
                         {forkMeta && (
-                            <section className="rounded-2xl border border-accent-100 bg-gradient-to-br from-accent-50 via-white to-white p-5">
+                            <section className={modalSectionClassName}>
                                 <div className="flex items-center gap-2">
                                     <MapPinned size={16} className="text-accent-700" />
                                     <h3 className="text-base font-semibold text-slate-900">{t('tripView.infoDialog.general.sections.source')}</h3>
@@ -588,14 +590,14 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                         )}
                     </TabsContent>
 
-                    <TabsContent value="history" className="space-y-4">
+                    <TabsContent value="history" className="space-y-6">
                         {isExamplePreview ? (
-                            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-600">
+                            <div className={modalSubtlePanelClassName}>
                                 {t('tripView.infoDialog.history.example')}
                             </div>
                         ) : (
                             <>
-                                <section className="flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200 bg-white p-5">
+                                <section className="flex flex-wrap items-center gap-2">
                                     <button
                                         type="button"
                                         onClick={onHistoryUndo}
@@ -620,12 +622,12 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                                 </section>
 
                                 {hasUnsyncedChanges && (
-                                    <section className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-900">
+                                    <section className="rounded-md bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-900">
                                         {failedSyncCount > 0 ? failedSyncLabel : pendingSyncLabel}
                                     </section>
                                 )}
 
-                                <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+                                <section className="overflow-hidden border-y border-slate-200">
                                     {visibleHistoryItems.length === 0 ? (
                                         <div className="p-6 text-sm text-slate-500">{t('tripView.infoDialog.history.empty')}</div>
                                     ) : (
@@ -635,7 +637,7 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                                                 const showUnsyncedBadge = hasUnsyncedChanges && index === 0;
                                                 return (
                                                     <li key={item.id} className={`flex items-start gap-3 p-4 ${item.isCurrent ? 'bg-accent-50/60' : 'bg-white'}`}>
-                                                        <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl ${item.meta.iconClass}`}>
+                                                        <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-md ${item.meta.iconClass}`}>
                                                             <Icon size={16} />
                                                         </div>
                                                         <div className="min-w-0 flex-1">
@@ -675,7 +677,7 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                     </TabsContent>
 
                     <TabsContent value="export" className="space-y-4">
-                        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white divide-y divide-slate-200">
+                        <div className="divide-y divide-slate-200 border-y border-slate-200">
                             <ActionCard
                                 title={t('tripView.infoDialog.export.activities.title')}
                                 description={t('tripView.infoDialog.export.activities.description')}
@@ -706,9 +708,9 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                         </div>
                     </TabsContent>
 
-                    <TabsContent value="destination" className="space-y-4">
+                    <TabsContent value="destination" className="space-y-6">
                         {travelerWarnings.length > 0 && (
-                            <section className="rounded-2xl border border-amber-200 bg-amber-50 p-5">
+                            <section className="rounded-md bg-amber-50 px-4 py-4">
                                 <div className="flex items-center gap-2">
                                     <ShieldAlert size={16} className="text-amber-700" />
                                     <h3 className="text-base font-semibold text-amber-950">{t('tripView.warningSummary.title')}</h3>
@@ -736,21 +738,21 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                             </section>
                         )}
 
-                        <section className="rounded-2xl border border-slate-200 bg-white p-5">
+                        <section className={travelerWarnings.length > 0 ? modalSectionClassName : 'space-y-4'}>
                             {countryInfo ? (
                                 <CountryInfo info={countryInfo} />
                             ) : isPaywallLocked ? (
-                                <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-600">
+                                <div className={modalSubtlePanelClassName}>
                                     {t('tripView.infoDialog.destination.locked')}
                                 </div>
                             ) : (
-                                <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-600">
+                                <div className={modalSubtlePanelClassName}>
                                     {t('tripView.infoDialog.destination.empty')}
                                 </div>
                             )}
                         </section>
 
-                        <section className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-5">
+                        <section className={modalSectionClassName}>
                             <div className="flex items-center gap-2">
                                 <AlertTriangle size={16} className="text-slate-600" />
                                 <h3 className="text-base font-semibold text-slate-900">{t('tripView.infoDialog.destination.futureChecksTitle')}</h3>
@@ -769,8 +771,8 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                     </TabsContent>
 
                     {canShowDebugTab && (
-                        <TabsContent value="debug" className="space-y-4">
-                            <section className="rounded-2xl border border-slate-200 bg-white p-5">
+                        <TabsContent value="debug" className="space-y-8">
+                            <section className="space-y-4">
                                 <h3 className="text-base font-semibold text-slate-900">Admin access</h3>
                                 <dl className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
                                     <SummaryCard label="Owner username" value={adminMeta?.ownerUsername || 'n/a'} />
@@ -780,7 +782,7 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                                 </dl>
                             </section>
 
-                            <section className="rounded-2xl border border-slate-200 bg-white p-5">
+                            <section className={modalSectionClassName}>
                                 <h3 className="text-base font-semibold text-slate-900">AI generation diagnostics</h3>
                                 <dl className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
                                     <SummaryCard label={t('tripView.generation.tripInfo.provider')} value={latestAttempt?.provider || aiMeta?.provider || '—'} />
@@ -797,27 +799,27 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                                 </dl>
                             </section>
 
-                            <section className="rounded-2xl border border-slate-200 bg-white p-5">
+                            <section className={modalSectionClassName}>
                                 <h3 className="text-base font-semibold text-slate-900">Raw payloads</h3>
                                 <div className="mt-4 space-y-4">
                                     {requestPayload && (
-                                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+                                        <div className="space-y-2">
                                             <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">Request payload JSON</p>
-                                            <pre className="mt-2 max-h-72 overflow-auto rounded-xl bg-slate-900 p-3 text-[11px] text-slate-100">
+                                            <pre className="max-h-72 overflow-auto rounded-md bg-slate-900 p-3 text-[11px] text-slate-100">
                                                 {JSON.stringify(requestPayload, null, 2)}
                                             </pre>
                                         </div>
                                     )}
                                     {inputSnapshot && (
-                                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+                                        <div className="space-y-2">
                                             <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">Input snapshot JSON</p>
-                                            <pre className="mt-2 max-h-72 overflow-auto rounded-xl bg-slate-900 p-3 text-[11px] text-slate-100">
+                                            <pre className="max-h-72 overflow-auto rounded-md bg-slate-900 p-3 text-[11px] text-slate-100">
                                                 {JSON.stringify(inputSnapshot, null, 2)}
                                             </pre>
                                         </div>
                                     )}
                                     {!requestPayload && !inputSnapshot && (
-                                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+                                        <div className={modalSubtlePanelClassName}>
                                             No raw request payloads were captured for this trip.
                                         </div>
                                     )}

--- a/components/navigation/AccountMenu.tsx
+++ b/components/navigation/AccountMenu.tsx
@@ -252,7 +252,7 @@ export const AccountMenu: React.FC<AccountMenuProps> = ({
                     trackEvent('navigation__account_menu--toggle', { open: next });
                 }}
                 className={[
-                    'inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 text-sm font-semibold text-slate-700 shadow-sm transition-colors',
+                    'inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 text-sm font-semibold text-slate-700 shadow-sm transition-colors',
                     'hover:border-slate-300 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2',
                     compact ? 'h-9 py-1.5' : 'h-10 py-2',
                     fullWidth ? 'w-full justify-between' : '',

--- a/components/tripview/TripViewHeader.tsx
+++ b/components/tripview/TripViewHeader.tsx
@@ -47,8 +47,8 @@ export const TripViewHeader: React.FC<TripViewHeaderProps> = ({
     isTripLockedByExpiry,
 }) => {
     const { t } = useTranslation('common');
-    const headerSecondaryButtonClassName = 'inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition-colors hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
-    const headerPrimaryButtonClassName = 'inline-flex items-center gap-2 rounded-lg bg-accent-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-accent-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+    const headerSecondaryButtonClassName = 'inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition-colors hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+    const headerPrimaryButtonClassName = 'inline-flex items-center gap-2 rounded-md bg-accent-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-accent-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
     const titleStyle = titleViewTransitionName
         ? ({ viewTransitionName: titleViewTransitionName } as React.CSSProperties)
         : undefined;
@@ -108,6 +108,7 @@ export const TripViewHeader: React.FC<TripViewHeaderProps> = ({
                     className="group flex min-w-0 flex-1 items-start gap-2 rounded-xl px-2 py-1 text-left transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2"
                     aria-label={titleTooltip}
                     data-tooltip={titleTooltip}
+                    data-no-press-scale="true"
                     {...getAnalyticsDebugAttributes('trip_view__trip_info--open', { source: 'header_title' })}
                 >
                     <div className="min-w-0 flex-1">
@@ -174,7 +175,7 @@ export const TripViewHeader: React.FC<TripViewHeaderProps> = ({
                         labelMode="profile"
                         showRecentTripsSection={false}
                         showCurrentPageSummary={false}
-                        triggerClassName="gap-2 rounded-lg px-3 py-2 text-sm font-medium text-slate-700 shadow-sm hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900"
+                        triggerClassName="gap-2 rounded-md px-3 py-2 text-sm font-medium text-slate-700 shadow-sm hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900"
                     />
                 ) : (
                     <button

--- a/components/tripview/TripViewPlannerWorkspace.tsx
+++ b/components/tripview/TripViewPlannerWorkspace.tsx
@@ -65,7 +65,7 @@ interface TripViewPlannerWorkspaceProps {
 
 const TRIP_FLOATING_MAP_PREVIEW_BETA_ENABLED = true;
 const formatZoomLevelLabel = (value: number): string => `×${value.toFixed(1)}`;
-const CONTROL_GROUP_CLASS_NAME = 'inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur';
+const CONTROL_GROUP_CLASS_NAME = 'inline-flex flex-col items-center gap-1 rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur';
 const CONTROL_TOGGLE_BUTTON_CLASS_NAME = 'rounded-md p-2 transition-colors';
 const CONTROL_TOGGLE_ACTIVE_CLASS_NAME = 'border-accent-700 bg-accent-600 text-white';
 const CONTROL_TOGGLE_INACTIVE_CLASS_NAME = 'text-gray-600 hover:bg-gray-100 hover:text-accent-600';

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ const tabsListVariants = cva(
     variants: {
       variant: {
         default: "bg-muted",
-        line: "gap-1 bg-transparent",
+        line: "gap-6 bg-transparent p-0",
       },
     },
     defaultVariants: {
@@ -62,10 +62,10 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/40 focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:h-auto group-data-[variant=line]/tabs-list:flex-none group-data-[variant=line]/tabs-list:rounded-none group-data-[variant=line]/tabs-list:border-0 group-data-[variant=line]/tabs-list:px-0 group-data-[variant=line]/tabs-list:py-3 group-data-[variant=line]/tabs-list:font-semibold group-data-[variant=line]/tabs-list:text-slate-500 group-data-[variant=line]/tabs-list:hover:text-slate-900 group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:text-accent-700 group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
         "data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
-        "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        "after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-1px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:after:bg-accent-600 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
         className
       )}
       {...props}

--- a/content/updates/2026-03-11-trip-page-layout-optimization.md
+++ b/content/updates/2026-03-11-trip-page-layout-optimization.md
@@ -7,7 +7,7 @@ published_at: 2026-03-11T20:47:06Z
 status: published
 notify_in_app: true
 in_app_hours: 24
-summary: "Trip pages now give titles and controls more room, make details easier to open and edit, stabilize map and pane layouts across resize changes, and improve zoom, checklist, and keyboard flow in the planner."
+summary: "Trip pages now give titles and controls more room, make details easier to open and edit, stabilize map and pane layouts across resize changes, and clean up the planner and details dialog so controls feel more consistent again."
 ---
 
 ## Changes
@@ -15,6 +15,8 @@ summary: "Trip pages now give titles and controls more room, make details easier
 - [x] [Improved] 🗂️ Trip details are easier to scan. The larger dialog now separates essentials, history, exports, destination context, and admin diagnostics into clearer sections.
 - [x] [Fixed] 🗺️ The planner holds its shape when you resize. Docked and floating maps recover more reliably, pane handles behave again, and side panels stop fighting for space.
 - [x] [Improved] 🔎 Zooming feels more useful at every scale. Calendar controls use compact 0.2 steps, Fit behaves more reliably, and vertical low-zoom views now show clearer day and month labels.
+- [x] [Polished] 🎛️ Planner controls feel tidier again. Map orientation toggles are grouped in the expected stacked layout, and the title keeps its helpful click behavior without acting like a giant button press.
+- [x] [Polished] 🪟 The trip dialog now feels more like the rest of TravelFlow. Tabs use a cleaner accent underline, inputs and buttons match shared surface styles, and the bulky boxed card treatment is replaced with lighter section spacing.
 - [x] [Improved] ✅ Notes are easier to act on. Checklist items align better, stay interactive in both timeline and details views, and Heads Up tips now stand out as simple alert banners.
 - [x] [Improved] ⌨️ Moving through a trip takes fewer clicks. Active city cards support keyboard navigation, and Enter or Space can open or close the matching details panel.
 - [ ] [Internal] 🧪 Added regression coverage for shared history listeners, speculation-rules cleanup during hot reload, vertical low-zoom date rails, map control grouping, and planner pane behavior.

--- a/index.css
+++ b/index.css
@@ -1145,7 +1145,7 @@ html:active-view-transition-type(blog-collapse)::view-transition-new(.blog-card-
     transition-duration: 150ms;
     transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
   }
-  button:not(:disabled):active {
+  button:not(:disabled):not([data-no-press-scale='true']):active {
     transform: scale(0.97);
   }
 }

--- a/tests/browser/itineraryMapControls.browser.test.ts
+++ b/tests/browser/itineraryMapControls.browser.test.ts
@@ -41,6 +41,7 @@ describe('components/ItineraryMap map controls availability', () => {
     expect(verticalLayoutButton).toBeInTheDocument();
     expect(horizontalLayoutButton).toBeInTheDocument();
     expect(verticalLayoutButton.parentElement).toBe(horizontalLayoutButton.parentElement);
+    expect(verticalLayoutButton.parentElement).toHaveClass('flex-col');
 
     const fitButton = screen.getByLabelText('Fit to itinerary');
     const styleButton = screen.getByLabelText('Map style');

--- a/tests/browser/tripview/TripInfoModal.browser.test.ts
+++ b/tests/browser/tripview/TripInfoModal.browser.test.ts
@@ -129,6 +129,9 @@ describe('components/TripInfoModal', () => {
 
     const titleField = screen.getByRole('textbox', { name: 'Trip title' });
     expect(titleField).toHaveValue('Sample Trip');
+    expect(titleField).toHaveClass('rounded-md');
+    expect(titleField).toHaveClass('h-11');
+    expect(screen.getByRole('button', { name: 'Add to favorites' })).toHaveClass('rounded-md');
 
     const debugTab = screen.getByRole('tab', { name: 'Debug' });
     fireEvent.mouseDown(debugTab, { button: 0 });

--- a/tests/browser/tripview/TripViewHeader.browser.test.ts
+++ b/tests/browser/tripview/TripViewHeader.browser.test.ts
@@ -78,6 +78,7 @@ describe('components/tripview/TripViewHeader', () => {
     );
 
     const titleButton = screen.getByRole('button', { name: 'Open trip details and edit the title' });
+    expect(titleButton).toHaveAttribute('data-no-press-scale', 'true');
     fireEvent.mouseEnter(titleButton);
     fireEvent.click(titleButton);
     fireEvent.click(screen.getByRole('button', { name: 'Trips' }));


### PR DESCRIPTION
## Summary
- restore the map orientation toggle to a stacked vertical group in planner and map surfaces
- opt the clickable trip title out of the global press-scale effect and tighten nav button radii
- flatten the trip details modal so tabs, inputs, and buttons match the shared app styling

## Testing
- pnpm test:core
- pnpm i18n:validate
- pnpm updates:validate
- pnpm dlx react-doctor@latest . --verbose --diff
