### PR TITLE
Prefer single-PR release note publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ This repository uses markdown release files as the source of truth for product u
 - Do not introduce native HTML `<select>` controls in product UI. Always use the shared styled Select (`components/ui/select`, shadcn/Radix) for dropdowns to keep visual and interaction behavior consistent across the app.
 - After completing any feature/fix/change, update `content/updates/*.md`.
 - Maintain exactly one release note file per worktree/feature. Do not create multiple incremental release-note files for the same work.
-- Keep that single release note in `status: draft` throughout feature PR development.
-- After merge to `main`, publish metadata in a follow-up update: set `status: published`, assign the next version, and set `published_at` to the actual post-merge deploy/merge timestamp (before 23:00 UTC).
+- Keep that single release note in `status: draft` while the feature is still in progress.
+- Prefer publishing release metadata in the same PR when the release is being finalized. Use a follow-up update only if the feature has already merged without final metadata or the publish timestamp/version must be corrected afterward.
 - Use `[x]` for website-visible user-facing items.
 - Use `[ ]` for hidden internal items.
 - Keep technical identifiers out of visible items (no route paths, code symbols, endpoints, or environment keys in `[x]` lines).

--- a/docs/UPDATE_FORMAT.md
+++ b/docs/UPDATE_FORMAT.md
@@ -34,7 +34,7 @@ summary: "One concise summary sentence."
 - `version`: release label shown in update UI (for example `v0.7.0`).
 - `date`: release date (`YYYY-MM-DD`).
 - `published_at`: exact timestamp when the release became live on `main` (merge/deploy time), used for in-app 24h notice windows and ordering. **Must be < 23:00 UTC** — the site renders dates in CET (UTC+1), so timestamps at or after 23:00 UTC display as the next calendar day. Do **not** use feature start time or first draft time.
-- `status`: `published` or `draft`. Keep feature/worktree entries as `draft` while the PR is open. Publish metadata only after merge to `main`.
+- `status`: `published` or `draft`. Keep feature/worktree entries as `draft` while the work is still in progress. Prefer publishing metadata in the main feature PR when the release is being finalized; use a follow-up only if the feature already merged without final metadata or the publish metadata needs correction afterward.
 - `notify_in_app`: if `true`, latest published release can appear inside trip view.
 - `in_app_hours`: notice lifetime in hours (current default: `24`).
 - `summary`: short description for cards/banners.
@@ -69,18 +69,17 @@ Mark as `[ ]` (hidden) when the item:
 
 Write visible items from the user's perspective — focus on the benefit, not the implementation.
 
-## Recommended workflow (draft-until-merge)
+## Recommended workflow
 1. Use exactly one release note file per worktree/feature.
 2. Keep coding notes locally while implementing; avoid creating multiple incremental release files for one feature.
-3. Before opening/updating the PR, keep the file accurate but leave `status: draft`.
-4. Merge the feature PR to `main`.
-5. After merge, publish metadata in a follow-up update:
+3. Keep the file accurate while the feature is in progress and leave `status: draft` until you are ready to finalize the release metadata.
+4. Prefer publishing the metadata in the main feature PR:
    - Get the next merged/published version with `pnpm updates:next-version`.
    - Set `status: published`.
-   - Set `published_at` to the actual post-merge deploy timestamp (or merge timestamp if deploy time is unavailable), always before 23:00 UTC.
+   - Set `published_at` to the actual deploy timestamp if available, otherwise the expected merge timestamp, always before 23:00 UTC.
    - Set `notify_in_app` as needed.
-6. Commit and push the metadata update so `/updates` reflects the final release ordering.
-7. Start the next draft file only for the next distinct feature/release.
+5. If the feature already merged without final metadata, publish it in one follow-up update instead of creating extra incremental release-note files.
+6. Start the next draft file only for the next distinct feature/release.
 
 ## Versioning policy
 - Every new published release must use a new version.


### PR DESCRIPTION
## Summary
- update agent guidance to prefer publishing release-note metadata in the same feature PR
- keep follow-up publish PRs as the fallback only when metadata was missed or needs correction

## Testing
- not run (docs/process-only change)
