### PR TITLE
Make mobile trip details intentional again

### DIFF
--- a/components/TripDetailsDrawer.tsx
+++ b/components/TripDetailsDrawer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Drawer, DrawerContent } from './ui/drawer';
 
-const PEEK_SNAP_POINT = '192px';
 const FULL_SNAP_POINT = 0.9;
 
 export interface TripDetailsDrawerProps {
@@ -14,66 +13,37 @@ export interface TripDetailsDrawerProps {
 
 export const TripDetailsDrawer: React.FC<TripDetailsDrawerProps> = ({
     open,
-    expanded,
+    expanded: _expanded,
     onOpenChange,
     onExpandedChange,
     children,
 }) => {
-    const [activeSnapPoint, setActiveSnapPoint] = React.useState<number | string | null>(
-        expanded ? FULL_SNAP_POINT : PEEK_SNAP_POINT
-    );
-    const isPeekVisible = activeSnapPoint === PEEK_SNAP_POINT;
-
-    React.useEffect(() => {
-        if (!open) {
-            setActiveSnapPoint(PEEK_SNAP_POINT);
-            return;
-        }
-        setActiveSnapPoint(expanded ? FULL_SNAP_POINT : PEEK_SNAP_POINT);
-    }, [expanded, open]);
-
     return (
         <Drawer
             open={open}
             onOpenChange={onOpenChange}
-            activeSnapPoint={activeSnapPoint}
+            activeSnapPoint={FULL_SNAP_POINT}
             setActiveSnapPoint={(nextSnapPoint) => {
-                setActiveSnapPoint(nextSnapPoint);
-                onExpandedChange(nextSnapPoint === FULL_SNAP_POINT);
+                const isExpanded = nextSnapPoint === FULL_SNAP_POINT;
+                onExpandedChange(isExpanded);
+                if (!isExpanded) onOpenChange(false);
             }}
-            snapPoints={[PEEK_SNAP_POINT, FULL_SNAP_POINT]}
+            snapPoints={[FULL_SNAP_POINT]}
             shouldScaleBackground={false}
             modal={false}
             autoFocus={false}
             handleOnly
             disablePreventScroll
-            dismissible={false}
+            dismissible
             snapToSequentialPoint
         >
             <DrawerContent
                 hideOverlay
-                className={`h-[min(88vh,720px)] p-0 ${isPeekVisible ? 'pointer-events-none' : 'pointer-events-auto'}`}
+                className="h-[min(92vh,780px)] p-0"
                 accessibleTitle="Trip details"
                 accessibleDescription="View and edit selected city, travel segment, or activity details."
             >
-                <div className="relative h-full">
-                    {isPeekVisible && (
-                        <button
-                            type="button"
-                            onClick={() => {
-                                setActiveSnapPoint(FULL_SNAP_POINT);
-                                onExpandedChange(true);
-                            }}
-                            className="pointer-events-auto absolute inset-x-0 top-0 z-20 h-20 cursor-ns-resize bg-transparent"
-                            aria-label="Expand trip details drawer"
-                        >
-                            <span className="sr-only">Expand trip details drawer</span>
-                        </button>
-                    )}
-                    <div className={`h-full ${isPeekVisible ? 'pointer-events-none overflow-hidden' : 'pointer-events-auto overflow-hidden'}`}>
-                        {children}
-                    </div>
-                </div>
+                <div className="h-full overflow-hidden">{children}</div>
             </DrawerContent>
         </Drawer>
     );

--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -509,7 +509,6 @@ const TripInfoModalLoadingFallback: React.FC<{ onClose: () => void }> = ({ onClo
 
 interface TripViewModalLayerProps {
     isMobile: boolean;
-    hasDetailsSelection: boolean;
     detailsPanelVisible: boolean;
     detailsPanelContent: React.ReactNode;
     onCloseDetailsDrawer: () => void;
@@ -608,7 +607,6 @@ interface TripViewModalLayerProps {
 
 const TripViewModalLayer: React.FC<TripViewModalLayerProps> = ({
     isMobile,
-    hasDetailsSelection,
     detailsPanelVisible,
     detailsPanelContent,
     onCloseDetailsDrawer,
@@ -696,10 +694,10 @@ const TripViewModalLayer: React.FC<TripViewModalLayerProps> = ({
     isPendingAuthContinueDisabled,
 }) => (
     <>
-        {isMobile && hasDetailsSelection && (
+        {isMobile && detailsPanelVisible && (
             <Suspense fallback={null}>
                 <TripDetailsDrawer
-                    open={hasDetailsSelection}
+                    open={detailsPanelVisible}
                     expanded={detailsPanelVisible}
                     onOpenChange={(open) => {
                         if (!open) onCloseDetailsDrawer();
@@ -2450,6 +2448,7 @@ const useTripViewRender = ({
         isHistoryOpen,
         isTripInfoOpen,
         autoOpenOnSelect: !isMobileViewport,
+        clearSelectionOnClose: isMobileViewport,
         setPendingLabel,
         handleUpdateItems,
     });
@@ -2820,6 +2819,7 @@ const useTripViewRender = ({
             timelineMode={timelineMode}
             timelineView={timelineView}
             trip={displayTrip}
+            isMobile={isMobile}
             onUpdateItems={handleUpdateItems}
             onToggleTaskCheckbox={canEdit ? handleTimelineTaskToggle : undefined}
             onSelect={handleTimelineSelect}
@@ -3180,7 +3180,6 @@ const useTripViewRender = ({
                     />
                     <TripViewModalLayer
                         isMobile={isMobile}
-                        hasDetailsSelection={hasSelection}
                         detailsPanelVisible={detailsPanelVisible}
                         detailsPanelContent={detailsPanelContent}
                         onCloseDetailsDrawer={closeDetailsPanel}

--- a/components/tripview/TripTimelineCanvas.tsx
+++ b/components/tripview/TripTimelineCanvas.tsx
@@ -14,6 +14,7 @@ interface TripTimelineCanvasProps {
     timelineMode: 'calendar' | 'timeline';
     timelineView: 'vertical' | 'horizontal';
     trip: ITrip;
+    isMobile: boolean;
     onUpdateItems: (items: ITimelineItem[], options?: { deferCommit?: boolean }) => void;
     onToggleTaskCheckbox?: (itemId: string, taskLineNumber: number, checked: boolean) => void;
     onSelect: (id: string | null, options?: { multi?: boolean; isCity?: boolean }) => void;
@@ -38,6 +39,7 @@ export const TripTimelineCanvas: React.FC<TripTimelineCanvasProps> = ({
     timelineMode,
     timelineView,
     trip,
+    isMobile,
     onUpdateItems,
     onToggleTaskCheckbox,
     onSelect,
@@ -65,6 +67,7 @@ export const TripTimelineCanvas: React.FC<TripTimelineCanvasProps> = ({
                 onToggleTaskCheckbox={onToggleTaskCheckbox}
                 onSelect={onSelect}
                 selectionVisibilityKey={selectionVisibilityKey}
+                enableScrollActiveCitySelection={!isMobile}
             />
         );
     }

--- a/components/tripview/TripTimelineListView.tsx
+++ b/components/tripview/TripTimelineListView.tsx
@@ -1,12 +1,15 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { Hotel, MapPin } from 'lucide-react';
 
 import { TransportModeIcon } from '../TransportModeIcon';
+import { ActivityTypeIcon, formatActivityTypeLabel, getActivityTypePaletteParts } from '../ActivityTypeVisuals';
 import { Checkbox } from '../ui/checkbox';
 import type { ITrip } from '../../types';
 import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analyticsService';
 import { buildTimelineListModel } from './timelineListViewModel';
+import { normalizeActivityTypes } from '../../utils';
 import {
     findMarkdownTaskLineNumbers,
     MARKDOWN_H1_CLASS,
@@ -27,6 +30,7 @@ interface TripTimelineListViewProps {
     onToggleTaskCheckbox?: (itemId: string, taskLineNumber: number, checked: boolean) => void;
     onSelect: (id: string | null, options?: { multi?: boolean; isCity?: boolean }) => void;
     selectionVisibilityKey?: string;
+    enableScrollActiveCitySelection?: boolean;
 }
 
 const formatTripDayLabel = (tripStartDate: string, dayOffset: number): string => {
@@ -241,6 +245,7 @@ export const TripTimelineListView: React.FC<TripTimelineListViewProps> = ({
     onToggleTaskCheckbox,
     onSelect,
     selectionVisibilityKey,
+    enableScrollActiveCitySelection = true,
 }) => {
     const model = useMemo(() => buildTimelineListModel(trip), [trip]);
     const sectionContainerRef = useRef<HTMLDivElement | null>(null);
@@ -346,6 +351,7 @@ export const TripTimelineListView: React.FC<TripTimelineListViewProps> = ({
     }, [updateTransferMidpoints]);
 
     const updateActiveCitySelection = useCallback(() => {
+        if (!enableScrollActiveCitySelection) return;
         if (!userScrollSelectionEnabledRef.current) return;
         if (!selectedItemId) return;
 
@@ -376,7 +382,7 @@ export const TripTimelineListView: React.FC<TripTimelineListViewProps> = ({
         lastAutoSelectedCityIdRef.current = activeCityId;
         if (selectedItemId === activeCityId) return;
         onSelect(activeCityId, { isCity: true });
-    }, [model.sections, onSelect, selectedItemId]);
+    }, [enableScrollActiveCitySelection, model.sections, onSelect, selectedItemId]);
 
     useEffect(() => {
         hasAutoScrolledToTodayRef.current = false;
@@ -391,6 +397,7 @@ export const TripTimelineListView: React.FC<TripTimelineListViewProps> = ({
     }, [selectionVisibilityKey]);
 
     useEffect(() => {
+        if (!enableScrollActiveCitySelection) return;
         const viewport = viewportRef.current;
         if (!viewport) return;
 
@@ -423,7 +430,7 @@ export const TripTimelineListView: React.FC<TripTimelineListViewProps> = ({
                 scrollSelectionFrameRef.current = null;
             }
         };
-    }, [updateActiveCitySelection]);
+    }, [enableScrollActiveCitySelection, updateActiveCitySelection]);
 
     useEffect(() => {
         if (!selectedItemId) {
@@ -535,6 +542,7 @@ export const TripTimelineListView: React.FC<TripTimelineListViewProps> = ({
                             const countryLabel = section.city.countryName?.trim() || section.city.countryCode?.trim() || null;
                             const citySelected = selectedItemId === section.city.id;
                             const citySummaryMarkdown = section.city.description?.trim() || section.arrivalDescription || '';
+                            const hotels = (section.city.hotels || []).filter((hotel) => hotel.name?.trim() || hotel.address?.trim());
 
                             const handleCitySelect = () => {
                                 trackEvent('trip_view__timeline_city--open', {
@@ -613,6 +621,32 @@ export const TripTimelineListView: React.FC<TripTimelineListViewProps> = ({
                                             </div>
                                         )}
 
+                                        {hotels.length > 0 && (
+                                            <div className="flex flex-wrap gap-2 pb-3">
+                                                {hotels.map((hotel) => (
+                                                    <div
+                                                        key={hotel.id}
+                                                        className="inline-flex max-w-full items-start gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-left text-sm text-slate-700"
+                                                    >
+                                                        <Hotel size={14} className="mt-0.5 shrink-0 text-accent-600" />
+                                                        <div className="min-w-0">
+                                                            {hotel.name?.trim() && (
+                                                                <p className="truncate font-semibold text-slate-900">
+                                                                    {hotel.name.trim()}
+                                                                </p>
+                                                            )}
+                                                            {hotel.address?.trim() && (
+                                                                <p className="mt-1 flex items-start gap-1 text-xs text-slate-500">
+                                                                    <MapPin size={12} className="mt-0.5 shrink-0" />
+                                                                    <span className="break-words">{hotel.address.trim()}</span>
+                                                                </p>
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        )}
+
                                         <div className="pt-1">
                                             {section.activities.length === 0 ? (
                                                 <p className="py-3 text-sm leading-7 text-slate-500">
@@ -623,6 +657,7 @@ export const TripTimelineListView: React.FC<TripTimelineListViewProps> = ({
                                                     {section.activities.map((activity) => {
                                                         const markerId = `activity-${activity.item.id}`;
                                                         const isSelected = selectedItemId === activity.item.id;
+                                                        const activityTypes = normalizeActivityTypes(activity.item.activityType, []);
                                                         return (
                                                             <li
                                                                 key={activity.item.id}
@@ -667,6 +702,29 @@ export const TripTimelineListView: React.FC<TripTimelineListViewProps> = ({
                                                                             >
                                                                                 {activity.item.description}
                                                                             </ReactMarkdown>
+                                                                        </div>
+                                                                    )}
+                                                                    {activityTypes.length > 0 && (
+                                                                        <div className="mt-3 flex items-center -space-x-2 ps-1">
+                                                                            {activityTypes.map((type) => {
+                                                                                const label = formatActivityTypeLabel(type);
+                                                                                const palette = getActivityTypePaletteParts(type);
+                                                                                return (
+                                                                                    <span
+                                                                                        key={`${activity.item.id}-${type}`}
+                                                                                        title={label}
+                                                                                        aria-label={label}
+                                                                                        className="group/type relative inline-flex h-8 items-center overflow-hidden rounded-full border border-slate-200 bg-white/95 pe-0 shadow-sm transition-[padding,transform,box-shadow] duration-200 hover:z-10 hover:-translate-y-0.5 hover:pe-3 hover:shadow-md"
+                                                                                    >
+                                                                                        <span className={`inline-flex size-8 shrink-0 items-center justify-center rounded-full border ${palette.bg} ${palette.border} ${palette.text}`}>
+                                                                                            <ActivityTypeIcon type={type} size={12} />
+                                                                                        </span>
+                                                                                        <span className="max-w-0 overflow-hidden whitespace-nowrap ps-0 text-[11px] font-medium text-slate-600 opacity-0 transition-all duration-200 group-hover/type:max-w-24 group-hover/type:ps-1.5 group-hover/type:opacity-100">
+                                                                                            {label}
+                                                                                        </span>
+                                                                                    </span>
+                                                                                );
+                                                                            })}
                                                                         </div>
                                                                     )}
                                                                 </button>

--- a/components/tripview/TripViewPlannerWorkspace.tsx
+++ b/components/tripview/TripViewPlannerWorkspace.tsx
@@ -357,8 +357,16 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
                 {isMobile ? (
                     <div className="w-full h-full flex flex-col">
                         <div
+                            ref={mapViewportRef}
+                            data-testid="planner-mobile-map-pane"
+                            className={`${isMobileMapExpanded ? 'fixed inset-x-0 bottom-0 h-[70vh] z-[1450] border-t border-gray-200 shadow-2xl bg-white' : 'relative h-[34vh] min-h-[220px] bg-gray-100'}`}
+                        >
+                            {renderMap('vertical', false)}
+                        </div>
+                        <div
                             ref={verticalLayoutTimelineRef}
-                            className="flex-1 min-h-0 w-full bg-white border-b border-gray-200 relative overflow-hidden"
+                            data-testid="planner-mobile-timeline-pane"
+                            className="flex-1 min-h-0 w-full bg-white border-t border-gray-200 relative overflow-hidden"
                             onTouchStart={timelineMode === 'calendar' ? onTimelineTouchStart : undefined}
                             onTouchMove={timelineMode === 'calendar' ? onTimelineTouchMove : undefined}
                             onTouchEnd={timelineMode === 'calendar' ? onTimelineTouchEnd : undefined}
@@ -368,12 +376,6 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
                             <div data-testid="planner-timeline-controls" className={`absolute top-3 end-3 ${plannerControlsLayerClassName} pointer-events-auto`}>
                                 {timelineControls}
                             </div>
-                        </div>
-                        <div
-                            ref={mapViewportRef}
-                            className={`${isMobileMapExpanded ? 'fixed inset-x-0 bottom-0 h-[70vh] z-[1450] border-t border-gray-200 shadow-2xl bg-white' : 'relative h-[34vh] min-h-[220px] bg-gray-100'}`}
-                        >
-                            {renderMap('vertical', false)}
                         </div>
                     </div>
                 ) : (

--- a/components/tripview/useTripSelectionController.ts
+++ b/components/tripview/useTripSelectionController.ts
@@ -13,6 +13,7 @@ interface UseTripSelectionControllerOptions {
     isHistoryOpen: boolean;
     isTripInfoOpen: boolean;
     autoOpenOnSelect?: boolean;
+    clearSelectionOnClose?: boolean;
     setPendingLabel: (label: string) => void;
     handleUpdateItems: (items: ITimelineItem[]) => void;
 }
@@ -27,6 +28,7 @@ export const useTripSelectionController = ({
     isHistoryOpen,
     isTripInfoOpen,
     autoOpenOnSelect = true,
+    clearSelectionOnClose = false,
     setPendingLabel,
     handleUpdateItems,
 }: UseTripSelectionControllerOptions) => {
@@ -57,8 +59,12 @@ export const useTripSelectionController = ({
 
     const closeDetailsPanel = useCallback(() => {
         if (!hasSelection) return;
+        if (clearSelectionOnClose) {
+            clearSelection();
+            return;
+        }
         setIsDetailsPanelOpen(false);
-    }, [hasSelection]);
+    }, [clearSelection, clearSelectionOnClose, hasSelection]);
 
     const toggleDetailsPanel = useCallback(() => {
         if (!hasSelection) return;
@@ -94,8 +100,17 @@ export const useTripSelectionController = ({
             return;
         }
 
+        const shouldOpenHiddenDetails = !autoOpenOnSelect
+            && !options?.multi
+            && selectedItemId === id
+            && !isDetailsPanelOpen;
+
         const selectedItem = tripItems.find((item) => item.id === id);
         if (!selectedItem) {
+            if (shouldOpenHiddenDetails) {
+                setIsDetailsPanelOpen(true);
+                return;
+            }
             setIsDetailsPanelOpen((previous) => (autoOpenOnSelect ? true : previous));
             setSelectedItemId(id);
             setSelectedCityIds([]);
@@ -103,6 +118,12 @@ export const useTripSelectionController = ({
         }
 
         if (selectedItem.type !== 'city') {
+            if (shouldOpenHiddenDetails) {
+                setSelectedItemId(id);
+                setSelectedCityIds([]);
+                setIsDetailsPanelOpen(true);
+                return;
+            }
             setIsDetailsPanelOpen((previous) => (autoOpenOnSelect ? true : previous));
             setSelectedItemId(id);
             setSelectedCityIds([]);
@@ -110,6 +131,12 @@ export const useTripSelectionController = ({
         }
 
         if (!options?.multi) {
+            if (shouldOpenHiddenDetails) {
+                setSelectedItemId(id);
+                setSelectedCityIds([id]);
+                setIsDetailsPanelOpen(true);
+                return;
+            }
             setIsDetailsPanelOpen((previous) => (autoOpenOnSelect ? true : previous));
             setSelectedItemId(id);
             setSelectedCityIds([id]);
@@ -137,6 +164,7 @@ export const useTripSelectionController = ({
     }, [
         clearSelection,
         autoOpenOnSelect,
+        isDetailsPanelOpen,
         selectedItemId,
         setSelectedCityIds,
         setSelectedItemId,

--- a/content/updates/2026-03-12-trip-page-mobile-detail-focus-and-context.md
+++ b/content/updates/2026-03-12-trip-page-mobile-detail-focus-and-context.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-03-12-trip-page-mobile-detail-focus-and-context
+version: v0.0.0
+title: "Mobile trip details feel intentional again"
+date: 2026-03-12
+published_at: 2026-03-12T15:00:00Z
+status: draft
+notify_in_app: true
+in_app_hours: 24
+summary: "Improves mobile trip-page detail interactions so selection stays calm, the full drawer opens only when you mean it, and timeline list stops show more useful context."
+---
+
+## Changes
+- [x] [Improved] 📱 Mobile trip details no longer steal focus. Tapping a city or activity now selects it first, tapping again opens the full-height drawer, and closing the drawer clears that selection cleanly.
+- [x] [Improved] 🗺️ On phones, the map now sits above the calendar and timeline so selecting extra trip details feels more deliberate.
+- [x] [Improved] 🛏️ Timeline list stops now surface accommodation and subtle activity-type hints so each stop is easier to scan at a glance.
+- [ ] [Internal] 🧪 Added regression coverage for the new mobile selection flow, full-height drawer behavior, mobile workspace order, and richer timeline list context.

--- a/tests/browser/tripDetailsDrawer.browser.test.ts
+++ b/tests/browser/tripDetailsDrawer.browser.test.ts
@@ -28,11 +28,11 @@ describe('components/TripDetailsDrawer', () => {
     drawerMocks.contentProps = [];
   });
 
-  it('opens as a non-modal peek drawer with a taller passive preview and no overlay', () => {
-    const { rerender } = render(
+  it('opens as a full-height non-modal drawer without the mobile peek state', () => {
+    render(
       React.createElement(TripDetailsDrawer, {
         open: true,
-        expanded: false,
+        expanded: true,
         onOpenChange: vi.fn(),
         onExpandedChange: vi.fn(),
       }, React.createElement('div', null, 'details')),
@@ -42,22 +42,11 @@ describe('components/TripDetailsDrawer', () => {
     expect(drawerMocks.rootProps.at(-1)?.autoFocus).toBe(false);
     expect(drawerMocks.rootProps.at(-1)?.handleOnly).toBe(true);
     expect(drawerMocks.rootProps.at(-1)?.disablePreventScroll).toBe(true);
-    expect(drawerMocks.rootProps.at(-1)?.dismissible).toBe(false);
-    expect(drawerMocks.rootProps.at(-1)?.snapPoints).toEqual(['192px', 0.9]);
-    expect(drawerMocks.rootProps.at(-1)?.activeSnapPoint).toBe('192px');
-    expect(drawerMocks.contentProps.at(-1)?.hideOverlay).toBe(true);
-    expect(String(drawerMocks.contentProps.at(-1)?.className)).toContain('pointer-events-none');
-    expect(screen.getByRole('button', { name: 'Expand trip details drawer' })).toBeInTheDocument();
-
-    rerender(
-      React.createElement(TripDetailsDrawer, {
-        open: true,
-        expanded: true,
-        onOpenChange: vi.fn(),
-        onExpandedChange: vi.fn(),
-      }, React.createElement('div', null, 'details')),
-    );
-
+    expect(drawerMocks.rootProps.at(-1)?.dismissible).toBe(true);
+    expect(drawerMocks.rootProps.at(-1)?.snapPoints).toEqual([0.9]);
     expect(drawerMocks.rootProps.at(-1)?.activeSnapPoint).toBe(0.9);
+    expect(drawerMocks.contentProps.at(-1)?.hideOverlay).toBe(true);
+    expect(String(drawerMocks.contentProps.at(-1)?.className)).toContain('h-[min(92vh,780px)]');
+    expect(screen.queryByRole('button', { name: 'Expand trip details drawer' })).not.toBeInTheDocument();
   });
 });

--- a/tests/browser/tripview/TripTimelineListView.browser.test.ts
+++ b/tests/browser/tripview/TripTimelineListView.browser.test.ts
@@ -35,10 +35,18 @@ describe('components/tripview/TripTimelineListView', () => {
     const activity = makeActivityItem('activity-b-1', 'Herat', 2.5);
     activity.title = 'Citadel of Herat';
     activity.description = 'Visit the **Citadel** and [book ahead](https://example.com).';
+    activity.activityType = ['culture', 'food'];
 
     const heratCity = makeCityItem({ id: 'city-b', title: 'Herat', startDateOffset: 2.3, duration: 2, color: 'bg-amber-400' });
     heratCity.countryName = 'Iran';
     heratCity.description = '### Must See\n- [x] Markt öffnen\n- [ ] Schlosspark besuchen\n\n### Heads Up\n- [ ] Stay near the main square after sunset.\n\nHistoric center with **old citadel walls**.\n~~Altprogramm~~';
+    heratCity.hotels = [
+      {
+        id: 'hotel-b-1',
+        name: 'Caravanserai Hotel',
+        address: 'Old Town, Herat',
+      },
+    ];
     const kabulCity = makeCityItem({ id: 'city-a', title: 'Kabul', startDateOffset: 0, duration: 2, color: 'bg-rose-400' });
     kabulCity.countryName = 'Afghanistan';
 
@@ -103,12 +111,17 @@ describe('components/tripview/TripTimelineListView', () => {
     expect(screen.queryByText('From Kabul via Train')).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Must See' })).toHaveClass('font-black');
     expect(screen.getByText('old citadel walls', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('Caravanserai Hotel')).toBeInTheDocument();
+    expect(screen.getByText('Old Town, Herat')).toBeInTheDocument();
     const checkboxes = screen.getAllByRole('checkbox');
     expect(checkboxes).toHaveLength(2);
     expect(screen.getByText('Stay near the main square after sunset.').closest('li')).toHaveAttribute('data-heads-up-banner', 'true');
     expect(screen.getByText('Altprogramm')).toBeInTheDocument();
     expect(screen.queryByText('**Citadel**')).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'book ahead' })).toHaveAttribute('href', 'https://example.com');
+    expect(screen.getByTitle('Culture')).toBeInTheDocument();
+    expect(screen.getByTitle('Food')).toBeInTheDocument();
+    expect(screen.getByTitle('Culture').parentElement).toHaveClass('-space-x-2');
 
     const heratHeading = screen.getByRole('heading', { name: 'Herat' });
     expect(heratHeading.closest('header')).toHaveClass('sticky');
@@ -217,6 +230,85 @@ describe('components/tripview/TripTimelineListView', () => {
       fireEvent.scroll(viewport);
 
       expect(onSelect).toHaveBeenCalledWith('city-b', { isCity: true });
+    } finally {
+      rafSpy.mockRestore();
+      cancelRafSpy.mockRestore();
+    }
+  });
+
+  it('does not auto-select a city while scrolling when mobile scroll sync is disabled', () => {
+    const kabulCity = makeCityItem({ id: 'city-a', title: 'Kabul', startDateOffset: 0, duration: 2, color: 'bg-rose-400' });
+    const heratCity = makeCityItem({ id: 'city-b', title: 'Herat', startDateOffset: 2.2, duration: 2, color: 'bg-amber-400' });
+    const trip = makeTrip({
+      startDate: '2026-03-01',
+      items: [kabulCity, makeTravelItem('travel-a-b', 2.05, 'Morning transfer'), heratCity],
+    });
+    const onSelect = vi.fn();
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    const cancelRafSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+
+    try {
+      const { container } = render(
+        React.createElement(TripTimelineListView, {
+          trip,
+          selectedItemId: 'city-a',
+          onSelect,
+          enableScrollActiveCitySelection: false,
+        }),
+      );
+
+      const viewport = container.querySelector('.h-full.overflow-y-auto') as HTMLDivElement | null;
+      const cityASection = container.querySelector('[data-city-section-id="city-a"]') as HTMLElement | null;
+      const cityBSection = container.querySelector('[data-city-section-id="city-b"]') as HTMLElement | null;
+      if (!viewport || !cityASection || !cityBSection) {
+        throw new Error('Expected viewport and city sections to render');
+      }
+
+      Object.defineProperty(viewport, 'clientHeight', {
+        configurable: true,
+        value: 600,
+      });
+      viewport.getBoundingClientRect = vi.fn(() => ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 900,
+        bottom: 600,
+        width: 900,
+        height: 600,
+        toJSON: () => ({}),
+      })) as any;
+      cityASection.getBoundingClientRect = vi.fn(() => ({
+        x: 0,
+        y: -260,
+        top: -260,
+        left: 0,
+        right: 900,
+        bottom: 120,
+        width: 900,
+        height: 380,
+        toJSON: () => ({}),
+      })) as any;
+      cityBSection.getBoundingClientRect = vi.fn(() => ({
+        x: 0,
+        y: 40,
+        top: 40,
+        left: 0,
+        right: 900,
+        bottom: 420,
+        width: 900,
+        height: 380,
+        toJSON: () => ({}),
+      })) as any;
+
+      fireEvent.wheel(viewport);
+      fireEvent.scroll(viewport);
+
+      expect(onSelect).not.toHaveBeenCalled();
     } finally {
       rafSpy.mockRestore();
       cancelRafSpy.mockRestore();

--- a/tests/browser/tripview/TripViewPlannerWorkspace.browser.test.ts
+++ b/tests/browser/tripview/TripViewPlannerWorkspace.browser.test.ts
@@ -115,6 +115,17 @@ describe('components/tripview/TripViewPlannerWorkspace', () => {
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
+  it('renders the map above the timeline on mobile', () => {
+    const props = baseProps();
+    props.isMobile = true;
+
+    render(React.createElement(TripViewPlannerWorkspace, props));
+
+    const mapPane = screen.getByTestId('planner-mobile-map-pane');
+    const timelinePane = screen.getByTestId('planner-mobile-timeline-pane');
+    expect(mapPane.compareDocumentPosition(timelinePane) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('minimizes map into floating mode when toggle is clicked', () => {
     const props = baseProps();
     render(React.createElement(TripViewPlannerWorkspace, props));

--- a/tests/browser/tripview/useTripSelectionController.browser.test.ts
+++ b/tests/browser/tripview/useTripSelectionController.browser.test.ts
@@ -29,6 +29,7 @@ describe('components/tripview/useTripSelectionController', () => {
         isHistoryOpen: false,
         isTripInfoOpen: false,
         autoOpenOnSelect: false,
+        clearSelectionOnClose: true,
         setPendingLabel,
         handleUpdateItems,
       });
@@ -46,5 +47,95 @@ describe('components/tripview/useTripSelectionController', () => {
     });
 
     expect(result.current.detailsPanelVisible).toBe(true);
+  });
+
+  it('re-opens hidden mobile details when the same selected item is tapped again', () => {
+    const setPendingLabel = vi.fn();
+    const handleUpdateItems = vi.fn();
+    const tripItems = [
+      makeCityItem({ id: 'city-1', title: 'Bangkok', startDateOffset: 0, duration: 2 }),
+      makeActivityItem('activity-1', 'Bangkok', 0),
+    ];
+
+    const { result } = renderHook(() => {
+      const [selectedItemId, setSelectedItemId] = React.useState<string | null>(null);
+      const [selectedCityIds, setSelectedCityIds] = React.useState<string[]>([]);
+
+      return useTripSelectionController({
+        tripItems,
+        displayTripItems: tripItems,
+        selectedItemId,
+        setSelectedItemId,
+        selectedCityIds,
+        setSelectedCityIds,
+        isHistoryOpen: false,
+        isTripInfoOpen: false,
+        autoOpenOnSelect: false,
+        clearSelectionOnClose: true,
+        setPendingLabel,
+        handleUpdateItems,
+      });
+    });
+
+    act(() => {
+      result.current.handleTimelineSelect('activity-1');
+    });
+
+    expect(result.current.detailsPanelVisible).toBe(false);
+
+    act(() => {
+      result.current.handleTimelineSelect('activity-1');
+    });
+
+    expect(result.current.detailsPanelVisible).toBe(true);
+  });
+
+  it('clears the mobile selection when the details drawer closes', () => {
+    const setPendingLabel = vi.fn();
+    const handleUpdateItems = vi.fn();
+    const tripItems = [
+      makeCityItem({ id: 'city-1', title: 'Bangkok', startDateOffset: 0, duration: 2 }),
+      makeActivityItem('activity-1', 'Bangkok', 0),
+    ];
+
+    const { result } = renderHook(() => {
+      const [selectedItemId, setSelectedItemId] = React.useState<string | null>(null);
+      const [selectedCityIds, setSelectedCityIds] = React.useState<string[]>([]);
+
+      return useTripSelectionController({
+        tripItems,
+        displayTripItems: tripItems,
+        selectedItemId,
+        setSelectedItemId,
+        selectedCityIds,
+        setSelectedCityIds,
+        isHistoryOpen: false,
+        isTripInfoOpen: false,
+        autoOpenOnSelect: false,
+        clearSelectionOnClose: true,
+        setPendingLabel,
+        handleUpdateItems,
+      });
+    });
+
+    act(() => {
+      result.current.handleTimelineSelect('city-1', { isCity: true });
+    });
+
+    expect(result.current.hasSelection).toBe(true);
+
+    act(() => {
+      result.current.openDetailsPanel();
+    });
+
+    expect(result.current.detailsPanelVisible).toBe(true);
+
+    act(() => {
+      result.current.closeDetailsPanel();
+    });
+
+    expect(result.current.hasSelection).toBe(false);
+    expect(result.current.detailsPanelVisible).toBe(false);
+    expect(result.current.selectedCitiesInTimeline).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- make mobile trip detail selection intentional instead of auto-opening the drawer
- restore a full-height mobile details drawer and clear selection when it closes
- move the mobile map above the calendar/timeline and add richer timeline list context

## Testing
- pnpm test:core
- pnpm i18n:validate
- pnpm updates:validate
- pnpm dlx react-doctor@latest . --verbose --diff

## Release note
- added draft update: `content/updates/2026-03-12-trip-page-mobile-detail-focus-and-context.md`
