### PR TITLE
Polish trip mobile drawer and activity pills

### DIFF
--- a/components/TripDetailsDrawer.tsx
+++ b/components/TripDetailsDrawer.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Drawer, DrawerContent } from './ui/drawer';
 
-const FULL_SNAP_POINT = 0.9;
-
 export interface TripDetailsDrawerProps {
     open: boolean;
     expanded: boolean;
@@ -15,30 +13,16 @@ export const TripDetailsDrawer: React.FC<TripDetailsDrawerProps> = ({
     open,
     expanded: _expanded,
     onOpenChange,
-    onExpandedChange,
+    onExpandedChange: _onExpandedChange,
     children,
 }) => {
     return (
         <Drawer
             open={open}
             onOpenChange={onOpenChange}
-            activeSnapPoint={FULL_SNAP_POINT}
-            setActiveSnapPoint={(nextSnapPoint) => {
-                const isExpanded = nextSnapPoint === FULL_SNAP_POINT;
-                onExpandedChange(isExpanded);
-                if (!isExpanded) onOpenChange(false);
-            }}
-            snapPoints={[FULL_SNAP_POINT]}
-            shouldScaleBackground={false}
-            modal={false}
             autoFocus={false}
-            handleOnly
-            disablePreventScroll
-            dismissible
-            snapToSequentialPoint
         >
             <DrawerContent
-                hideOverlay
                 className="h-[min(92vh,780px)] p-0"
                 accessibleTitle="Trip details"
                 accessibleDescription="View and edit selected city, travel segment, or activity details."

--- a/components/tripview/TripTimelineListView.tsx
+++ b/components/tripview/TripTimelineListView.tsx
@@ -4,7 +4,7 @@ import remarkGfm from 'remark-gfm';
 import { Hotel, MapPin } from 'lucide-react';
 
 import { TransportModeIcon } from '../TransportModeIcon';
-import { ActivityTypeIcon, formatActivityTypeLabel, getActivityTypePaletteParts } from '../ActivityTypeVisuals';
+import { ActivityTypeIcon, formatActivityTypeLabel, getActivityTypePaletteClass } from '../ActivityTypeVisuals';
 import { Checkbox } from '../ui/checkbox';
 import type { ITrip } from '../../types';
 import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analyticsService';
@@ -705,21 +705,20 @@ export const TripTimelineListView: React.FC<TripTimelineListViewProps> = ({
                                                                         </div>
                                                                     )}
                                                                     {activityTypes.length > 0 && (
-                                                                        <div className="mt-3 flex items-center -space-x-2 ps-1">
-                                                                            {activityTypes.map((type) => {
+                                                                        <div className="group/pills mt-3 flex items-center ps-1">
+                                                                            {activityTypes.map((type, index) => {
                                                                                 const label = formatActivityTypeLabel(type);
-                                                                                const palette = getActivityTypePaletteParts(type);
                                                                                 return (
                                                                                     <span
                                                                                         key={`${activity.item.id}-${type}`}
                                                                                         title={label}
                                                                                         aria-label={label}
-                                                                                        className="group/type relative inline-flex h-8 items-center overflow-hidden rounded-full border border-slate-200 bg-white/95 pe-0 shadow-sm transition-[padding,transform,box-shadow] duration-200 hover:z-10 hover:-translate-y-0.5 hover:pe-3 hover:shadow-md"
+                                                                                        className={`relative inline-flex h-8 items-center overflow-hidden rounded-full border pe-0 opacity-85 transition-[margin,opacity] duration-200 ease-out [z-index:calc(sibling-count()-sibling-index())] ${getActivityTypePaletteClass(type)} ${index > 0 ? '-ms-2 group-hover/pills:ms-2 group-focus-visible:ms-2' : ''} group-hover/pills:opacity-100 group-focus-visible:opacity-100`}
                                                                                     >
-                                                                                        <span className={`inline-flex size-8 shrink-0 items-center justify-center rounded-full border ${palette.bg} ${palette.border} ${palette.text}`}>
+                                                                                        <span className="inline-flex size-8 shrink-0 items-center justify-center">
                                                                                             <ActivityTypeIcon type={type} size={12} />
                                                                                         </span>
-                                                                                        <span className="max-w-0 overflow-hidden whitespace-nowrap ps-0 text-[11px] font-medium text-slate-600 opacity-0 transition-all duration-200 group-hover/type:max-w-24 group-hover/type:ps-1.5 group-hover/type:opacity-100">
+                                                                                        <span className="max-w-0 overflow-hidden whitespace-nowrap pe-0 ps-0 text-[11px] font-semibold opacity-0 transition-[max-width,padding,opacity] duration-200 ease-out [transition-delay:0ms] group-hover/pills:max-w-24 group-hover/pills:pe-2 group-hover/pills:ps-0.5 group-hover/pills:opacity-100 group-hover/pills:[transition-delay:calc((sibling-index()-1)*36ms)] group-focus-visible:max-w-24 group-focus-visible:pe-2 group-focus-visible:ps-0.5 group-focus-visible:opacity-100 group-focus-visible:[transition-delay:calc((sibling-index()-1)*36ms)]">
                                                                                             {label}
                                                                                         </span>
                                                                                     </span>

--- a/components/tripview/TripViewPlannerWorkspace.tsx
+++ b/components/tripview/TripViewPlannerWorkspace.tsx
@@ -359,7 +359,7 @@ export const TripViewPlannerWorkspace: React.FC<TripViewPlannerWorkspaceProps> =
                         <div
                             ref={mapViewportRef}
                             data-testid="planner-mobile-map-pane"
-                            className={`${isMobileMapExpanded ? 'fixed inset-x-0 bottom-0 h-[70vh] z-[1450] border-t border-gray-200 shadow-2xl bg-white' : 'relative h-[34vh] min-h-[220px] bg-gray-100'}`}
+                            className={`${isMobileMapExpanded ? 'fixed inset-x-0 bottom-0 h-[70vh] z-[1450] border-t border-gray-200 shadow-2xl bg-white' : 'relative h-[26vh] min-h-[180px] bg-gray-100'}`}
                         >
                             {renderMap('vertical', false)}
                         </div>

--- a/content/updates/2026-03-12-trip-mobile-drawer-and-activity-pill-polish.md
+++ b/content/updates/2026-03-12-trip-mobile-drawer-and-activity-pill-polish.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-03-12-trip-mobile-drawer-and-activity-pill-polish
+version: v0.95.0
+title: "Trip mobile drawer and timeline cues feel lighter again"
+date: 2026-03-12
+published_at: 2026-03-12T15:01:00Z
+status: published
+notify_in_app: true
+in_app_hours: 24
+summary: "Restores a familiar mobile trip drawer, makes timeline activity cues lighter, and gives the mobile map more breathing room."
+---
+
+## Changes
+- [x] [Improved] 📱 Mobile trip details keep the second-tap opening logic, but the drawer now uses the familiar backdrop, swipe behavior, and sheet animation again.
+- [x] [Improved] 🏷️ Timeline activity hints now stack lightly and expand together into readable colored pills with text, so they stay useful without pulling too much attention.
+- [x] [Improved] 🗺️ The default mobile map now takes a bit less vertical space, leaving more room for the timeline below.
+- [ ] [Internal] 🧪 Updated trip-page drawer, timeline-list, and mobile workspace regression coverage for the restored sheet behavior and the new pill styling.

--- a/tests/browser/tripDetailsDrawer.browser.test.ts
+++ b/tests/browser/tripDetailsDrawer.browser.test.ts
@@ -28,7 +28,7 @@ describe('components/TripDetailsDrawer', () => {
     drawerMocks.contentProps = [];
   });
 
-  it('opens as a full-height non-modal drawer without the mobile peek state', () => {
+  it('uses the default mobile drawer behavior with overlay and full-height content', () => {
     render(
       React.createElement(TripDetailsDrawer, {
         open: true,
@@ -38,15 +38,14 @@ describe('components/TripDetailsDrawer', () => {
       }, React.createElement('div', null, 'details')),
     );
 
-    expect(drawerMocks.rootProps.at(-1)?.modal).toBe(false);
     expect(drawerMocks.rootProps.at(-1)?.autoFocus).toBe(false);
-    expect(drawerMocks.rootProps.at(-1)?.handleOnly).toBe(true);
-    expect(drawerMocks.rootProps.at(-1)?.disablePreventScroll).toBe(true);
-    expect(drawerMocks.rootProps.at(-1)?.dismissible).toBe(true);
-    expect(drawerMocks.rootProps.at(-1)?.snapPoints).toEqual([0.9]);
-    expect(drawerMocks.rootProps.at(-1)?.activeSnapPoint).toBe(0.9);
-    expect(drawerMocks.contentProps.at(-1)?.hideOverlay).toBe(true);
+    expect(drawerMocks.rootProps.at(-1)?.modal).toBeUndefined();
+    expect(drawerMocks.rootProps.at(-1)?.handleOnly).toBeUndefined();
+    expect(drawerMocks.rootProps.at(-1)?.disablePreventScroll).toBeUndefined();
+    expect(drawerMocks.rootProps.at(-1)?.dismissible).toBeUndefined();
+    expect(drawerMocks.rootProps.at(-1)?.snapPoints).toBeUndefined();
+    expect(drawerMocks.rootProps.at(-1)?.activeSnapPoint).toBeUndefined();
+    expect(drawerMocks.contentProps.at(-1)?.hideOverlay).toBeUndefined();
     expect(String(drawerMocks.contentProps.at(-1)?.className)).toContain('h-[min(92vh,780px)]');
-    expect(screen.queryByRole('button', { name: 'Expand trip details drawer' })).not.toBeInTheDocument();
   });
 });

--- a/tests/browser/tripview/TripTimelineListView.browser.test.ts
+++ b/tests/browser/tripview/TripTimelineListView.browser.test.ts
@@ -121,7 +121,14 @@ describe('components/tripview/TripTimelineListView', () => {
     expect(screen.getByRole('link', { name: 'book ahead' })).toHaveAttribute('href', 'https://example.com');
     expect(screen.getByTitle('Culture')).toBeInTheDocument();
     expect(screen.getByTitle('Food')).toBeInTheDocument();
-    expect(screen.getByTitle('Culture').parentElement).toHaveClass('-space-x-2');
+    expect(screen.getByTitle('Culture')).not.toHaveClass('shadow-sm');
+    expect(screen.getByTitle('Culture')).toHaveClass('-ms-2');
+    expect(screen.getByTitle('Culture')).toHaveClass('group-hover/pills:ms-2');
+    expect(screen.getByTitle('Culture').getAttribute('class')).toContain('[z-index:calc(sibling-count()-sibling-index())]');
+    expect(screen.getByTitle('Food').lastElementChild).toHaveClass('group-hover/pills:max-w-24');
+    expect(screen.getByTitle('Food').lastElementChild).toHaveClass('group-focus-visible:max-w-24');
+    expect(screen.getByTitle('Food').lastElementChild).toHaveClass('ease-out');
+    expect(screen.getByTitle('Food').lastElementChild?.getAttribute('class')).toContain('group-hover/pills:[transition-delay:calc((sibling-index()-1)*36ms)]');
 
     const heratHeading = screen.getByRole('heading', { name: 'Herat' });
     expect(heratHeading.closest('header')).toHaveClass('sticky');

--- a/tests/browser/tripview/TripViewPlannerWorkspace.browser.test.ts
+++ b/tests/browser/tripview/TripViewPlannerWorkspace.browser.test.ts
@@ -123,6 +123,8 @@ describe('components/tripview/TripViewPlannerWorkspace', () => {
 
     const mapPane = screen.getByTestId('planner-mobile-map-pane');
     const timelinePane = screen.getByTestId('planner-mobile-timeline-pane');
+    expect(mapPane.className).toContain('h-[26vh]');
+    expect(mapPane.className).toContain('min-h-[180px]');
     expect(mapPane.compareDocumentPosition(timelinePane) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary
- restore the mobile trip details drawer to the default backdrop, swipe, and animation behavior
- keep the mobile second-tap opening logic and the non-auto-opening timeline selection behavior
- refine timeline activity pills with quieter stacked pills, grouped hover/focus expansion, staggered ease-out motion, and a smaller mobile map height
- publish the release note as `v0.95.0`

## Testing
- `pnpm test:core`
- `pnpm updates:validate`
- `pnpm dlx react-doctor@latest . --verbose --diff`
