### PR TITLE
Fix admin trip-generation retry persistence

### DIFF
--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -1982,6 +1982,7 @@ const useTripViewRender = ({
                 source: source === 'trip_info' ? 'trip_info_modal' : 'trip_status_strip',
                 contextSource: 'trip_retry',
                 modelId: selectedRetryModelId,
+                adminOverride: isAdminFallbackView && adminOverrideEnabled,
                 onTripUpdate: (updatedTrip) => {
                     if (shouldPollTripGenerationState(updatedTrip, Date.now())) {
                         pendingRetryGenerationStateRef.current = false;

--- a/content/updates/2026-03-03-failed-trip-generation-observability-retry.md
+++ b/content/updates/2026-03-03-failed-trip-generation-observability-retry.md
@@ -113,6 +113,7 @@ summary: "Trip generation now keeps running in the background, recovers more saf
 - [x] [Improved] 🎨 Trip city lanes now keep the intended default palette depth after loading, avoiding both washed-out and over-dark itinerary colors.
 - [x] [Fixed] 🔄 Reopening a newly created trip after background loading resumes no longer crashes the trip page before the itinerary appears.
 - [ ] [Internal] 🛠️ Admin override-enabled trip views can now restart failed generation even when the trip would otherwise be read-only for normal traveler edits.
+- [ ] [Internal] 🛡️ Admin-triggered retry state sync now persists through the admin override commit path, fixing failed restarts that could log an attempt but never queue it.
 - [ ] [Internal] 🛠️ Trip view settings sync now emits only normalized payload deltas and ignores callback-identity churn, further reducing duplicate `user_settings` writes.
 - [ ] [Internal] 🛠️ Visual-diff commit detection now normalizes zoom precision and ignores sub-threshold jitter, reducing repeated idle `upsert_trip` loops.
 - [ ] [Internal] 🛠️ Local Vite dev now proxies async generation-worker requests to Netlify dev and logs explicit guidance when `pnpm dev:netlify` is not running, replacing misleading raw 404 worker errors.

--- a/services/tripGenerationRetryService.ts
+++ b/services/tripGenerationRetryService.ts
@@ -23,7 +23,12 @@ import {
 } from './tripGenerationDiagnosticsService';
 import type { ITrip, TripGenerationFlow, TripGenerationInputSnapshot, TripGenerationState } from '../types';
 import { enqueueAsyncTripGenerationJob } from './tripGenerationAsyncEnqueueService';
-import { dbGetTrip, dbUpsertTrip, ensureDbSession } from './dbApi';
+import {
+    dbAdminOverrideTripCommit,
+    dbGetTrip,
+    dbUpsertTrip,
+    ensureDbSession,
+} from './dbApi';
 import {
     isTripGenerationJobActive,
     listTripGenerationJobsByTrip,
@@ -36,6 +41,7 @@ export interface RetryTripGenerationOptions {
     onTripUpdate?: (trip: ITrip) => Promise<void> | void;
     contextSource?: string;
     modelId?: string | null;
+    adminOverride?: boolean;
 }
 
 export interface RetryTripGenerationResult {
@@ -131,6 +137,25 @@ const resolveRetryRoundTrip = (
         return Boolean(options.roundTrip || trip.roundTrip);
     }
     return true;
+};
+
+const persistRetryTripState = async (
+    trip: ITrip,
+    options: RetryTripGenerationOptions,
+): Promise<boolean> => {
+    await ensureDbSession();
+
+    if (options.adminOverride) {
+        const persisted = await dbAdminOverrideTripCommit(
+            trip,
+            undefined,
+            'Data: Admin retry state sync',
+        );
+        return Boolean(persisted?.tripId);
+    }
+
+    const persistedTripId = await dbUpsertTrip(trip, undefined);
+    return Boolean(persistedTripId);
 };
 
 const isTerminalAttemptState = (state: string | null | undefined): boolean => (
@@ -282,8 +307,7 @@ export const retryTripGenerationWithDefaultModel = async (
             throw new Error('Retry attempt could not be initialized.');
         }
 
-        await ensureDbSession();
-        const persistedTripId = await dbUpsertTrip(runningTripWithCanonicalAttempt, undefined);
+        const persistedTripId = await persistRetryTripState(runningTripWithCanonicalAttempt, options);
         if (!persistedTripId) {
             throw new Error('Retry attempt could not be persisted before queueing.');
         }

--- a/tests/services/tripGenerationRetryService.test.ts
+++ b/tests/services/tripGenerationRetryService.test.ts
@@ -10,6 +10,7 @@ const finishAttemptLogMock = vi.fn();
 const listOwnerAttemptLogsMock = vi.fn();
 const enqueueAsyncTripGenerationJobMock = vi.fn();
 const dbGetTripMock = vi.fn();
+const dbAdminOverrideTripCommitMock = vi.fn();
 const dbUpsertTripMock = vi.fn();
 const ensureDbSessionMock = vi.fn();
 const waitForTripAttemptPersistenceMock = vi.fn();
@@ -38,6 +39,7 @@ vi.mock('../../services/tripGenerationAsyncEnqueueService', () => ({
 }));
 
 vi.mock('../../services/dbApi', () => ({
+  dbAdminOverrideTripCommit: (...args: unknown[]) => dbAdminOverrideTripCommitMock(...args),
   dbGetTrip: (...args: unknown[]) => dbGetTripMock(...args),
   dbUpsertTrip: (...args: unknown[]) => dbUpsertTripMock(...args),
   ensureDbSession: (...args: unknown[]) => ensureDbSessionMock(...args),
@@ -143,6 +145,7 @@ describe('retryTripGenerationWithDefaultModel', () => {
     enqueueAsyncTripGenerationJobMock.mockReset();
     buildClassicItineraryPromptMock.mockClear();
     dbGetTripMock.mockReset();
+    dbAdminOverrideTripCommitMock.mockReset();
     dbUpsertTripMock.mockReset();
     ensureDbSessionMock.mockReset();
     waitForTripAttemptPersistenceMock.mockReset();
@@ -154,6 +157,7 @@ describe('retryTripGenerationWithDefaultModel', () => {
     finishAttemptLogMock.mockResolvedValue(undefined);
     enqueueAsyncTripGenerationJobMock.mockResolvedValue(true);
     dbGetTripMock.mockResolvedValue(null);
+    dbAdminOverrideTripCommitMock.mockResolvedValue({ tripId: 'trip-existing', versionId: 'version-1' });
     dbUpsertTripMock.mockResolvedValue('trip-existing');
     ensureDbSessionMock.mockResolvedValue('user-1');
     waitForTripAttemptPersistenceMock.mockResolvedValue(true);
@@ -226,6 +230,24 @@ describe('retryTripGenerationWithDefaultModel', () => {
     expect(waitForTripAttemptPersistenceMock).toHaveBeenCalledTimes(1);
     expect(dbUpsertTripMock.mock.invocationCallOrder[0]).toBeLessThan(waitForTripAttemptPersistenceMock.mock.invocationCallOrder[0]);
     expect(finishAttemptLogMock).not.toHaveBeenCalled();
+  });
+
+  it('persists admin fallback retries through the admin override commit path', async () => {
+    const result = await retryTripGenerationWithDefaultModel(buildTrip(), {
+      source: 'trip_status_strip',
+      adminOverride: true,
+    });
+
+    expect(result.state).toBe('queued');
+    expect(dbAdminOverrideTripCommitMock).toHaveBeenCalledTimes(1);
+    expect(dbAdminOverrideTripCommitMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'trip-existing' }),
+      undefined,
+      'Data: Admin retry state sync',
+    );
+    expect(dbUpsertTripMock).not.toHaveBeenCalled();
+    expect(waitForTripAttemptPersistenceMock).toHaveBeenCalledTimes(1);
+    expect(enqueueAsyncTripGenerationJobMock).toHaveBeenCalledTimes(1);
   });
 
   it('keeps same trip id and records failed retry when enqueue fails', async () => {


### PR DESCRIPTION
## Summary
- persist admin-triggered generation retries through the admin override commit path
- pass the admin override retry flag from the trip view into the retry service
- add a regression test covering admin fallback retry persistence

## Testing
- pnpm test:core
- pnpm updates:validate
