### PR TITLE
Fix horizontal activity cards and floating map stacking

### DIFF
--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -16,6 +16,7 @@ import { TransportModeIcon } from './TransportModeIcon';
 import { normalizeTransportMode } from '../shared/transportModes';
 import { getExampleCityLaneViewTransitionName } from '../shared/viewTransitionNames';
 import { buildRenderedTimelineDaySlots, buildRenderedTimelineMonths } from './tripview/timelineRenderedSlots';
+import { getTimelineVisualSpan } from '../utils/timelineVisualLayout';
 
 interface TimelineProps {
   trip: ITrip;
@@ -297,16 +298,18 @@ export const Timeline: React.FC<TimelineProps> = ({
 
   // Robust "Packing" algorithm for activities to handle same-day overlapping
   const activityLanes: ITimelineItem[][] = [];
-  activities.sort((a, b) => {
-      // Sort by start time, then by duration (longest first)
-      if (a.startDateOffset === b.startDateOffset) return b.duration - a.duration;
-      return a.startDateOffset - b.startDateOffset;
+  activities.slice().sort((a, b) => {
+      const aSpan = getTimelineVisualSpan(a);
+      const bSpan = getTimelineVisualSpan(b);
+      if (aSpan.startOffset === bSpan.startOffset) return bSpan.duration - aSpan.duration;
+      return aSpan.startOffset - bSpan.startOffset;
   }).forEach(item => {
+    const itemSpan = getTimelineVisualSpan(item);
     let placed = false;
     for (const lane of activityLanes) {
         const lastInLane = lane[lane.length - 1];
-        // Ensure visual gap of at least 0.05 days
-        if (lastInLane.startDateOffset + lastInLane.duration + 0.05 <= item.startDateOffset) {
+        const lastSpan = getTimelineVisualSpan(lastInLane);
+        if (lastSpan.endOffset + 0.05 <= itemSpan.startOffset) {
             lane.push(item);
             placed = true;
             break;
@@ -1072,7 +1075,7 @@ export const Timeline: React.FC<TimelineProps> = ({
                              <div
                                 key={laneIdx}
                                 className={`relative w-full group/lane rounded-lg border border-transparent ${
-                                    useCompactHorizontalActivityCards ? 'h-28' : 'h-20'
+                                    useCompactHorizontalActivityCards ? 'h-36' : 'h-28'
                                 }`}
                              >
                                 {lane.map(item => (

--- a/components/TimelineBlock.tsx
+++ b/components/TimelineBlock.tsx
@@ -5,6 +5,7 @@ import { Maximize, Minimize, ArrowLeftRight, ArrowUpDown } from 'lucide-react';
 import { ActivityTypeIcon } from './ActivityTypeVisuals';
 import { TransportModeIcon } from './TransportModeIcon';
 import { normalizeTransportMode } from '../shared/transportModes';
+import { getTimelineVisualSpan } from '../utils/timelineVisualLayout';
 
 interface TimelineBlockProps {
   item: ITimelineItem;
@@ -71,9 +72,10 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
   const dragStartPos = useRef<{x: number, y: number} | null>(null);
   
   // Visual Dimensions
-  const dimensionCheck = item.duration * pixelsPerDay;
+  const visualSpan = getTimelineVisualSpan(item, { vertical });
+  const dimensionCheck = visualSpan.duration * pixelsPerDay;
   const size = Math.max(dimensionCheck, (isTravel || isEmptyTravel) ? 40 : 20); 
-  const position = (item.startDateOffset - timelineStartOffset) * pixelsPerDay;
+  const position = (visualSpan.startOffset - timelineStartOffset) * pixelsPerDay;
 
   // Buffer calculations (Minutes -> Days -> Pixels)
   const bufferBeforePx = item.bufferBefore ? (item.bufferBefore / 1440) * pixelsPerDay : 0;
@@ -105,7 +107,7 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
   const isCompactVerticalActivity = vertical && item.type === 'activity' && size >= 20 && size < 40;
   const isCompactHorizontalActivity = !vertical && item.type === 'activity' && size < 92;
   const compactVerticalTitleSize = Math.max(9, Math.min(11, size * 0.28));
-  const compactHorizontalTitleSize = Math.max(8, Math.min(10, size * 0.16));
+  const compactHorizontalTitleSize = Math.max(12, Math.min(14, size * 0.16));
   const cityDayCount = isCity ? Math.max(1, Math.ceil(item.duration - 0.01)) : 0;
   const cityNightCount = isCity ? Math.max(0, cityDayCount - 1) : 0;
   const cityDurationFullLabel = `${cityDayCount} ${cityDayCount === 1 ? 'Day' : 'Days'} / ${cityNightCount} ${cityNightCount === 1 ? 'Night' : 'Nights'}`;
@@ -206,8 +208,8 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
   }
 
   if (!vertical && item.type === 'activity') {
-      style.top = isCompactHorizontalActivity ? '10px' : '12px';
-      style.height = isCompactHorizontalActivity ? '78px' : '56px';
+      style.top = '8px';
+      style.height = isCompactHorizontalActivity ? '112px' : '88px';
   }
   const selectedOutline = isSelected
       ? '0 0 0 3px rgb(37 99 235 / 0.98)'
@@ -385,8 +387,8 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
                )
              : (
                 isCity
-                  ? 'justify-center flex-col text-center py-0.5'
-                  : (isCompactHorizontalActivity ? 'justify-center gap-1 flex-col text-center py-1.5' : 'justify-center flex-col text-center')
+                 ? 'justify-center flex-col text-center py-0.5'
+                  : (isCompactHorizontalActivity ? 'justify-start gap-1.5 flex-col text-center pt-2 pb-1.5' : 'justify-start gap-2 flex-col text-center pt-2.5 pb-2')
                )}
       `}>
         
@@ -403,7 +405,11 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
         )}
 
         {!isTravel && !isEmptyTravel && item.type === 'activity' && !isCompactVerticalActivity && (
-             <ActivityTypeIcon type={primaryActivityType || 'general'} size={14} className={`${isInactiveActivity ? 'opacity-60' : 'opacity-70'} ${vertical && item.duration * pixelsPerDay >= 60 ? 'mb-1' : ''}`} />
+             <ActivityTypeIcon
+                 type={primaryActivityType || 'general'}
+                 size={14}
+                 className={`${isInactiveActivity ? 'opacity-60' : 'opacity-70'} ${vertical && item.duration * pixelsPerDay >= 60 ? 'mb-1' : ''}`}
+             />
         )}
 
         {!isEmptyTravel && !shouldRotateVerticalCityLabel && (
@@ -413,7 +419,7 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
                         ? 'w-full truncate whitespace-nowrap text-center'
                         : `${isCompactHorizontalActivity
                             ? 'inline-flex max-w-full items-center justify-center overflow-hidden text-ellipsis whitespace-nowrap text-center font-semibold'
-                            : (isTravel ? 'text-xs w-full whitespace-normal line-clamp-2' : (isCity ? 'text-[12px] md:text-[14px] w-full whitespace-normal line-clamp-2' : 'text-sm whitespace-normal'))}
+                            : (isTravel ? 'text-xs w-full whitespace-normal line-clamp-2' : (isCity ? 'text-[12px] md:text-[14px] w-full whitespace-normal line-clamp-2' : 'text-[15px] whitespace-normal'))}
                            ${!isTravel && !isCompactHorizontalActivity ? 'line-clamp-2' : ''}
                            ${vertical 
                                ? (item.duration * pixelsPerDay < 60 ? 'w-full truncate whitespace-nowrap text-center' : 'w-full break-words text-center') 
@@ -426,10 +432,11 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
                         ? {
                             transform: 'rotate(-90deg)',
                             transformOrigin: 'center center',
-                            lineHeight: 0.95,
-                            width: 'calc(100% - 10px)',
-                            maxWidth: 'calc(100% - 10px)',
+                            lineHeight: 1,
+                            width: 'calc(100% - 8px)',
+                            maxWidth: 'calc(100% - 8px)',
                             fontSize: `${compactHorizontalTitleSize}px`,
+                            letterSpacing: '0.01em',
                         }
                         : undefined)}
             >

--- a/components/tripview/TripViewPlannerWorkspace.tsx
+++ b/components/tripview/TripViewPlannerWorkspace.tsx
@@ -126,6 +126,7 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
     const dockedMapAnchorRef = useRef<HTMLDivElement | null>(null);
     const isFloatingMapPreviewEnabled = !isMobile && TRIP_FLOATING_MAP_PREVIEW_BETA_ENABLED;
     const effectiveMapDockMode: 'docked' | 'floating' = isFloatingMapPreviewEnabled ? mapDockMode : 'docked';
+    const plannerControlsLayerClassName = effectiveMapDockMode === 'floating' ? 'z-[30]' : 'z-[60]';
     const dockedGeometryKey = `${effectiveLayoutMode}:${layoutMode}:${sidebarWidth}:${detailsWidth}:${timelineHeight}:${detailsPanelVisible ? '1' : '0'}`;
     const floatingMapReservedRightInset = effectiveMapDockMode === 'floating' && detailsPanelVisible
         ? detailsWidth + 4
@@ -364,7 +365,7 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
                             onTouchCancel={timelineMode === 'calendar' ? onTimelineTouchEnd : undefined}
                         >
                             {timelineCanvas}
-                            <div className="absolute top-3 end-3 z-[60] pointer-events-auto">
+                            <div data-testid="planner-timeline-controls" className={`absolute top-3 end-3 ${plannerControlsLayerClassName} pointer-events-auto`}>
                                 {timelineControls}
                             </div>
                         </div>
@@ -394,7 +395,7 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
                                             onTouchCancel={timelineMode === 'calendar' ? onTimelineTouchEnd : undefined}
                                         >
                                             {timelineCanvas}
-                                            <div className="absolute top-4 end-4 z-[60] pointer-events-auto">
+                                            <div data-testid="planner-timeline-controls" className={`absolute top-4 end-4 ${plannerControlsLayerClassName} pointer-events-auto`}>
                                                 {timelineControls}
                                             </div>
                                         </div>
@@ -422,7 +423,7 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
                                         <div className="w-full flex-1 overflow-hidden relative flex flex-col min-w-0">
                                             <div ref={verticalLayoutTimelineRef} className="flex-1 w-full overflow-hidden relative min-w-0">
                                                 {timelineCanvas}
-                                                <div className="absolute top-4 end-4 z-[60] pointer-events-auto">
+                                                <div data-testid="planner-timeline-controls" className={`absolute top-4 end-4 ${plannerControlsLayerClassName} pointer-events-auto`}>
                                                     {timelineControls}
                                                 </div>
                                             </div>
@@ -472,7 +473,7 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
                                         <div ref={verticalLayoutTimelineRef} className="flex-1 h-full relative border-r border-gray-100 min-w-0">
                                             <div className="w-full h-full relative min-w-0">
                                                 {timelineCanvas}
-                                                <div className="absolute top-4 end-4 z-[60] pointer-events-auto">
+                                                <div data-testid="planner-timeline-controls" className={`absolute top-4 end-4 ${plannerControlsLayerClassName} pointer-events-auto`}>
                                                     {timelineControls}
                                                 </div>
                                             </div>

--- a/content/updates/2026-03-11-trip-page-layout-optimization.md
+++ b/content/updates/2026-03-11-trip-page-layout-optimization.md
@@ -7,15 +7,15 @@ published_at: 2026-03-12T07:34:52Z
 status: draft
 notify_in_app: true
 in_app_hours: 24
-summary: "Trip pages now feel calmer and more predictable across desktop and mobile, with clearer compact activities, steadier floating-map controls, cleaner trip details tabs, and a mobile details drawer that stays out of the way until you need it."
+summary: "Trip pages now feel calmer and more predictable across desktop and mobile, with full-day activity cards that stay readable, floating-map controls that no longer get trapped, cleaner trip details tabs, and a mobile details drawer that stays out of the way until you need it."
 ---
 
 ## Changes
 - [x] [Fixed] 🛟 Trip pages load reliably again after the latest polish pass. A mobile viewport state regression that could stop the planner from rendering has been resolved.
 - [x] [Fixed] 🗂️ Trip details tabs now sit cleanly on the divider again. The underline anchors directly to the grey rule without the extra offset or boxed active state.
-- [x] [Improved] 📍 Floating maps feel safer to move. The preview now stays above planner controls while dragging, so the move handle cannot get trapped underneath other UI.
+- [x] [Improved] 📍 Floating maps feel safer to move. The preview now stays above planner controls in floating mode, so the move handle cannot get trapped underneath other UI.
 - [x] [Improved] 🪟 Mobile details drawers give a clearer cue without taking over. The bottom peek is taller, background scrolling stays available in list view, and opening the drawer is now more intentional.
-- [x] [Improved] 📝 Compact horizontal activities are easier to read at small zoom levels. Rotated labels now get taller cards and tighter text sizing so names stay inside the activity chip more reliably.
+- [x] [Improved] 📝 Horizontal activity cards are much easier to read. Activities now claim the full day they touch in the horizontal planner, which gives rotated labels more height, keeps icons at the top, and makes short-duration activities easier to scan at any zoom level.
 - [x] [Improved] 🧭 Trip navigation feels lighter and more focused. The title sits closer to the TravelFlow mark, opens trip details on click, and profile actions now center around Create Trip and My Trips instead of a crowded shortcut list.
 - [x] [Improved] 📱 Mobile trip pages stay calmer while you explore. Account menus layer above planner controls, the profile trigger collapses to the avatar, toast popups stay out of the way, and the details drawer now peeks from the bottom instead of taking over immediately.
 - [x] [Fixed] 🗓️ Low-zoom calendars use space much better. Vertical views now center month labels across the visible span, compact day rails stay readable, and small activity cards in the planner are easier to scan at a glance.

--- a/tests/browser/TimelineBlock.browser.test.ts
+++ b/tests/browser/TimelineBlock.browser.test.ts
@@ -16,6 +16,17 @@ const buildCityItem = (): ITimelineItem => ({
   description: '',
 });
 
+const buildActivityItem = (id: string, duration: number, startDateOffset = 0): ITimelineItem => ({
+  id,
+  type: 'activity',
+  title: 'Colosseum & Forum',
+  startDateOffset,
+  duration,
+  color: 'border',
+  description: '',
+  activityType: ['culture'],
+});
+
 describe('components/TimelineBlock keyboard city navigation', () => {
   it('moves between selected city panels with arrow keys and tab, and toggles the details panel with enter or space', () => {
     const onNavigatePreviousCity = vi.fn();
@@ -53,5 +64,52 @@ describe('components/TimelineBlock keyboard city navigation', () => {
     expect(onNavigateNextCity).toHaveBeenCalledTimes(2);
     expect(onNavigatePreviousCity).toHaveBeenCalledTimes(2);
     expect(onToggleDetailsPanel).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders horizontal activity cards as full touched-day spans with roomier sizing', () => {
+    const compact = render(
+      React.createElement(TimelineBlock, {
+        item: buildActivityItem('activity-compact', 0.5, 1.4),
+        isSelected: false,
+        pixelsPerDay: 40,
+        onSelect: vi.fn(),
+        onResizeStart: vi.fn(),
+        onMoveStart: vi.fn(),
+      }),
+    );
+
+    const compactBlock = compact.container.querySelector<HTMLElement>('.timeline-block-item');
+    const compactContent = compact.container.querySelector<HTMLElement>('.timeline-block-item > div');
+    const compactTitle = compact.container.querySelector<HTMLElement>('.timeline-block-item span');
+
+    expect(compactBlock?.style.left).toBe('40px');
+    expect(compactBlock?.style.width).toBe('40px');
+    expect(compactBlock?.style.height).toBe('112px');
+    expect(compactContent?.className).toContain('justify-start');
+    expect(compactTitle?.style.transform).toBe('rotate(-90deg)');
+    expect(Number.parseFloat(compactTitle?.style.fontSize || '0')).toBeGreaterThanOrEqual(12);
+
+    compact.unmount();
+
+    const regular = render(
+      React.createElement(TimelineBlock, {
+        item: buildActivityItem('activity-regular', 0.4, 3.2),
+        isSelected: false,
+        pixelsPerDay: 120,
+        onSelect: vi.fn(),
+        onResizeStart: vi.fn(),
+        onMoveStart: vi.fn(),
+      }),
+    );
+
+    const regularBlock = regular.container.querySelector<HTMLElement>('.timeline-block-item');
+    const regularContent = regular.container.querySelector<HTMLElement>('.timeline-block-item > div');
+    const regularTitle = regular.container.querySelector<HTMLElement>('.timeline-block-item span');
+
+    expect(regularBlock?.style.left).toBe('360px');
+    expect(regularBlock?.style.width).toBe('120px');
+    expect(regularBlock?.style.height).toBe('88px');
+    expect(regularContent?.className).toContain('justify-start');
+    expect(regularTitle?.className).toContain('text-[15px]');
   });
 });

--- a/tests/browser/tripview/TripViewPlannerWorkspace.browser.test.ts
+++ b/tests/browser/tripview/TripViewPlannerWorkspace.browser.test.ts
@@ -134,6 +134,7 @@ describe('components/tripview/TripViewPlannerWorkspace', () => {
     expect(screen.getByTestId('floating-map-container')).toBeInTheDocument();
     expect(screen.getByTestId('floating-map-drag-handle')).toBeInTheDocument();
     expect(screen.getByTestId('planner-timeline-pane')).toBeInTheDocument();
+    expect(screen.getByTestId('planner-timeline-controls').className).toContain('z-[30]');
     expect(screen.getByLabelText('Maximize map preview')).toBeInTheDocument();
     expect(screen.getByLabelText('Resize details panel')).toBeInTheDocument();
   });

--- a/tests/unit/timelineVisualLayout.test.ts
+++ b/tests/unit/timelineVisualLayout.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTimelineVisualSpan } from '../../utils/timelineVisualLayout';
+
+describe('getTimelineVisualSpan', () => {
+  it('keeps non-activity items on their original offsets', () => {
+    expect(
+      getTimelineVisualSpan({
+        type: 'city',
+        startDateOffset: 2.25,
+        duration: 1.5,
+      }),
+    ).toEqual({
+      startOffset: 2.25,
+      endOffset: 3.75,
+      duration: 1.5,
+    });
+  });
+
+  it('expands horizontal activity items to the full touched-day span', () => {
+    expect(
+      getTimelineVisualSpan({
+        type: 'activity',
+        startDateOffset: 3.4,
+        duration: 0.2,
+      }),
+    ).toEqual({
+      startOffset: 3,
+      endOffset: 4,
+      duration: 1,
+    });
+
+    expect(
+      getTimelineVisualSpan({
+        type: 'activity',
+        startDateOffset: 3.6,
+        duration: 1.2,
+      }),
+    ).toEqual({
+      startOffset: 3,
+      endOffset: 5,
+      duration: 2,
+    });
+  });
+
+  it('preserves the original activity span in vertical mode', () => {
+    expect(
+      getTimelineVisualSpan(
+        {
+          type: 'activity',
+          startDateOffset: 3.4,
+          duration: 0.2,
+        },
+        { vertical: true },
+      ),
+    ).toEqual({
+      startOffset: 3.4,
+      endOffset: 3.6,
+      duration: 0.2,
+    });
+  });
+});

--- a/utils/timelineVisualLayout.ts
+++ b/utils/timelineVisualLayout.ts
@@ -1,0 +1,35 @@
+import type { ITimelineItem } from '../types';
+
+const TIMELINE_DAY_EPSILON = 1e-4;
+
+export interface TimelineVisualSpan {
+  startOffset: number;
+  endOffset: number;
+  duration: number;
+}
+
+export function getTimelineVisualSpan(
+  item: Pick<ITimelineItem, 'type' | 'startDateOffset' | 'duration'>,
+  options?: { vertical?: boolean },
+): TimelineVisualSpan {
+  const startOffset = Number.isFinite(item.startDateOffset) ? item.startDateOffset : 0;
+  const duration = Number.isFinite(item.duration) ? Math.max(0, item.duration) : 0;
+
+  if (options?.vertical || item.type !== 'activity') {
+    return {
+      startOffset,
+      endOffset: startOffset + duration,
+      duration,
+    };
+  }
+
+  const dayStart = Math.floor(startOffset);
+  const actualEnd = startOffset + Math.max(duration, TIMELINE_DAY_EPSILON);
+  const dayEnd = Math.max(dayStart + 1, Math.ceil(actualEnd - TIMELINE_DAY_EPSILON));
+
+  return {
+    startOffset: dayStart,
+    endOffset: dayEnd,
+    duration: dayEnd - dayStart,
+  };
+}


### PR DESCRIPTION
## Summary
- render horizontal activity cards against full touched-day spans so short activities stay readable
- give horizontal activity cards more vertical room and keep floating map previews above planner controls
- add regression coverage for the new horizontal activity span helper and floating-map stacking

## Validation
- pnpm test:core
- pnpm updates:validate
- pnpm dlx react-doctor@latest . --verbose --diff
