### PR TITLE
Fix trip view mobile viewport initialization

### DIFF
--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -1329,6 +1329,10 @@ const useTripViewRender = ({
         if (!isAdminFallbackView || !adminAccess?.ownerId) return null;
         return `/admin/trips?user=${encodeURIComponent(adminAccess.ownerId)}&drawer=user`;
     }, [adminAccess?.ownerId, isAdminFallbackView]);
+    const [isMobileViewport, setIsMobileViewport] = useState(() => {
+        if (typeof window === 'undefined') return false;
+        return window.innerWidth <= MOBILE_VIEWPORT_MAX_WIDTH;
+    });
 
     const paywallActivationMode = useMemo<TripPaywallActivationMode>(
         () => resolveTripPaywallActivationMode({
@@ -1545,11 +1549,6 @@ const useTripViewRender = ({
         [canEdit, location.search]
     );
     const { viewMode, setViewMode } = useTripViewModeState();
-
-    const [isMobileViewport, setIsMobileViewport] = useState(() => {
-        if (typeof window === 'undefined') return false;
-        return window.innerWidth <= MOBILE_VIEWPORT_MAX_WIDTH;
-    });
     const currentUrl = location.pathname + location.search;
     const {
         isHistoryOpen,

--- a/content/updates/2026-03-11-trip-page-layout-optimization.md
+++ b/content/updates/2026-03-11-trip-page-layout-optimization.md
@@ -1,16 +1,17 @@
 ---
 id: rel-2026-03-11-trip-page-layout-optimization
-version: v0.92.2
+version: v0.92.3
 title: "Trip pages feel smoother, clearer, and easier to steer"
 date: 2026-03-11
 published_at: 2026-03-12T06:56:18Z
-status: published
+status: draft
 notify_in_app: true
 in_app_hours: 24
-summary: "Trip pages now feel calmer and more predictable across desktop and mobile, with a lighter profile menu, cleaner trip details editing, better low-zoom calendar readability, and mobile interactions that stay out of the way until you need them."
+summary: "Trip pages now feel calmer and more predictable across desktop and mobile, with a lighter profile menu, cleaner trip details editing, better low-zoom calendar readability, and a runtime fix that keeps the page loading reliably again."
 ---
 
 ## Changes
+- [x] [Fixed] 🛟 Trip pages load reliably again after the latest polish pass. A mobile viewport state regression that could stop the planner from rendering has been resolved.
 - [x] [Improved] 🧭 Trip navigation feels lighter and more focused. The title sits closer to the TravelFlow mark, opens trip details on click, and profile actions now center around Create Trip and My Trips instead of a crowded shortcut list.
 - [x] [Improved] 📱 Mobile trip pages stay calmer while you explore. Account menus layer above planner controls, the profile trigger collapses to the avatar, toast popups stay out of the way, and the details drawer now peeks from the bottom instead of taking over immediately.
 - [x] [Fixed] 🗓️ Low-zoom calendars use space much better. Vertical views now center month labels across the visible span, compact day rails stay readable, and small activity cards in the planner are easier to scan at a glance.
@@ -19,3 +20,4 @@ summary: "Trip pages now feel calmer and more predictable across desktop and mob
 - [x] [Improved] ✅ Notes and checklists are easier to work with. Checklist rows stay aligned, task toggles now hit the correct line in timeline and details views, and Heads Up guidance shows up as simple banner-style callouts.
 - [x] [Improved] ⌨️ Moving through a trip takes fewer clicks. Active city cards support keyboard travel with arrow keys or Tab, and Enter or Space can open or close the matching details panel.
 - [ ] [Internal] 🧪 Added regression coverage for low-zoom month rails, mobile peek drawers, account-menu trip actions, modal title editing, and planner control behavior.
+- [ ] [Internal] 🧷 Added regression coverage to keep mobile viewport state declared before the trip-view callbacks that depend on it.

--- a/tests/unit/tripViewRuntimeOrder.test.ts
+++ b/tests/unit/tripViewRuntimeOrder.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('components/TripView runtime ordering', () => {
+    it('declares viewport state before callbacks that depend on it', () => {
+        const source = readFileSync(
+            resolve(process.cwd(), 'components/TripView.tsx'),
+            'utf8',
+        );
+
+        const viewportStateIndex = source.indexOf('const [isMobileViewport, setIsMobileViewport]');
+        const paywallHandlerIndex = source.indexOf('const handlePaywallActivateClick = useCallback');
+        const pendingAuthHandlerIndex = source.indexOf('const handleResolvePendingAuthGeneration = useCallback');
+
+        expect(viewportStateIndex).toBeGreaterThan(-1);
+        expect(paywallHandlerIndex).toBeGreaterThan(-1);
+        expect(pendingAuthHandlerIndex).toBeGreaterThan(-1);
+        expect(viewportStateIndex).toBeLessThan(paywallHandlerIndex);
+        expect(viewportStateIndex).toBeLessThan(pendingAuthHandlerIndex);
+    });
+});


### PR DESCRIPTION
## Summary
- move `isMobileViewport` state above the callbacks that reference it in `TripView`
- add a regression test that guards the callback ordering which triggered the runtime `ReferenceError`
- keep the trip page release note accurate while this hotfix is in review by marking it back to draft and noting the runtime repair

## Testing
- `pnpm test:core`
- `pnpm updates:validate`
- `pnpm dlx react-doctor@latest . --verbose --diff`
