### PR TITLE
fix: polish mobile trip and profile follow-ups

### DIFF
--- a/components/DetailsPanel.tsx
+++ b/components/DetailsPanel.tsx
@@ -1363,19 +1363,6 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                       </div>
                   )}
              </div>
-             {supportsApproval && (
-                <div className="mb-3 flex items-center gap-2 text-xs text-gray-600">
-                    <Switch
-                        checked={isItemApproved}
-                        onCheckedChange={handleSetItemApproved}
-                        disabled={!canEdit}
-                        className="h-5 w-9 data-[state=checked]:bg-emerald-600 data-[state=unchecked]:bg-amber-400"
-                        aria-label="Toggle item approval"
-                    />
-                    <span className="font-medium">{isItemApproved ? 'Approved' : 'Needs approval'}</span>
-                </div>
-             )}
-             
              <textarea 
                 value={displayItem.title} 
                 onChange={canEdit ? ((e) => handleUpdate(displayItem.id, { title: e.target.value })) : undefined} 
@@ -1457,6 +1444,18 @@ export const DetailsPanel: React.FC<DetailsPanelProps> = ({
                             </div>
                             {isCity && countryNameForDisplay && (
                                 <div className="text-xs text-gray-500 mt-0.5">{countryNameForDisplay}</div>
+                            )}
+                            {supportsApproval && (
+                                <div className="mt-3 flex items-center gap-2 text-xs text-gray-600">
+                                    <Switch
+                                        checked={isItemApproved}
+                                        onCheckedChange={handleSetItemApproved}
+                                        disabled={!canEdit}
+                                        className="h-5 w-9 data-[state=checked]:bg-emerald-600 data-[state=unchecked]:bg-amber-400"
+                                        aria-label="Toggle item approval"
+                                    />
+                                    <span className="font-medium">{isItemApproved ? 'Approved' : 'Needs approval'}</span>
+                                </div>
                             )}
                         </div>
                     </div>

--- a/components/TripDetailsDrawer.tsx
+++ b/components/TripDetailsDrawer.tsx
@@ -1,42 +1,53 @@
 import React from 'react';
 import { Drawer, DrawerContent } from './ui/drawer';
 
-const PEEK_SNAP_POINT = '156px';
+const PEEK_SNAP_POINT = '192px';
 const FULL_SNAP_POINT = 0.9;
 
 export interface TripDetailsDrawerProps {
     open: boolean;
+    expanded: boolean;
     onOpenChange: (open: boolean) => void;
+    onExpandedChange: (expanded: boolean) => void;
     children: React.ReactNode;
 }
 
 export const TripDetailsDrawer: React.FC<TripDetailsDrawerProps> = ({
     open,
+    expanded,
     onOpenChange,
+    onExpandedChange,
     children,
 }) => {
-    const [activeSnapPoint, setActiveSnapPoint] = React.useState<number | string | null>(PEEK_SNAP_POINT);
+    const [activeSnapPoint, setActiveSnapPoint] = React.useState<number | string | null>(
+        expanded ? FULL_SNAP_POINT : PEEK_SNAP_POINT
+    );
     const isPeekVisible = activeSnapPoint === PEEK_SNAP_POINT;
 
     React.useEffect(() => {
         if (!open) {
             setActiveSnapPoint(PEEK_SNAP_POINT);
+            return;
         }
-    }, [open]);
+        setActiveSnapPoint(expanded ? FULL_SNAP_POINT : PEEK_SNAP_POINT);
+    }, [expanded, open]);
 
     return (
         <Drawer
             open={open}
             onOpenChange={onOpenChange}
             activeSnapPoint={activeSnapPoint}
-            setActiveSnapPoint={setActiveSnapPoint}
+            setActiveSnapPoint={(nextSnapPoint) => {
+                setActiveSnapPoint(nextSnapPoint);
+                onExpandedChange(nextSnapPoint === FULL_SNAP_POINT);
+            }}
             snapPoints={[PEEK_SNAP_POINT, FULL_SNAP_POINT]}
             shouldScaleBackground={false}
             modal={false}
             autoFocus={false}
             handleOnly
             disablePreventScroll
-            dismissible
+            dismissible={false}
             snapToSequentialPoint
         >
             <DrawerContent
@@ -49,8 +60,11 @@ export const TripDetailsDrawer: React.FC<TripDetailsDrawerProps> = ({
                     {isPeekVisible && (
                         <button
                             type="button"
-                            onClick={() => setActiveSnapPoint(FULL_SNAP_POINT)}
-                            className="pointer-events-auto absolute inset-x-0 top-0 z-20 h-[156px] cursor-ns-resize bg-transparent"
+                            onClick={() => {
+                                setActiveSnapPoint(FULL_SNAP_POINT);
+                                onExpandedChange(true);
+                            }}
+                            className="pointer-events-auto absolute inset-x-0 top-0 z-20 h-20 cursor-ns-resize bg-transparent"
                             aria-label="Expand trip details drawer"
                         >
                             <span className="sr-only">Expand trip details drawer</span>

--- a/components/TripManager.tsx
+++ b/components/TripManager.tsx
@@ -371,7 +371,7 @@ const computeHoverBridgeStyle = (anchorRect: DOMRect, tooltip: TooltipPosition):
     width,
     height,
     background: 'transparent',
-    zIndex: 1395,
+    zIndex: 2315,
   };
 };
 
@@ -586,7 +586,7 @@ const TripTooltip: React.FC<TripTooltipProps> = ({ trip, position, onHoverStart,
 
   return (
     <div
-      className="fixed z-[1400]"
+      className="fixed z-[2320] hidden lg:block"
       style={{ left: position.left, top: position.top, width: position.width, height: position.height }}
       onMouseEnter={onHoverStart}
       onMouseLeave={onHoverEnd}
@@ -1476,6 +1476,7 @@ export const TripManager: React.FC<TripManagerProps> = ({
         <>
           {hoverBridgeStyle && (
             <div
+              className="hidden lg:block"
               style={hoverBridgeStyle}
               onMouseEnter={cancelHoverClose}
               onMouseLeave={scheduleHoverClose}

--- a/components/TripShareModal.tsx
+++ b/components/TripShareModal.tsx
@@ -31,7 +31,7 @@ export const TripShareModal: React.FC<TripShareModalProps> = ({
             description="Choose view-only or collaboration editing."
             closeLabel="Close share trip dialog"
             size="sm"
-            mobileSheet
+            mobileSheet={false}
             bodyClassName="p-4 space-y-3"
             footer={
                 <div className="flex items-center justify-end gap-2">

--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -509,9 +509,11 @@ const TripInfoModalLoadingFallback: React.FC<{ onClose: () => void }> = ({ onClo
 
 interface TripViewModalLayerProps {
     isMobile: boolean;
+    hasDetailsSelection: boolean;
     detailsPanelVisible: boolean;
     detailsPanelContent: React.ReactNode;
     onCloseDetailsDrawer: () => void;
+    onOpenDetailsDrawer: () => void;
     addActivityState: { isOpen: boolean; dayOffset: number; location: string };
     onCloseAddActivity: () => void;
     onAddActivity: (...args: any[]) => void;
@@ -606,9 +608,11 @@ interface TripViewModalLayerProps {
 
 const TripViewModalLayer: React.FC<TripViewModalLayerProps> = ({
     isMobile,
+    hasDetailsSelection,
     detailsPanelVisible,
     detailsPanelContent,
     onCloseDetailsDrawer,
+    onOpenDetailsDrawer,
     addActivityState,
     onCloseAddActivity,
     onAddActivity,
@@ -692,9 +696,22 @@ const TripViewModalLayer: React.FC<TripViewModalLayerProps> = ({
     isPendingAuthContinueDisabled,
 }) => (
     <>
-        {isMobile && detailsPanelVisible && (
+        {isMobile && hasDetailsSelection && (
             <Suspense fallback={null}>
-                <TripDetailsDrawer open={detailsPanelVisible} onOpenChange={(open) => { if (!open) onCloseDetailsDrawer(); }}>
+                <TripDetailsDrawer
+                    open={hasDetailsSelection}
+                    expanded={detailsPanelVisible}
+                    onOpenChange={(open) => {
+                        if (!open) onCloseDetailsDrawer();
+                    }}
+                    onExpandedChange={(expanded) => {
+                        if (expanded) {
+                            onOpenDetailsDrawer();
+                            return;
+                        }
+                        onCloseDetailsDrawer();
+                    }}
+                >
                     {detailsPanelContent}
                 </TripDetailsDrawer>
             </Suspense>
@@ -2414,6 +2431,7 @@ const useTripViewRender = ({
     const {
         selectedCitiesInTimeline,
         showSelectedCitiesPanel,
+        hasSelection,
         detailsPanelVisible,
         openDetailsPanel,
         closeDetailsPanel,
@@ -2431,6 +2449,7 @@ const useTripViewRender = ({
         setSelectedCityIds,
         isHistoryOpen,
         isTripInfoOpen,
+        autoOpenOnSelect: !isMobileViewport,
         setPendingLabel,
         handleUpdateItems,
     });
@@ -3161,9 +3180,11 @@ const useTripViewRender = ({
                     />
                     <TripViewModalLayer
                         isMobile={isMobile}
+                        hasDetailsSelection={hasSelection}
                         detailsPanelVisible={detailsPanelVisible}
                         detailsPanelContent={detailsPanelContent}
                         onCloseDetailsDrawer={closeDetailsPanel}
+                        onOpenDetailsDrawer={openDetailsPanel}
                         addActivityState={addActivityState}
                         onCloseAddActivity={() => setAddActivityState({ ...addActivityState, isOpen: false })}
                         onAddActivity={handleAddActivityItem}

--- a/components/profile/ProfileHero.tsx
+++ b/components/profile/ProfileHero.tsx
@@ -16,14 +16,6 @@ interface ProfileHeroProps {
   analyticsAttributes?: Record<string, string>;
 }
 
-const splitToGraphemes = (value: string): string[] => {
-  if (typeof Intl !== 'undefined' && typeof (Intl as { Segmenter?: unknown }).Segmenter === 'function') {
-    const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
-    return Array.from(segmenter.segment(value), (segment) => segment.segment);
-  }
-  return Array.from(value);
-};
-
 export const ProfileHero: React.FC<ProfileHeroProps> = ({
   greeting,
   name,
@@ -37,30 +29,18 @@ export const ProfileHero: React.FC<ProfileHeroProps> = ({
   onCtaClick,
   analyticsAttributes,
 }) => {
-  const greetingGlyphs = React.useMemo(() => splitToGraphemes(greeting), [greeting]);
-
   return (
     <section className="py-8 md:py-12">
       <div className="mx-auto max-w-5xl text-center">
         <h1 className="text-balance text-5xl font-black tracking-tight text-slate-900 sm:text-6xl md:text-7xl">
-          <span className="text-accent-700">
-            {greetingGlyphs.map((character, index) => (
-              <span
-                key={`hero-glyph-${index}-${character}`}
-                className="profile-greeting-letter inline-block whitespace-pre"
-                style={{ animationDelay: `${index * 24}ms` }}
-              >
-                {character === ' ' ? '\u00A0' : character}
-              </span>
-            ))}
-          </span>
+          <span className="text-accent-700">{greeting}</span>
           <span>{`, ${name}`}</span>
         </h1>
 
-        <p className="mt-5 text-base leading-7 text-slate-600 md:text-lg">
-          <span className="font-semibold text-slate-900">{transliteration}</span>
+        <p className="mt-5 text-base leading-7 text-slate-600 [text-wrap:pretty] md:text-lg">
+          <span className="font-semibold text-accent-700">{transliteration}</span>
           {' '}
-          <span className="font-medium text-slate-700">/{ipa}/</span>
+          <span className="font-medium text-accent-600">/{ipa}/</span>
           {' '}
           <span>{context}</span>
         </p>

--- a/components/tripview/TripViewHeader.tsx
+++ b/components/tripview/TripViewHeader.tsx
@@ -85,7 +85,7 @@ export const TripViewHeader: React.FC<TripViewHeaderProps> = ({
     return (
         <header className="relative z-[1600] isolate shrink-0 border-b border-gray-200 bg-white px-4 py-2.5 sm:px-6">
             <div className="flex items-center justify-between gap-4">
-            <div className="flex min-w-0 flex-1 items-center gap-1.5 sm:gap-2.5">
+            <div className="flex min-w-0 flex-1 items-center gap-1 sm:gap-2.5">
                 <Link
                     to="/"
                     className="flex shrink-0 cursor-pointer items-center gap-1 transition-opacity hover:opacity-80"
@@ -105,7 +105,7 @@ export const TripViewHeader: React.FC<TripViewHeaderProps> = ({
                     onMouseEnter={onPrewarmTripInfo}
                     onFocus={onPrewarmTripInfo}
                     onTouchStart={onPrewarmTripInfo}
-                    className="group flex min-w-0 flex-1 items-start gap-2 rounded-xl px-2 py-1 text-left transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2"
+                    className="group flex min-w-0 flex-1 items-start gap-1 rounded-xl px-1 py-1 text-left transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 sm:gap-2 sm:px-2"
                     aria-label={titleTooltip}
                     data-tooltip={titleTooltip}
                     data-no-press-scale="true"
@@ -124,7 +124,7 @@ export const TripViewHeader: React.FC<TripViewHeaderProps> = ({
                             </div>
                         )}
                     </div>
-                    <span className="mt-1 inline-flex shrink-0 items-center gap-1 rounded-full border border-slate-200 bg-white/90 px-2 py-1 text-[11px] font-semibold text-slate-500 opacity-0 shadow-sm transition-all group-hover:opacity-100 group-focus-visible:opacity-100">
+                    <span className="mt-1 hidden shrink-0 items-center gap-1 rounded-full border border-slate-200 bg-white/90 px-2 py-1 text-[11px] font-semibold text-slate-500 opacity-0 shadow-sm transition-all group-hover:opacity-100 group-focus-visible:opacity-100 md:inline-flex">
                         {canManageTripMetadata ? <Pencil size={12} /> : <Info size={12} />}
                         <span className="hidden lg:inline">
                             {canManageTripMetadata ? t('tripView.header.editTitleCta') : t('tripView.header.openDetailsCta')}

--- a/components/tripview/useTripSelectionController.ts
+++ b/components/tripview/useTripSelectionController.ts
@@ -12,6 +12,7 @@ interface UseTripSelectionControllerOptions {
     setSelectedCityIds: Dispatch<SetStateAction<string[]>>;
     isHistoryOpen: boolean;
     isTripInfoOpen: boolean;
+    autoOpenOnSelect?: boolean;
     setPendingLabel: (label: string) => void;
     handleUpdateItems: (items: ITimelineItem[]) => void;
 }
@@ -25,10 +26,11 @@ export const useTripSelectionController = ({
     setSelectedCityIds,
     isHistoryOpen,
     isTripInfoOpen,
+    autoOpenOnSelect = true,
     setPendingLabel,
     handleUpdateItems,
 }: UseTripSelectionControllerOptions) => {
-    const [isDetailsPanelOpen, setIsDetailsPanelOpen] = useState(true);
+    const [isDetailsPanelOpen, setIsDetailsPanelOpen] = useState(autoOpenOnSelect);
     const selectedCitiesInTimeline = useMemo(() => {
         if (selectedCityIds.length === 0) return [];
 
@@ -43,10 +45,10 @@ export const useTripSelectionController = ({
     const detailsPanelVisible = hasSelection && isDetailsPanelOpen;
 
     const clearSelection = useCallback(() => {
-        setIsDetailsPanelOpen(true);
+        setIsDetailsPanelOpen(autoOpenOnSelect);
         setSelectedItemId(null);
         setSelectedCityIds([]);
-    }, [setSelectedCityIds, setSelectedItemId]);
+    }, [autoOpenOnSelect, setSelectedCityIds, setSelectedItemId]);
 
     const openDetailsPanel = useCallback(() => {
         if (!hasSelection) return;
@@ -65,8 +67,8 @@ export const useTripSelectionController = ({
 
     useEffect(() => {
         if (hasSelection) return;
-        setIsDetailsPanelOpen(true);
-    }, [hasSelection]);
+        setIsDetailsPanelOpen(autoOpenOnSelect);
+    }, [autoOpenOnSelect, hasSelection]);
 
     useEffect(() => {
         const handleEscape = (event: KeyboardEvent) => {
@@ -94,27 +96,27 @@ export const useTripSelectionController = ({
 
         const selectedItem = tripItems.find((item) => item.id === id);
         if (!selectedItem) {
-            setIsDetailsPanelOpen(true);
+            setIsDetailsPanelOpen((previous) => (autoOpenOnSelect ? true : previous));
             setSelectedItemId(id);
             setSelectedCityIds([]);
             return;
         }
 
         if (selectedItem.type !== 'city') {
-            setIsDetailsPanelOpen(true);
+            setIsDetailsPanelOpen((previous) => (autoOpenOnSelect ? true : previous));
             setSelectedItemId(id);
             setSelectedCityIds([]);
             return;
         }
 
         if (!options?.multi) {
-            setIsDetailsPanelOpen(true);
+            setIsDetailsPanelOpen((previous) => (autoOpenOnSelect ? true : previous));
             setSelectedItemId(id);
             setSelectedCityIds([id]);
             return;
         }
 
-        setIsDetailsPanelOpen(true);
+        setIsDetailsPanelOpen((previous) => (autoOpenOnSelect ? true : previous));
         setSelectedCityIds((previous) => {
             const baseSelection = previous.length > 0
                 ? previous
@@ -134,6 +136,7 @@ export const useTripSelectionController = ({
         });
     }, [
         clearSelection,
+        autoOpenOnSelect,
         selectedItemId,
         setSelectedCityIds,
         setSelectedItemId,
@@ -172,6 +175,7 @@ export const useTripSelectionController = ({
     return {
         selectedCitiesInTimeline,
         showSelectedCitiesPanel,
+        hasSelection,
         detailsPanelVisible,
         openDetailsPanel,
         closeDetailsPanel,

--- a/content/updates/2026-03-11-trip-page-layout-optimization.md
+++ b/content/updates/2026-03-11-trip-page-layout-optimization.md
@@ -4,13 +4,20 @@ version: v0.92.0
 title: "Trip pages feel smoother, clearer, and easier to steer"
 date: 2026-03-11
 published_at: 2026-03-12T09:13:05Z
-status: published
+status: draft
 notify_in_app: true
 in_app_hours: 24
-summary: "Trip pages now feel calmer and more predictable across desktop and mobile, with full-day activity cards that fit their labels more cleanly, floating maps that stay usable above planner controls, simpler title editing in trip details, and mobile account layers that stay in the right order."
+summary: "Trip pages now feel calmer and more predictable across desktop and mobile, with more readable mobile profile layouts, a less intrusive details drawer, a centered share dialog on phones, and safer recovery from stale share chunks."
 ---
 
 ## Changes
+- [x] [Fixed] 🤝 Sharing now fails more gracefully after stale app updates. The trip share flow recognizes MIME-type chunk mismatches as recoverable, so a stale cached page is much less likely to strand the share dialog behind a broken lazy import.
+- [x] [Improved] 📱 Mobile trip sharing feels steadier. The share dialog now opens centered instead of dropping into a bottom sheet on small screens.
+- [x] [Improved] 🪟 Mobile trip details stay out of the way until you ask for them. Selecting a city no longer auto-opens the drawer, the bottom peek is easier to grab, and scrolling the timeline stays more natural while details remain collapsed.
+- [x] [Improved] 🙋 Profile pages feel lighter on phones. Mobile now focuses on the greeting and trip list first, keeps a simple Edit profile action close at hand, and lets trip cards span the full column before stepping up to two and three columns on larger screens.
+- [x] [Fixed] 💬 Greetings and profile names read more naturally on smaller screens. Greeting text now wraps by whole words instead of single letters, the pronunciation line uses accent styling with prettier wrapping, and the owner profile now prefers the saved first and last name over stale display-name leftovers.
+- [x] [Improved] 📍 City detail basics are easier to scan. The approval toggle now sits below the location instead of competing with the title area.
+- [x] [Improved] 🧭 Small-screen trip headers make better use of the space they already have. The hidden hover-only info pill no longer reserves room on mobile, so the trip title can breathe more naturally beside the TravelFlow mark.
 - [x] [Fixed] 🛟 Trip pages load reliably again after the latest polish pass. A mobile viewport state regression that could stop the planner from rendering has been resolved.
 - [x] [Fixed] 🗂️ Trip details tabs now sit cleanly on the divider again. The underline anchors directly to the grey rule without the extra offset or boxed active state.
 - [x] [Improved] 📍 Floating maps feel safer to move. The preview now stays above planner controls in floating mode, so the move handle cannot get trapped underneath other UI.
@@ -26,3 +33,4 @@ summary: "Trip pages now feel calmer and more predictable across desktop and mob
 - [ ] [Internal] 🧪 Added regression coverage for low-zoom month rails, mobile peek drawers, account-menu trip actions, modal title editing, and planner control behavior.
 - [ ] [Internal] 🧷 Added regression coverage to keep mobile viewport state declared before the trip-view callbacks that depend on it.
 - [ ] [Internal] 🧪 Added regression coverage for the compact horizontal activity layout, the passive mobile drawer preview, the cleaned-up line tabs, the floating map layer order, and the account-menu/My Trips stacking behavior.
+- [ ] [Internal] 📝 The richer profile overview cards are temporarily hidden more broadly than originally planned while we keep the mobile-first profile simplification in place for this pass.

--- a/pages/ProfilePage.tsx
+++ b/pages/ProfilePage.tsx
@@ -150,8 +150,9 @@ export const ProfilePage: React.FC = () => {
     const fallbackDisplayName = metadataDisplayName
         || access?.email?.trim().split('@')[0]
         || t('fallback.displayName');
-    const displayName = profile?.displayName
-        || [profile?.firstName || '', profile?.lastName || ''].filter(Boolean).join(' ')
+    const resolvedProfileName = [profile?.firstName || '', profile?.lastName || ''].filter(Boolean).join(' ');
+    const displayName = resolvedProfileName
+        || profile?.displayName
         || fallbackDisplayName;
     const greetingDisplayName = formatDisplayNameForGreeting(
         profile?.firstName || '',
@@ -865,6 +866,19 @@ export const ProfilePage: React.FC = () => {
                     })}
                 />
 
+                <div className="md:hidden">
+                    <NavLink
+                        to={buildPath('profileSettings')}
+                        onClick={() => {
+                            trackEvent('profile__summary--edit_profile');
+                        }}
+                        className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900"
+                        {...getAnalyticsDebugAttributes('profile__summary--edit_profile')}
+                    >
+                        {t('summary.editProfile')}
+                    </NavLink>
+                </div>
+
                 {pinNotice && (
                     <section className="rounded-xl border border-accent-200 bg-accent-50 px-4 py-3 text-sm text-accent-900">
                         {pinNotice}
@@ -949,9 +963,10 @@ export const ProfilePage: React.FC = () => {
                     isPassportOpen={searchParams.get(PROFILE_PASSPORT_QUERY_KEY) === PROFILE_PASSPORT_QUERY_VALUE}
                     canShareProfile={Boolean(publicProfileUrl)}
                     locale={appLocale}
+                    className="hidden md:grid"
                 />
 
-                <section className="space-y-2">
+                <section className="hidden space-y-2 md:block">
                     <h2 className="text-sm font-black tracking-tight text-slate-900">{t('actions.title')}</h2>
                     <div className="flex flex-wrap items-center gap-2">
                         <NavLink
@@ -997,7 +1012,7 @@ export const ProfilePage: React.FC = () => {
                                 {t('sections.highlightsCount', { count: pinnedTrips.length })}
                             </span>
                         </div>
-                        <div className="grid grid-cols-2 gap-4 xl:grid-cols-3">
+                        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                             {pinnedTrips.map((trip) => (
                                 <ProfileTripCard
                                     key={`pinned-${trip.id}`}
@@ -1194,7 +1209,7 @@ export const ProfilePage: React.FC = () => {
                         </div>
                     ) : (
                         <>
-                            <div className="grid grid-cols-2 gap-4 xl:grid-cols-3">
+                            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                                 {visibleTripsForTab.map((trip) => (
                                     <ProfileTripCard
                                         key={trip.id}
@@ -1239,7 +1254,7 @@ export const ProfilePage: React.FC = () => {
 
                             {hasMoreTripsForTab && (
                                 <>
-                                    <div className="grid grid-cols-2 gap-4 xl:grid-cols-3" aria-hidden="true">
+                                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
                                         {Array.from({ length: skeletonTripCount || PROFILE_TRIPS_PAGE_SIZE }).map((_, index) => (
                                             <ProfileTripCardSkeleton key={`profile-trip-skeleton-${index}`} pulse={isTripPaginationPending} />
                                         ))}

--- a/pages/PublicProfilePage.tsx
+++ b/pages/PublicProfilePage.tsx
@@ -505,7 +505,7 @@ export const PublicProfilePage: React.FC = () => {
                                         {t('sections.highlightsCount', { count: pinnedTrips.length })}
                                     </span>
                                 </div>
-                                <div className="grid grid-cols-2 gap-4 xl:grid-cols-3">
+                                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                                     {pinnedTrips.map((trip) => (
                                         <ProfileTripCard
                                                 key={`public-pinned-${trip.id}`}
@@ -541,7 +541,7 @@ export const PublicProfilePage: React.FC = () => {
                         <section className="space-y-3">
                             <h2 className="text-lg font-black tracking-tight text-slate-900">{t('publicProfile.tripsTitle')}</h2>
                             {isTripsLoading && trips.length === 0 ? (
-                                <div className="grid grid-cols-2 gap-4 xl:grid-cols-3" aria-hidden="true">
+                                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
                                     {Array.from({ length: 3 }).map((_, index) => (
                                         <ProfileTripCardSkeleton key={`public-trip-loading-${index}`} />
                                     ))}
@@ -552,7 +552,7 @@ export const PublicProfilePage: React.FC = () => {
                                 </div>
                             ) : (
                                 <>
-                                    <div className="grid grid-cols-2 gap-4 xl:grid-cols-3">
+                                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                                         {trips.map((trip) => (
                                             <ProfileTripCard
                                                 key={`public-trip-${trip.id}`}
@@ -585,7 +585,7 @@ export const PublicProfilePage: React.FC = () => {
 
                                     {(hasMoreTrips || isTripsLoadingMore) && (
                                         <>
-                                            <div className="grid grid-cols-2 gap-4 xl:grid-cols-3" aria-hidden="true">
+                                            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
                                                 {Array.from({ length: 3 }).map((_, index) => (
                                                     <ProfileTripCardSkeleton
                                                         key={`public-trip-more-skeleton-${index}`}

--- a/services/lazyImportRecovery.ts
+++ b/services/lazyImportRecovery.ts
@@ -12,6 +12,8 @@ const RECOVERABLE_IMPORT_ERROR_PATTERNS: RegExp[] = [
     /loading chunk [\w-]+ failed/i,
     /chunkloaderror/i,
     /unexpected token '<'/i,
+    /not a valid javascript mime type/i,
+    /mime type .*javascript/i,
 ];
 
 const extractErrorMessage = (error: unknown): string => {
@@ -20,14 +22,14 @@ const extractErrorMessage = (error: unknown): string => {
     return '';
 };
 
-const isRecoverableImportError = (error: unknown): boolean => {
+export const isRecoverableLazyImportError = (error: unknown): boolean => {
     const message = extractErrorMessage(error);
     if (message && RECOVERABLE_IMPORT_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
         return true;
     }
 
     if (typeof error === 'object' && error !== null && 'cause' in error) {
-        return isRecoverableImportError((error as { cause?: unknown }).cause);
+        return isRecoverableLazyImportError((error as { cause?: unknown }).cause);
     }
 
     return false;
@@ -64,7 +66,7 @@ export const loadLazyComponentWithRecovery = async <TModule>(
         clearRecoveryAttempt(moduleKey);
         return loadedModule;
     } catch (error) {
-        const canRecover = isRecoverableImportError(error) && markRecoveryAttempt(moduleKey);
+        const canRecover = isRecoverableLazyImportError(error) && markRecoveryAttempt(moduleKey);
         if (!canRecover) {
             throw error;
         }

--- a/tests/browser/lazyImportRecovery.browser.test.ts
+++ b/tests/browser/lazyImportRecovery.browser.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('../../services/analyticsService', () => ({
+  trackEvent: mocks.trackEvent,
+}));
+
+import { isRecoverableLazyImportError } from '../../services/lazyImportRecovery';
+
+describe('services/lazyImportRecovery', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    mocks.trackEvent.mockReset();
+  });
+
+  it('treats MIME type lazy-import failures as recoverable', () => {
+    expect(
+      isRecoverableLazyImportError(new TypeError("'text/html' is not a valid JavaScript MIME type."))
+    ).toBe(true);
+  });
+});

--- a/tests/browser/profilePage.browser.test.ts
+++ b/tests/browser/profilePage.browser.test.ts
@@ -536,4 +536,21 @@ describe('pages/ProfilePage query-driven tabs and sort', () => {
     expect(tripAAfter).not.toBeChecked();
     expect(tripBAfter).toBeChecked();
   });
+
+  it('prefers the saved first and last name over a stale display name on the owner profile surface', async () => {
+    mocks.auth.profile = {
+      ...mocks.auth.profile,
+      displayName: 'Old Alias',
+      firstName: 'Chris',
+      lastName: 'Wisniewski',
+    };
+
+    renderProfilePage('/profile');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Chris Wisniewski/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Old Alias')).toBeNull();
+  });
 });

--- a/tests/browser/tripDetailsDrawer.browser.test.ts
+++ b/tests/browser/tripDetailsDrawer.browser.test.ts
@@ -32,7 +32,9 @@ describe('components/TripDetailsDrawer', () => {
     const { rerender } = render(
       React.createElement(TripDetailsDrawer, {
         open: true,
+        expanded: false,
         onOpenChange: vi.fn(),
+        onExpandedChange: vi.fn(),
       }, React.createElement('div', null, 'details')),
     );
 
@@ -40,25 +42,22 @@ describe('components/TripDetailsDrawer', () => {
     expect(drawerMocks.rootProps.at(-1)?.autoFocus).toBe(false);
     expect(drawerMocks.rootProps.at(-1)?.handleOnly).toBe(true);
     expect(drawerMocks.rootProps.at(-1)?.disablePreventScroll).toBe(true);
-    expect(drawerMocks.rootProps.at(-1)?.snapPoints).toEqual(['156px', 0.9]);
-    expect(drawerMocks.rootProps.at(-1)?.activeSnapPoint).toBe('156px');
+    expect(drawerMocks.rootProps.at(-1)?.dismissible).toBe(false);
+    expect(drawerMocks.rootProps.at(-1)?.snapPoints).toEqual(['192px', 0.9]);
+    expect(drawerMocks.rootProps.at(-1)?.activeSnapPoint).toBe('192px');
     expect(drawerMocks.contentProps.at(-1)?.hideOverlay).toBe(true);
     expect(String(drawerMocks.contentProps.at(-1)?.className)).toContain('pointer-events-none');
     expect(screen.getByRole('button', { name: 'Expand trip details drawer' })).toBeInTheDocument();
 
     rerender(
       React.createElement(TripDetailsDrawer, {
-        open: false,
-        onOpenChange: vi.fn(),
-      }, React.createElement('div', null, 'details')),
-    );
-    rerender(
-      React.createElement(TripDetailsDrawer, {
         open: true,
+        expanded: true,
         onOpenChange: vi.fn(),
+        onExpandedChange: vi.fn(),
       }, React.createElement('div', null, 'details')),
     );
 
-    expect(drawerMocks.rootProps.at(-1)?.activeSnapPoint).toBe('156px');
+    expect(drawerMocks.rootProps.at(-1)?.activeSnapPoint).toBe(0.9);
   });
 });

--- a/tests/browser/tripview/useTripSelectionController.browser.test.ts
+++ b/tests/browser/tripview/useTripSelectionController.browser.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { makeActivityItem, makeCityItem } from '../../helpers/tripFixtures';
+import { useTripSelectionController } from '../../../components/tripview/useTripSelectionController';
+
+describe('components/tripview/useTripSelectionController', () => {
+  it('keeps the mobile details drawer collapsed after selecting an item until the user explicitly opens it', () => {
+    const setPendingLabel = vi.fn();
+    const handleUpdateItems = vi.fn();
+    const tripItems = [
+      makeCityItem({ id: 'city-1', title: 'Bangkok', startDateOffset: 0, duration: 2 }),
+      makeActivityItem('activity-1', 'Bangkok', 0),
+    ];
+
+    const { result } = renderHook(() => {
+      const [selectedItemId, setSelectedItemId] = React.useState<string | null>(null);
+      const [selectedCityIds, setSelectedCityIds] = React.useState<string[]>([]);
+
+      return useTripSelectionController({
+        tripItems,
+        displayTripItems: tripItems,
+        selectedItemId,
+        setSelectedItemId,
+        selectedCityIds,
+        setSelectedCityIds,
+        isHistoryOpen: false,
+        isTripInfoOpen: false,
+        autoOpenOnSelect: false,
+        setPendingLabel,
+        handleUpdateItems,
+      });
+    });
+
+    act(() => {
+      result.current.handleTimelineSelect('city-1', { isCity: true });
+    });
+
+    expect(result.current.hasSelection).toBe(true);
+    expect(result.current.detailsPanelVisible).toBe(false);
+
+    act(() => {
+      result.current.openDetailsPanel();
+    });
+
+    expect(result.current.detailsPanelVisible).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- harden the share flow against stale chunk MIME recovery failures and center the share modal on mobile
- stop the mobile details drawer from auto-opening, make its peek state less intrusive, and move the city approved toggle below location
- simplify mobile profile/trip surfaces, improve responsive trip grids, and tighten small-screen header space and desktop sidebar tooltip layering

## Testing
- [x] `pnpm test:core`
- [x] `pnpm i18n:validate`
- [x] `pnpm updates:validate`
- [x] `pnpm dlx react-doctor@latest . --verbose --diff`

## Release note
- [x] Updated `content/updates/2026-03-11-trip-page-layout-optimization.md` (kept in draft for pre-merge work)
