### PR TITLE
docs: publish trip page layout release note

### DIFF
--- a/content/updates/2026-03-11-trip-page-layout-optimization.md
+++ b/content/updates/2026-03-11-trip-page-layout-optimization.md
@@ -3,8 +3,8 @@ id: rel-2026-03-11-trip-page-layout-optimization
 version: v0.92.0
 title: "Trip pages feel smoother, clearer, and easier to steer"
 date: 2026-03-11
-published_at: 2026-03-12T09:13:05Z
-status: draft
+published_at: 2026-03-12T11:38:32Z
+status: published
 notify_in_app: true
 in_app_hours: 24
 summary: "Trip pages now feel calmer and more predictable across desktop and mobile, with more readable mobile profile layouts, a less intrusive details drawer, a centered share dialog on phones, and safer recovery from stale share chunks."


### PR DESCRIPTION
## Summary
- publish the trip page layout update note after merge to main
- stamp the note with the actual main merge time and keep the release version metadata aligned

## Testing
- [x] `pnpm updates:validate`
