### PR TITLE
Redesign the features page with a location-aware globe hero

### DIFF
--- a/components/marketing/features/FeaturesBentoGrid.tsx
+++ b/components/marketing/features/FeaturesBentoGrid.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { LinkSimple, MapTrifold, Printer, ShareNetwork, Sparkle } from '@phosphor-icons/react';
+import type { Icon } from '@phosphor-icons/react';
+import { Card, CardContent } from '../../ui/card';
+import { cn } from '../../../lib/utils';
+
+export interface FeatureBentoItem {
+    id: 'itinerary' | 'timeline' | 'inspiration' | 'sharing' | 'relive';
+    eyebrow: string;
+    title: string;
+    description: string;
+    detail: string;
+}
+
+interface BentoVisualProps {
+    item: FeatureBentoItem;
+}
+
+const layoutClasses: Record<FeatureBentoItem['id'], string> = {
+    itinerary: 'md:col-span-3 md:row-span-2',
+    timeline: 'md:col-span-3',
+    inspiration: 'md:col-span-2',
+    sharing: 'md:col-span-2',
+    relive: 'md:col-span-2',
+};
+
+const iconMap: Record<FeatureBentoItem['id'], Icon> = {
+    itinerary: Sparkle,
+    timeline: MapTrifold,
+    inspiration: LinkSimple,
+    sharing: ShareNetwork,
+    relive: Printer,
+};
+
+const ItineraryVisual: React.FC<BentoVisualProps> = ({ item }) => (
+    <div className="rounded-[16px] border border-slate-200 bg-slate-50 p-5">
+        <div className="flex flex-wrap gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1">Lisbon</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1">Porto</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1">Bilbao</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1">Bordeaux</span>
+        </div>
+        <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_180px]">
+            <div className="rounded-[14px] border border-slate-200 bg-white p-4">
+                <div className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                    Draft route
+                </div>
+                <div className="mt-4 flex items-center gap-3 text-sm font-medium text-slate-700">
+                    <span>Coast cities</span>
+                    <span className="h-px flex-1 bg-slate-200" />
+                    <span>Train-friendly</span>
+                    <span className="h-px flex-1 bg-slate-200" />
+                    <span>Late sunsets</span>
+                </div>
+                <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                    <div className="rounded-[12px] bg-slate-50 p-3">
+                        <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Trip rhythm</p>
+                        <p className="mt-2 text-lg font-bold text-slate-950">Slow mornings, packed evenings</p>
+                    </div>
+                    <div className="rounded-[12px] border border-accent-200 bg-accent-50 p-3 text-accent-800">
+                        <p className="text-xs uppercase tracking-[0.18em] text-accent-700">Ready in</p>
+                        <p className="mt-2 text-3xl font-black">26s</p>
+                    </div>
+                </div>
+            </div>
+            <div className="rounded-[14px] border border-slate-200 bg-white p-4">
+                <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Why it lands</p>
+                <p className="mt-3 text-lg font-bold text-slate-950">{item.detail}</p>
+                <div className="mt-4 grid gap-2 text-sm text-slate-700">
+                    <span className="rounded-full bg-slate-50 px-3 py-2">AI route draft</span>
+                    <span className="rounded-full bg-slate-50 px-3 py-2">Activity context</span>
+                    <span className="rounded-full bg-slate-50 px-3 py-2">Booking-ready notes</span>
+                </div>
+            </div>
+        </div>
+    </div>
+);
+
+const TimelineVisual: React.FC<BentoVisualProps> = ({ item }) => (
+    <div className="rounded-[16px] border border-slate-200 bg-slate-50 p-5">
+        <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+            <span>Route edits</span>
+            <span>{item.detail}</span>
+        </div>
+        <div className="mt-5 grid gap-3">
+            {['Day 03', 'Day 05', 'Day 08'].map((day, index) => (
+                <div key={day} className="flex items-start gap-3 rounded-[12px] border border-slate-200 bg-white p-3 shadow-sm">
+                    <div className={cn(
+                        'mt-1 size-3 rounded-full',
+                        day === 'Day 03' ? 'bg-accent-500' : day === 'Day 05' ? 'bg-slate-400' : 'bg-slate-300',
+                    )}
+                    />
+                    <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">{day}</p>
+                        <p className="mt-1 text-sm font-medium text-slate-700">
+                            {index === 0 ? 'Stretch beach time in Porto' : index === 1 ? 'Swap train for ferry' : 'Pull dinner closer to the hotel'}
+                        </p>
+                    </div>
+                </div>
+            ))}
+        </div>
+    </div>
+);
+
+const InspirationVisual: React.FC<BentoVisualProps> = ({ item }) => (
+    <div className="overflow-hidden rounded-[16px] border border-slate-200 bg-white">
+        <div className="relative h-48 overflow-hidden">
+            <img
+                src="/images/inspirations/cherry-blossom-trail-480.webp"
+                alt=""
+                aria-hidden="true"
+                className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
+                loading="lazy"
+            />
+            <div className="absolute inset-x-4 bottom-4 rounded-[12px] border border-slate-200 bg-white/96 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-accent-700">{item.detail}</p>
+                <p className="mt-2 text-lg font-bold text-slate-950">Fork a route that already feels believable</p>
+            </div>
+        </div>
+    </div>
+);
+
+const SharingVisual: React.FC<BentoVisualProps> = ({ item }) => (
+    <div className="rounded-[16px] border border-slate-200 bg-slate-50 p-5">
+        <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+            <span>Crew loop</span>
+            <span>{item.detail}</span>
+        </div>
+        <div className="mt-5 flex -space-x-2">
+            {['M', 'J', 'A', 'L'].map((letter, index) => (
+                <div
+                    key={letter}
+                    className={cn(
+                        'flex size-11 items-center justify-center rounded-full border-2 border-white text-sm font-bold text-white shadow-sm',
+                        index === 0 ? 'bg-accent-600' : index === 1 ? 'bg-slate-500' : index === 2 ? 'bg-slate-400' : 'bg-slate-300',
+                    )}
+                >
+                    {letter}
+                </div>
+            ))}
+        </div>
+        <div className="mt-5 grid gap-3">
+            <div className="rounded-[12px] border border-slate-200 bg-white p-3 text-sm text-slate-700 shadow-sm">
+                “Can we keep one slower day here?”
+            </div>
+            <div className="rounded-[12px] border border-slate-200 bg-white p-3 text-sm text-slate-700 shadow-sm">
+                “This route finally makes sense.”
+            </div>
+        </div>
+    </div>
+);
+
+const ReliveVisual: React.FC<BentoVisualProps> = ({ item }) => (
+    <div className="rounded-[16px] border border-slate-200 bg-slate-50 p-5">
+        <div className="grid gap-3">
+            <div className="rounded-[14px] border border-slate-200 bg-white p-4 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Final handoff</p>
+                <p className="mt-2 text-lg font-bold text-slate-900">{item.detail}</p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                        Print view
+                    </span>
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                        Notes intact
+                    </span>
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                        Links attached
+                    </span>
+                </div>
+            </div>
+            <div className="rounded-[14px] border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm">
+                A shareable plan for the trip and a cleaner memory of how it came together.
+            </div>
+        </div>
+    </div>
+);
+
+const BentoVisual: React.FC<BentoVisualProps> = ({ item }) => {
+    switch (item.id) {
+        case 'itinerary':
+            return <ItineraryVisual item={item} />;
+        case 'timeline':
+            return <TimelineVisual item={item} />;
+        case 'inspiration':
+            return <InspirationVisual item={item} />;
+        case 'sharing':
+            return <SharingVisual item={item} />;
+        case 'relive':
+            return <ReliveVisual item={item} />;
+        default:
+            return null;
+    }
+};
+
+export const FeaturesBentoGrid: React.FC<{ items: FeatureBentoItem[] }> = ({ items }) => {
+    return (
+        <div className="grid gap-5 md:grid-cols-6 md:auto-rows-[minmax(220px,auto)]">
+            {items.map((item, index) => {
+                const IconComponent = iconMap[item.id];
+
+                return (
+                    <Card
+                        key={item.id}
+                        className={cn(
+                            'group animate-scroll-fade-up overflow-hidden rounded-[18px] border-slate-200 bg-white py-0 shadow-sm shadow-slate-200/60 transition-all hover:-translate-y-1 hover:shadow-md hover:shadow-slate-200/80',
+                            layoutClasses[item.id],
+                        )}
+                        style={{ animationDelay: `${index * 90}ms` }}
+                    >
+                        <CardContent className="flex h-full flex-col gap-6 px-6 pb-6 pt-6">
+                            <div className="flex items-start justify-between gap-4">
+                                <div>
+                                    <h3 className="text-2xl font-black tracking-tight text-slate-950">
+                                        {item.title}
+                                    </h3>
+                                    <p className="mt-3 max-w-xl text-sm leading-relaxed text-slate-600">
+                                        {item.description}
+                                    </p>
+                                </div>
+                                <div className="flex size-11 shrink-0 items-center justify-center rounded-lg border border-slate-200 bg-slate-50 text-accent-700 shadow-sm">
+                                    <IconComponent size={20} weight="duotone" />
+                                </div>
+                            </div>
+                            <div className="mt-auto"><BentoVisual item={item} /></div>
+                        </CardContent>
+                    </Card>
+                );
+            })}
+        </div>
+    );
+};

--- a/components/marketing/features/FeaturesGlobe.tsx
+++ b/components/marketing/features/FeaturesGlobe.tsx
@@ -1,0 +1,652 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '../../../lib/utils';
+import {
+    ensureRuntimeLocationLoaded,
+    getRuntimeLocationSnapshot,
+    subscribeRuntimeLocation,
+    type RuntimeLocationStoreSnapshot,
+} from '../../../services/runtimeLocationService';
+import {
+    getGlobeRotationForLocation,
+    projectGlobeLocation,
+    type GlobeLocation,
+} from './globeProjection';
+
+interface GlobeCardCopy {
+    detail?: string;
+    emoji: string;
+    id: string;
+    title: string;
+}
+
+interface GlobePreviewCopy {
+    alt: string;
+    title: string;
+}
+
+interface MarkerConfig {
+    id: string;
+    location: GlobeLocation;
+    size: number;
+}
+
+interface ArcConfig {
+    from: GlobeLocation;
+    id: string;
+    to: GlobeLocation;
+}
+
+interface OverlayConfig {
+    anchorId: string;
+    anchorX: number;
+    anchorY: number;
+    depthBoost?: number;
+    id: string;
+    minVisibility: number;
+    offsetX: number;
+    offsetY: number;
+    rotateDeg?: number;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const DEFAULT_ORIGIN_LOCATION: GlobeLocation = [53.5511, 9.9937];
+
+const DESTINATION_MARKERS: MarkerConfig[] = [
+    { id: 'paris', location: [48.8566, 2.3522], size: 0.026 },
+    { id: 'fiji', location: [-17.7134, 178.065], size: 0.024 },
+    { id: 'south-africa', location: [-34.5904, 19.3512], size: 0.024 },
+    { id: 'thailand-preview', location: [13.7563, 100.5018], size: 0.012 },
+    { id: 'route66-chicago', location: [41.8781, -87.6298], size: 0.011 },
+    { id: 'route66-st-louis', location: [38.627, -90.1994], size: 0.0085 },
+    { id: 'route66-amarillo', location: [35.2219, -101.8313], size: 0.0085 },
+    { id: 'route66-santa-monica', location: [34.0195, -118.4912], size: 0.011 },
+];
+
+const ROUTE_66_ARCS: ArcConfig[] = [
+    {
+        id: 'route66-segment-1',
+        from: [41.8781, -87.6298],
+        to: [38.627, -90.1994],
+    },
+    {
+        id: 'route66-segment-2',
+        from: [38.627, -90.1994],
+        to: [35.2219, -101.8313],
+    },
+    {
+        id: 'route66-segment-3',
+        from: [35.2219, -101.8313],
+        to: [34.0195, -118.4912],
+    },
+];
+
+const canvasSizeDefaults = {
+    width: 960,
+    height: 960,
+};
+
+const displaySizeDefaults = {
+    width: 520,
+    height: 520,
+};
+
+const globeRenderConfig = {
+    markerElevation: 0.018,
+    offset: [0, 20] as [number, number],
+    scale: 0.92,
+};
+
+const globeMaskStyle: React.CSSProperties = {
+    WebkitMaskImage: 'radial-gradient(circle at center, black 0%, black 78%, rgba(0,0,0,0.95) 90%, transparent 99%)',
+    maskImage: 'radial-gradient(circle at center, black 0%, black 78%, rgba(0,0,0,0.95) 90%, transparent 99%)',
+    maskRepeat: 'no-repeat',
+    maskSize: '100% 100%',
+};
+
+const getRuntimeCoordinates = (snapshot: RuntimeLocationStoreSnapshot): GlobeLocation | null => {
+    const { latitude, longitude } = snapshot.location;
+    if (!snapshot.available || latitude === null || longitude === null) return null;
+    return [latitude, longitude];
+};
+
+const buildConnectionArcs = (origin: GlobeLocation): ArcConfig[] => [
+    { id: 'origin-paris', from: origin, to: [48.8566, 2.3522] },
+    { id: 'origin-fiji', from: origin, to: [-17.7134, 178.065] },
+    { id: 'origin-south-africa', from: origin, to: [-34.5904, 19.3512] },
+    { id: 'origin-thailand-preview', from: origin, to: [13.7563, 100.5018] },
+    { id: 'origin-route66', from: origin, to: [41.8781, -87.6298] },
+];
+
+export const FeaturesGlobe: React.FC = () => {
+    const { t } = useTranslation('features');
+    const initialRuntimeSnapshot = getRuntimeLocationSnapshot();
+    const initialOriginLocation = getRuntimeCoordinates(initialRuntimeSnapshot) ?? DEFAULT_ORIGIN_LOCATION;
+    const initialRotation = getGlobeRotationForLocation(initialOriginLocation);
+
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const dragRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
+    const overlayRefs = useRef(new Map<string, HTMLDivElement>());
+    const markerConfigsRef = useRef<MarkerConfig[]>([]);
+    const arcConfigsRef = useRef<ArcConfig[]>([]);
+    const lastOriginRef = useRef<GlobeLocation>(initialOriginLocation);
+    const rotationRef = useRef({
+        phi: initialRotation.phi,
+        theta: initialRotation.theta,
+        targetPhi: initialRotation.phi,
+        targetTheta: initialRotation.theta,
+    });
+
+    const [runtimeLocation, setRuntimeLocation] = useState<RuntimeLocationStoreSnapshot>(initialRuntimeSnapshot);
+    const [canvasSize, setCanvasSize] = useState(canvasSizeDefaults);
+    const [displaySize, setDisplaySize] = useState(displaySizeDefaults);
+    const [isDragging, setIsDragging] = useState(false);
+    const [isFallback, setIsFallback] = useState(false);
+    const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+    const cardMap = useMemo(() => {
+        const cards = t('globe.cards', { returnObjects: true }) as GlobeCardCopy[];
+        return new Map(cards.map((card) => [card.id, card]));
+    }, [t]);
+
+    const preview = t('globe.preview', { returnObjects: true }) as GlobePreviewCopy;
+    const compactLayout = displaySize.width < 560;
+    const originLocation = getRuntimeCoordinates(runtimeLocation) ?? DEFAULT_ORIGIN_LOCATION;
+
+    const markerConfigs = useMemo<MarkerConfig[]>(() => ([
+        {
+            id: 'origin',
+            location: originLocation,
+            size: 0.0001,
+        },
+        ...DESTINATION_MARKERS,
+    ]), [originLocation]);
+
+    const arcConfigs = useMemo<ArcConfig[]>(() => ([
+        ...buildConnectionArcs(originLocation),
+        ...ROUTE_66_ARCS,
+    ]), [originLocation]);
+
+    markerConfigsRef.current = markerConfigs;
+    arcConfigsRef.current = arcConfigs;
+
+    const overlayConfigs = useMemo<OverlayConfig[]>(() => [
+        {
+            id: 'origin-marker',
+            anchorId: 'origin',
+            anchorX: 0.5,
+            anchorY: 0.5,
+            minVisibility: -0.04,
+            offsetX: 0,
+            offsetY: 0,
+        },
+        {
+            id: 'origin-core',
+            anchorId: 'origin',
+            anchorX: 0.5,
+            anchorY: 0.5,
+            depthBoost: 14,
+            minVisibility: -0.04,
+            offsetX: 0,
+            offsetY: 0,
+        },
+        {
+            id: 'paris-panel',
+            anchorId: 'paris',
+            anchorX: 0.08,
+            anchorY: 1,
+            minVisibility: 0.03,
+            offsetX: compactLayout ? -6 : -10,
+            offsetY: compactLayout ? -28 : -34,
+        },
+        {
+            id: 'fiji-panel',
+            anchorId: 'fiji',
+            anchorX: 0.18,
+            anchorY: 0.16,
+            minVisibility: 0.02,
+            offsetX: compactLayout ? 10 : 14,
+            offsetY: compactLayout ? 4 : 8,
+        },
+        {
+            id: 'south-africa-panel',
+            anchorId: 'south-africa',
+            anchorX: 0,
+            anchorY: 0.56,
+            minVisibility: -0.02,
+            offsetX: compactLayout ? 10 : 14,
+            offsetY: compactLayout ? -6 : -10,
+        },
+        {
+            id: 'route66-panel',
+            anchorId: 'route66-santa-monica',
+            anchorX: 0,
+            anchorY: 0.74,
+            minVisibility: -0.05,
+            offsetX: compactLayout ? 10 : 14,
+            offsetY: compactLayout ? -12 : -16,
+        },
+        {
+            id: 'trip-preview',
+            anchorId: 'thailand-preview',
+            anchorX: 0.66,
+            anchorY: 0.16,
+            depthBoost: 14,
+            minVisibility: -0.1,
+            offsetX: compactLayout ? -46 : -54,
+            offsetY: compactLayout ? 18 : 24,
+            rotateDeg: -5,
+        },
+    ], [compactLayout]);
+
+    useEffect(() => {
+        const unsubscribe = subscribeRuntimeLocation((snapshot) => {
+            setRuntimeLocation(snapshot);
+        });
+
+        void ensureRuntimeLocationLoaded();
+
+        return unsubscribe;
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return undefined;
+
+        if (typeof window.matchMedia !== 'function') {
+            setPrefersReducedMotion(false);
+            return undefined;
+        }
+
+        const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+        const updateReducedMotion = () => setPrefersReducedMotion(mediaQuery.matches);
+        updateReducedMotion();
+
+        if (typeof mediaQuery.addEventListener === 'function') {
+            mediaQuery.addEventListener('change', updateReducedMotion);
+            return () => mediaQuery.removeEventListener('change', updateReducedMotion);
+        }
+
+        mediaQuery.addListener(updateReducedMotion);
+        return () => mediaQuery.removeListener(updateReducedMotion);
+    }, []);
+
+    useEffect(() => {
+        const node = containerRef.current;
+        if (!node) return undefined;
+
+        const updateSize = () => {
+            const rect = node.getBoundingClientRect();
+            const ratio = Math.min(typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1, 2);
+            const width = Math.max(640, Math.round((rect.width || 480) * ratio));
+            const height = Math.max(640, Math.round((rect.height || rect.width || 480) * ratio));
+            setDisplaySize({
+                width: rect.width || 480,
+                height: rect.height || rect.width || 480,
+            });
+            setCanvasSize({ width, height });
+        };
+
+        updateSize();
+
+        if (typeof ResizeObserver === 'undefined') return undefined;
+        const observer = new ResizeObserver(() => updateSize());
+        observer.observe(node);
+        return () => observer.disconnect();
+    }, []);
+
+    useEffect(() => {
+        const [latitude, longitude] = originLocation;
+        const [previousLatitude, previousLongitude] = lastOriginRef.current;
+
+        if (latitude === previousLatitude && longitude === previousLongitude) return;
+
+        lastOriginRef.current = originLocation;
+        const nextRotation = getGlobeRotationForLocation(originLocation);
+        rotationRef.current.targetPhi = nextRotation.phi;
+        rotationRef.current.targetTheta = nextRotation.theta;
+    }, [originLocation]);
+
+    useEffect(() => {
+        let isCancelled = false;
+        let animationFrameId = 0;
+        let globe: { destroy?: () => void; update?: (state: Record<string, unknown>) => void } | undefined;
+
+        const updateOverlays = () => {
+            const markerConfigMap = new Map(markerConfigsRef.current.map((marker) => [marker.id, marker]));
+            const overlayPadding = compactLayout ? 12 : 18;
+            const overlayScale = compactLayout ? 0.92 : 1;
+
+            overlayConfigs.forEach((overlay) => {
+                const node = overlayRefs.current.get(overlay.id);
+                const marker = markerConfigMap.get(overlay.anchorId);
+                if (!node || !marker) return;
+
+                const projected = projectGlobeLocation(marker.location, {
+                    width: displaySize.width,
+                    height: displaySize.height,
+                    phi: rotationRef.current.phi,
+                    theta: rotationRef.current.theta,
+                    scale: globeRenderConfig.scale,
+                    offset: globeRenderConfig.offset,
+                    markerElevation: globeRenderConfig.markerElevation,
+                });
+
+                const renderedVisibility = clamp((projected.depth - overlay.minVisibility + 0.16) / 0.24, 0, 1);
+                const nodeWidth = node.offsetWidth;
+                const nodeHeight = node.offsetHeight;
+                const unclampedX = projected.x - (nodeWidth * overlay.anchorX) + (overlay.offsetX * overlayScale);
+                const unclampedY = projected.y - (nodeHeight * overlay.anchorY) + (overlay.offsetY * overlayScale);
+                const x = clamp(unclampedX, overlayPadding, displaySize.width - nodeWidth - overlayPadding);
+                const y = clamp(unclampedY, overlayPadding, displaySize.height - nodeHeight - overlayPadding);
+                const scale = overlay.id === 'origin-marker'
+                    ? 0.96 + (renderedVisibility * 0.08)
+                    : overlay.id === 'origin-core'
+                        ? 0.98 + (renderedVisibility * 0.04)
+                        : 0.92 + (renderedVisibility * 0.08);
+                const blur = overlay.id === 'origin-marker'
+                    ? (1 - renderedVisibility) * 9
+                    : overlay.id === 'origin-core'
+                        ? (1 - renderedVisibility) * 2.5
+                        : (1 - renderedVisibility) * 15;
+                const translateY = overlay.id === 'origin-core' ? (1 - renderedVisibility) * 4 : (1 - renderedVisibility) * 10;
+
+                node.style.opacity = renderedVisibility.toFixed(3);
+                node.style.visibility = renderedVisibility < 0.005 ? 'hidden' : 'visible';
+                node.style.transform = `translate3d(${x}px, ${y + translateY}px, 0) scale(${scale.toFixed(3)}) rotate(${overlay.rotateDeg ?? 0}deg)`;
+                node.style.filter = `blur(${blur.toFixed(2)}px)`;
+                node.style.zIndex = overlay.id === 'origin-marker'
+                    ? '0'
+                    : overlay.id === 'origin-core'
+                        ? '26'
+                    : `${20 + Math.round((projected.depth + 1) * 12) + (overlay.depthBoost ?? 0)}`;
+            });
+        };
+
+        const initialize = async () => {
+            const canvas = canvasRef.current;
+            if (!canvas) return;
+
+            try {
+                const hasWebGlContext = Boolean(
+                    canvas.getContext('webgl2')
+                    || canvas.getContext('webgl')
+                    || canvas.getContext('experimental-webgl'),
+                );
+
+                if (!hasWebGlContext) {
+                    setIsFallback(true);
+                    return;
+                }
+
+                const cobeModule = await import('cobe');
+                if (isCancelled) return;
+
+                const createGlobe = cobeModule.default;
+                const ratio = Math.min(typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1, 2);
+
+                globe = createGlobe(canvas, {
+                    devicePixelRatio: ratio,
+                    width: canvasSize.width,
+                    height: canvasSize.height,
+                    phi: rotationRef.current.phi,
+                    theta: rotationRef.current.theta,
+                    dark: 0,
+                    diffuse: 1.3,
+                    mapSamples: canvasSize.width > 900 ? 26000 : 19000,
+                    mapBrightness: 6.1,
+                    mapBaseBrightness: 0.06,
+                    baseColor: [0.975, 0.978, 0.986],
+                    markerColor: [0.38, 0.31, 0.9],
+                    glowColor: [0.995, 0.995, 0.995],
+                    arcColor: [0.38, 0.31, 0.9],
+                    arcWidth: 0.58,
+                    arcHeight: 0.14,
+                    markerElevation: globeRenderConfig.markerElevation,
+                    scale: globeRenderConfig.scale,
+                    offset: globeRenderConfig.offset,
+                    opacity: 1,
+                    markers: markerConfigsRef.current,
+                    arcs: arcConfigsRef.current,
+                });
+
+                const animate = () => {
+                    const rotation = rotationRef.current;
+
+                    if (!dragRef.current && !prefersReducedMotion) {
+                        rotation.targetPhi += 0.00135;
+                    }
+
+                    rotation.targetTheta = clamp(rotation.targetTheta, -0.34, 0.34);
+                    rotation.phi += (rotation.targetPhi - rotation.phi) * 0.075;
+                    rotation.theta += (rotation.targetTheta - rotation.theta) * 0.085;
+
+                    globe?.update?.({
+                        phi: rotation.phi,
+                        theta: rotation.theta,
+                        width: canvasSize.width,
+                        height: canvasSize.height,
+                        markers: markerConfigsRef.current,
+                        arcs: arcConfigsRef.current,
+                    });
+                    updateOverlays();
+
+                    animationFrameId = requestAnimationFrame(animate);
+                };
+
+                animate();
+                setIsFallback(false);
+            } catch {
+                if (!isCancelled) {
+                    setIsFallback(true);
+                }
+            }
+        };
+
+        void initialize();
+
+        return () => {
+            isCancelled = true;
+            cancelAnimationFrame(animationFrameId);
+            globe?.destroy?.();
+        };
+    }, [canvasSize.height, canvasSize.width, compactLayout, displaySize.height, displaySize.width, overlayConfigs, prefersReducedMotion]);
+
+    const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+        dragRef.current = {
+            pointerId: event.pointerId,
+            x: event.clientX,
+            y: event.clientY,
+        };
+        setIsDragging(true);
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+    };
+
+    const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+        if (!dragRef.current || dragRef.current.pointerId !== event.pointerId) return;
+
+        const deltaX = event.clientX - dragRef.current.x;
+        const deltaY = event.clientY - dragRef.current.y;
+        dragRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+
+        rotationRef.current.targetPhi += deltaX * 0.0105;
+        rotationRef.current.targetTheta = clamp(
+            rotationRef.current.targetTheta + deltaY * 0.0065,
+            -0.34,
+            0.34,
+        );
+    };
+
+    const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+        if (dragRef.current?.pointerId !== event.pointerId) return;
+        dragRef.current = null;
+        setIsDragging(false);
+        event.currentTarget.releasePointerCapture?.(event.pointerId);
+    };
+
+    const parisCard = cardMap.get('paris');
+    const fijiCard = cardMap.get('fiji');
+    const southAfricaCard = cardMap.get('south-africa');
+    const route66Card = cardMap.get('route66');
+
+    return (
+        <div
+            ref={containerRef}
+            role="img"
+            aria-label={t('globe.accessibility')}
+            className={cn(
+                'relative isolate aspect-[1.02/0.98] min-h-[480px] overflow-hidden',
+                isDragging ? 'cursor-grabbing' : 'cursor-grab',
+            )}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerCancel={handlePointerUp}
+            style={{ touchAction: 'none' }}
+        >
+            <div className="pointer-events-none absolute inset-0 z-0 [&>*]:invisible [&>*]:opacity-0">
+                <div
+                    ref={(node) => {
+                        if (node) overlayRefs.current.set('origin-marker', node);
+                        else overlayRefs.current.delete('origin-marker');
+                    }}
+                    className="absolute left-0 top-0 transition-[opacity,filter,transform] duration-500 ease-out will-change-transform"
+                >
+                    <span className="relative block size-10">
+                        <span
+                            className="absolute inset-[-9px] rounded-full border-2 border-[#f39a3d]/55 animate-ping"
+                            style={{ animationDuration: '2.4s' }}
+                        />
+                        <span
+                            className="absolute inset-[-18px] rounded-full border border-[#f39a3d]/38 animate-ping"
+                            style={{ animationDelay: '0.55s', animationDuration: '3.1s' }}
+                        />
+                        <span className="absolute inset-[1px] rounded-full bg-[#f7a454]/28 blur-lg" />
+                        <span className="absolute inset-[10px] rounded-full bg-[#f38b2a]/28 blur-sm" />
+                    </span>
+                </div>
+            </div>
+
+            <canvas
+                ref={canvasRef}
+                className={cn(
+                    'absolute inset-0 z-10 size-full select-none transition-opacity duration-500',
+                    isFallback ? 'opacity-0' : 'opacity-100',
+                )}
+                aria-hidden="true"
+                style={globeMaskStyle}
+            />
+
+            {!isFallback ? (
+                <div className="pointer-events-none absolute inset-0 z-20 [&>*]:invisible [&>*]:opacity-0">
+                    <div
+                        ref={(node) => {
+                            if (node) overlayRefs.current.set('origin-core', node);
+                            else overlayRefs.current.delete('origin-core');
+                        }}
+                        className="absolute left-0 top-0 transition-[opacity,filter,transform] duration-500 ease-out will-change-transform"
+                    >
+                        <span className="relative block size-4">
+                            <span className="absolute inset-0 rounded-full border border-white/95 bg-[#f38b2a] shadow-[0_0_0_2px_rgba(255,255,255,0.92),0_0_16px_rgba(243,139,42,0.38)]" />
+                        </span>
+                    </div>
+
+                    {parisCard ? (
+                        <div
+                            ref={(node) => {
+                                if (node) overlayRefs.current.set('paris-panel', node);
+                                else overlayRefs.current.delete('paris-panel');
+                            }}
+                            className="absolute left-0 top-0 w-[7.6rem] rounded-[12px] border border-[#ddd1ff] bg-[#f7f3ff]/98 px-2.5 py-2 text-slate-800 shadow-[0_14px_22px_rgba(91,79,230,0.1)] transition-[opacity,filter,transform] duration-500 ease-out will-change-transform"
+                        >
+                            <p className="flex items-start gap-1.5 text-[0.76rem] font-semibold leading-[1.15] text-slate-900">
+                                <span className="shrink-0 text-[0.92rem]" aria-hidden="true">{parisCard.emoji}</span>
+                                <span>{parisCard.title}</span>
+                            </p>
+                        </div>
+                    ) : null}
+
+                    {fijiCard ? (
+                        <div
+                            ref={(node) => {
+                                if (node) overlayRefs.current.set('fiji-panel', node);
+                                else overlayRefs.current.delete('fiji-panel');
+                            }}
+                            className="absolute left-0 top-0 w-[7.9rem] rounded-[12px] border border-[#cbe9d7] bg-[#eef9f1]/98 px-2.5 py-2 text-slate-800 shadow-[0_14px_22px_rgba(36,116,88,0.1)] transition-[opacity,filter,transform] duration-500 ease-out will-change-transform"
+                        >
+                            <p className="flex items-start gap-1.5 text-[0.76rem] font-semibold leading-[1.15] text-slate-900">
+                                <span className="shrink-0 text-[0.92rem]" aria-hidden="true">{fijiCard.emoji}</span>
+                                <span>{fijiCard.title}</span>
+                            </p>
+                        </div>
+                    ) : null}
+
+                    {southAfricaCard ? (
+                        <div
+                            ref={(node) => {
+                                if (node) overlayRefs.current.set('south-africa-panel', node);
+                                else overlayRefs.current.delete('south-africa-panel');
+                            }}
+                            className="absolute left-0 top-0 w-[8.1rem] rounded-[12px] border border-[#cfe8ee] bg-[#eef8fb]/98 px-2.5 py-2 text-slate-800 shadow-[0_14px_22px_rgba(44,116,154,0.1)] transition-[opacity,filter,transform] duration-500 ease-out will-change-transform"
+                        >
+                            <p className="flex items-start gap-1.5 text-[0.76rem] font-semibold leading-[1.15] text-slate-900">
+                                <span className="shrink-0 text-[0.92rem]" aria-hidden="true">{southAfricaCard.emoji}</span>
+                                <span>{southAfricaCard.title}</span>
+                            </p>
+                        </div>
+                    ) : null}
+
+                    {route66Card ? (
+                        <div
+                            ref={(node) => {
+                                if (node) overlayRefs.current.set('route66-panel', node);
+                                else overlayRefs.current.delete('route66-panel');
+                            }}
+                            className="absolute left-0 top-0 w-[7.4rem] rounded-[12px] border border-[#f0d5bf] bg-[#fff4e9]/98 px-2.5 py-2 text-slate-800 shadow-[0_14px_22px_rgba(170,96,78,0.1)] transition-[opacity,filter,transform] duration-500 ease-out will-change-transform"
+                        >
+                            <p className="flex items-start gap-1.5 text-[0.76rem] font-semibold leading-[1.15] text-slate-900">
+                                <span className="shrink-0 text-[0.92rem]" aria-hidden="true">{route66Card.emoji}</span>
+                                <span>{route66Card.title}</span>
+                            </p>
+                        </div>
+                    ) : null}
+
+                    <div
+                        ref={(node) => {
+                            if (node) overlayRefs.current.set('trip-preview', node);
+                            else overlayRefs.current.delete('trip-preview');
+                        }}
+                        className="absolute left-0 top-0 w-[9.75rem] border border-slate-200 bg-white px-2.5 py-2.5 shadow-[0_20px_34px_rgba(15,23,42,0.13)] transition-[opacity,filter,transform] duration-500 ease-out will-change-transform"
+                        style={{ borderRadius: '14px 14px 18px 18px' }}
+                        >
+                            <div className="overflow-hidden rounded-[10px] border border-slate-100">
+                                <img
+                                    src="/images/trip-maps/thailand-islands.png"
+                                    alt={preview.alt}
+                                    className="h-20 w-full object-cover"
+                                    loading="lazy"
+                                />
+                            </div>
+                            <div className="pt-2.5">
+                                <p className="text-[0.78rem] font-semibold leading-[1.2] text-slate-900">
+                                    {preview.title}
+                                </p>
+                            </div>
+                        </div>
+                </div>
+            ) : null}
+
+            {isFallback ? (
+                <div className="pointer-events-none absolute inset-x-6 bottom-6 rounded-[16px] border border-slate-200 bg-white p-5 shadow-[0_14px_28px_rgba(15,23,42,0.08)]">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        {t('globe.fallbackTitle')}
+                    </p>
+                    <p className="mt-2 text-sm leading-relaxed text-slate-600">
+                        {t('globe.fallbackDescription')}
+                    </p>
+                </div>
+            ) : null}
+        </div>
+    );
+};

--- a/components/marketing/features/globeProjection.ts
+++ b/components/marketing/features/globeProjection.ts
@@ -1,0 +1,83 @@
+export type GlobeLocation = [number, number];
+
+export interface GlobeProjectionConfig {
+    height: number;
+    markerElevation: number;
+    offset: [number, number];
+    phi: number;
+    scale: number;
+    theta: number;
+    width: number;
+}
+
+export interface ProjectedGlobePoint {
+    depth: number;
+    visible: boolean;
+    visibility: number;
+    x: number;
+    y: number;
+}
+
+const GLOBE_RADIUS = 0.8;
+const MAX_TILT = 0.32;
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const normalizeAngle = (value: number): number => {
+    let angle = value;
+    while (angle <= -Math.PI) angle += Math.PI * 2;
+    while (angle > Math.PI) angle -= Math.PI * 2;
+    return angle;
+};
+
+const globeLocationToVector = ([latitude, longitude]: GlobeLocation) => {
+    const lat = latitude * (Math.PI / 180);
+    const lon = longitude * (Math.PI / 180);
+    const cosLat = Math.cos(lat);
+
+    return [
+        cosLat * Math.cos(lon),
+        Math.sin(lat),
+        -cosLat * Math.sin(lon),
+    ] as const;
+};
+
+export const projectGlobeLocation = (
+    location: GlobeLocation,
+    config: GlobeProjectionConfig,
+): ProjectedGlobePoint => {
+    const vector = globeLocationToVector(location);
+    const radius = GLOBE_RADIUS + config.markerElevation;
+    const x = vector[0] * radius;
+    const y = vector[1] * radius;
+    const z = vector[2] * radius;
+
+    const cosTheta = Math.cos(config.theta);
+    const cosPhi = Math.cos(config.phi);
+    const sinTheta = Math.sin(config.theta);
+    const sinPhi = Math.sin(config.phi);
+
+    const projectedX = (cosPhi * x) + (sinPhi * z);
+    const projectedY = (sinPhi * sinTheta * x) + (cosTheta * y) - (cosPhi * sinTheta * z);
+    const depth = (-sinPhi * cosTheta * x) + (sinTheta * y) + (cosPhi * cosTheta * z);
+    const visible = depth >= 0 || ((projectedX * projectedX) + (projectedY * projectedY) >= 0.64);
+
+    return {
+        x: (((projectedX / (config.width / config.height)) * config.scale) + ((config.offset[0] * config.scale) / config.width) + 1) * 0.5 * config.width,
+        y: ((-(projectedY * config.scale)) + ((config.offset[1] * config.scale) / config.height) + 1) * 0.5 * config.height,
+        depth,
+        visible,
+        visibility: visible ? 1 : 0,
+    };
+};
+
+export const getGlobeRotationForLocation = (location: GlobeLocation) => {
+    const [latitude, longitude] = location;
+    const latitudeRadians = latitude * (Math.PI / 180);
+    const longitudeRadians = longitude * (Math.PI / 180);
+
+    return {
+        phi: normalizeAngle((-Math.PI / 2) - longitudeRadians),
+        theta: clamp(latitudeRadians * 0.24, -MAX_TILT, MAX_TILT),
+    };
+};

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/content/updates/2026-03-19-features-page-globe-redesign.md
+++ b/content/updates/2026-03-19-features-page-globe-redesign.md
@@ -13,6 +13,6 @@ summary: "Rebuilds the features page around a custom interactive globe hero, sha
 ## Changes
 - [x] [Improved] 🌍 The features page now opens with a custom interactive globe hero, anchored trip callouts, and a more polished planning-first story around TravelFlow.
 - [x] [Improved] 🧭 The globe hero now starts over Europe, keeps its travel callouts orbiting with the sphere, and cleans up the hero layout so the floating panels feel more intentional.
-- [x] [Improved] 📍 The globe now uses the session runtime location to highlight your starting point, draw routes out from it, and keep the travel chips smaller, shorter, and easier to read across languages.
+- [x] [Improved] 📍 The globe now uses the session runtime location to highlight your starting point, draw routes out from it, and keep the travel chips smaller, shorter, and easier to read across all supported languages.
 - [x] [Improved] 🧩 A new animated bento grid now shows how AI itineraries, route editing, crew sharing, and inspiration work together instead of listing features in isolation.
 - [ ] [Internal] 🧪 Added browser coverage for the new hero CTA analytics and the globe fallback path.

--- a/content/updates/2026-03-19-features-page-globe-redesign.md
+++ b/content/updates/2026-03-19-features-page-globe-redesign.md
@@ -1,0 +1,18 @@
+---
+id: rel-2026-03-19-features-page-globe-redesign
+version: v0.0.0
+title: "Features page now opens with a richer globe-led story"
+date: 2026-03-19
+published_at: 2026-03-19T16:20:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Rebuilds the features page around a custom interactive globe hero, sharper planning-first copy, and a more polished visual product story."
+---
+
+## Changes
+- [x] [Improved] 🌍 The features page now opens with a custom interactive globe hero, anchored trip callouts, and a more polished planning-first story around TravelFlow.
+- [x] [Improved] 🧭 The globe hero now starts over Europe, keeps its travel callouts orbiting with the sphere, and cleans up the hero layout so the floating panels feel more intentional.
+- [x] [Improved] 📍 The globe now uses the session runtime location to highlight your starting point, draw routes out from it, and keep the travel chips smaller, shorter, and easier to read across languages.
+- [x] [Improved] 🧩 A new animated bento grid now shows how AI itineraries, route editing, crew sharing, and inspiration work together instead of listing features in isolation.
+- [ ] [Internal] 🧪 Added browser coverage for the new hero CTA analytics and the globe fallback path.

--- a/lib/legal/cookies.config.ts
+++ b/lib/legal/cookies.config.ts
@@ -203,6 +203,14 @@ export const COOKIE_REGISTRY: CookieRegistry = {
       storage: 'sessionStorage',
     },
     {
+      name: 'tf_runtime_location_v1',
+      purpose: 'Stores the current session runtime location snapshot for geo-aware defaults and debugger diagnostics.',
+      duration: 'Session',
+      provider: 'TravelFlow',
+      storage: 'sessionStorage',
+      notes: 'Approximate Netlify-derived location only; no raw IP is stored.',
+    },
+    {
       name: 'tf_map_style',
       purpose: 'Persists selected map visual style.',
       duration: 'Persistent',

--- a/locales/de/features.json
+++ b/locales/de/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "Produktfunktionen",
-    "title": "Smarter planen, besser reisen",
-    "description": "TravelFlow combines AI generation, visual editing, and collaboration into one workspace. Here is everything the platform can do for your next trip."
+    "badge": "Interaktive Reiseplanung",
+    "titleBefore": "Plane Reisen, die sich schon",
+    "titleHighlight": "abflugbereit anfühlen",
+    "description": "TravelFlow macht aus Reiseideen eine Route, auf die dein Team sofort reagieren kann. Erstelle den ersten Plan mit KI, forme ihn auf Karte und Timeline weiter und teile einen Link, der auch dann noch klar wirkt, wenn es konkret wird.",
+    "primaryCta": "Jetzt planen",
+    "secondaryCta": "Beispielreisen ansehen",
+    "proof": [
+      "KI-Reiseentwürfe in Sekunden",
+      "Route per Drag-and-Drop feinjustieren",
+      "Ein klarer Link statt chaotischer Gruppenchat-Screenshots"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "KI-Reiseerstellung",
-      "description": "Describe where you want to go and TravelFlow creates a full itinerary — optimized routes, curated activities, realistic timing — in under 30 seconds. Classic, Wizard, or Surprise Me modes adapt to how you like to plan."
+  "globe": {
+    "accessibility": "Interaktive Globusvorschau mit Routen von deinem Startpunkt zu farbigen Reiseideen rund um die Welt.",
+    "fallbackTitle": "Interaktive Globus-Ersatzansicht",
+    "fallbackDescription": "Auch ohne den Live-Globus bleiben die Reiserouten, Trip-Karten und dein Startpunkt sichtbar.",
+    "origin": {
+      "current": "Ab {city}",
+      "countryFallback": "Ab {country}",
+      "fallback": "Startpunkt"
     },
-    "map": {
-      "title": "Interaktive Karte und Timeline",
-      "description": "Your trip lives on a real map with animated route lines, city markers, and dynamic zoom. Below the map, a visual timeline shows every day at a glance. Switch between satellite, terrain, and minimalist styles."
-    },
-    "editing": {
-      "title": "Drag-and-Drop Bearbeitung",
-      "description": "Reorder cities, stretch stay durations, and insert spontaneous stops — all by dragging on the timeline. Dates, connections, and the map update automatically so everything stays in sync."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "Paris-Wochenende",
+        "detail": "Cafe-Stopps und spaete Museen."
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "Fiji-Flitterwochen",
+        "detail": "Inseltage und Bootsstopps."
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "Weisser-Hai-Dive",
+        "detail": "Kaltes Wasser und voller Adrenalinkick."
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "Route 66 Drive",
+        "detail": "Westkueste, Motels und langer Asphalt."
+      }
+    ],
+    "preview": {
+      "title": "30 Tage SEA",
+      "alt": "Trip-Vorschau fuer 30 Tage in Suedostasien"
     }
+  },
+  "bento": {
+    "badge": "Planen mit Flow",
+    "title": "Die wichtigsten Teile der Reiseplanung bleiben endlich zusammen",
+    "subtitle": "Statt zwischen Docs, Karten, Screenshots und halbfertigen Chats zu springen, haelt TravelFlow Route, Timing und Reisekontext in einer Bewegung.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "KI-Entwurf",
+        "title": "Starte mit einer Route statt mit einer leeren Seite",
+        "description": "Beschreibe die Reise in normaler Sprache und erhalte einen glaubwuerdigen ersten Plan, in dem Staedte, Tempo und Aktivitaetskontext bereits zusammenpassen.",
+        "detail": "Ein erster Entwurf, auf den deine Gruppe sofort reagieren kann"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live auf Karte und Timeline",
+        "title": "Passe den Plan an, ohne ihn zu zerlegen",
+        "description": "Verlaengere Stopps, sortiere Orte um oder veraendere das Tempo. TravelFlow haelt Karte und Timeline synchron, damit jeder Edit stimmig bleibt.",
+        "detail": "Karte und Timing bleiben verbunden"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Inspirationsrouten",
+        "title": "Uebernimm gute Ideen und mach sie zu deiner Reise",
+        "description": "Nutze glaubwuerdige Routen als Startpunkt, statt eine stimmige Reise jedes Mal wieder ganz neu zusammenzusetzen.",
+        "detail": "Starte mit echter Reiseenergie"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew-Feedback",
+        "title": "Teile etwas, das deine Mitreisenden sofort verstehen",
+        "description": "Verschicke einen Link, in dem Route, Tempo und Notizen schon drin sind, damit Feedback an der Reise selbst ansetzt und nicht an verstreuten Screenshots.",
+        "detail": "Kein Konto noetig"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Buchung und Uebergabe",
+        "title": "Am Ende bleibt ein Plan, der trotzdem sauber wirkt",
+        "description": "Wenn die Route steht, bleibt auch der praktische Kontext erhalten: Links, Notizen und eine aufgeraeumte Druckansicht fuer die finale Version.",
+        "detail": "Bereit zum Teilen, Speichern oder Drucken"
+      }
+    ]
   },
   "workflow": {
-    "title": "So funktioniert es",
-    "subtitle": "From idea to itinerary in three steps.",
-    "step1Title": "Choose your destination",
-    "step1Description": "Pick countries, islands, or let Surprise Me suggest the perfect match for your travel window.",
-    "step2Title": "Generate with AI",
-    "step2Description": "Our model drafts a full route with city timing, activities, and logistics. Tweak the result in seconds.",
-    "step3Title": "Refine & share",
-    "step3Description": "Drag cities, adjust durations, add notes. Then share a link — your crew sees the live map and timeline."
-  },
-  "more": {
-    "title": "Und vieles mehr",
-    "subtitle": "Every detail is designed to remove friction from trip planning."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "Teilen mit einem Klick",
-      "description": "Generate a link and send it to your travel crew. They see the full map, timeline, and activities — no account needed."
-    },
-    "community": {
-      "title": "Community-Inspirationen",
-      "description": "Browse curated trips from travelers worldwide. Fork any itinerary as a starting point and make it your own."
-    },
-    "booking": {
-      "title": "Buchungslinks",
-      "description": "Every AI-suggested activity links to booking platforms — tours, restaurants, transport — so you can reserve without leaving TravelFlow."
-    },
-    "duration": {
-      "title": "Smarte Dauerhinweise",
-      "description": "TravelFlow analyzes seasonal data and travel distances to suggest how long to spend in each city so you never feel rushed."
-    },
-    "mobile": {
-      "title": "Mobil optimiert",
-      "description": "Plan on the go with a responsive layout tuned for phones and tablets. The map, timeline, and editing all adapt to smaller screens."
-    },
-    "print": {
-      "title": "Druckfertige Routen",
-      "description": "Switch to print view for a clean, paper-friendly itinerary with day headers, activity lists, and essential logistics."
-    },
-    "routing": {
-      "title": "Routing über mehrere Länder",
-      "description": "Select multiple countries or islands and TravelFlow builds a cross-border route with realistic transit between regions."
-    },
-    "history": {
-      "title": "Versionsverlauf",
-      "description": "Every meaningful change creates a snapshot. Jump back to any previous version of your trip with a single click."
-    },
-    "privacy": {
-      "title": "Datenschutz zuerst",
-      "description": "Your trips stay local by default. Optional cloud sync is consent-gated, and analytics only run after explicit opt-in."
-    }
-  },
-  "comparison": {
-    "title": "So schneidet TravelFlow ab",
-    "subtitle": "Side-by-side against spreadsheet planning and other trip tools.",
-    "featureHeader": "Feature",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "Spreadsheet",
-    "otherHeader": "Other Tools",
-    "yes": "Yes",
-    "partial": "Partial",
-    "manual": "Manual",
-    "freemium": "Freemium",
-    "rows": {
-      "ai": "AI-generated itinerary",
-      "interactiveMap": "Interactive map",
-      "dragDrop": "Drag-and-drop timeline",
-      "oneClickSharing": "One-click sharing",
-      "bookingLinks": "Booking links",
-      "offlineFirst": "Offline-first / local data",
-      "freeToUse": "Free to use"
+    "badge": "Von der Idee bis zur gruppentauglichen Route",
+    "title": "Ein gemeinsamer Flow fuer Entwurf, Feinschliff und Teilen",
+    "subtitle": "TravelFlow passt besonders gut, wenn der inspirierende Teil der Planung und der praktische Teil der Planung am selben Ort bleiben sollen.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Starte mit Ziel, Stimmung oder einer vorhandenen Route",
+        "description": "Beginne mit einer Landerliste, einer Saison-Idee oder einer noch unscharfen Reiserichtung. Die perfekte Reihenfolge musst du noch nicht kennen."
+      },
+      {
+        "step": "02",
+        "title": "Schleife Tempo und Strecke auf Karte und Timeline ein",
+        "description": "Sieh die Route auf dem Globus und zieh sie auf der Timeline so lange zurecht, bis Transfers, Energielevel und Gruppenwuensche zusammenpassen."
+      },
+      {
+        "step": "03",
+        "title": "Teile eine Version, die schon bewusst gestaltet wirkt",
+        "description": "Sobald Feedback oder Buchungen anstehen, hat derselbe Plan bereits Karte, Struktur und den Zusatzkontext, nach dem sonst immer gefragt wird."
+      }
+    ],
+    "glance": {
+      "eyebrow": "Was die Gruppe sieht",
+      "title": "Ein Plan, der schon beim Teilen fertig wirkt",
+      "description": "Karte, Tagesstruktur und praktische Details bleiben zusammen, damit Rueckmeldungen schneller und klarer kommen.",
+      "items": [
+        "Live-Routenansicht mit Tempo-Kontext",
+        "Buchungsnahe Aktivitaetslinks bei Bedarf",
+        "Eine saubere Druckansicht fuer die finale Version"
+      ]
     }
   },
   "cta": {
-    "title": "Sieh es in Aktion",
-    "subtitle": "Create your first AI-powered itinerary in under a minute.",
-    "button": "Start Planning — Free"
+    "badge": "Plane, solange die Idee noch frisch ist",
+    "title": "Starte mit der Route. Behalte das Reisegefuehl.",
+    "subtitle": "Entwirf deine naechste Reise in wenigen Minuten und verfeinere sie danach am selben Ort, statt sie ueber mehrere Tools neu zusammenzubauen.",
+    "button": "Jetzt planen"
   }
 }

--- a/locales/en/features.json
+++ b/locales/en/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "Product Capabilities",
-    "title": "Plan smarter, travel better",
-    "description": "TravelFlow combines AI generation, visual editing, and collaboration into one workspace. Here is everything the platform can do for your next trip."
+    "badge": "Interactive trip planning",
+    "titleBefore": "Build trips that already feel",
+    "titleHighlight": "ready to go",
+    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
+    "primaryCta": "Start planning",
+    "secondaryCta": "See example trips",
+    "proof": [
+      "AI itinerary drafts in seconds",
+      "Drag the route until it feels right",
+      "Share one clean link before the group chat gets chaotic"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "AI Trip Generation",
-      "description": "Describe where you want to go and TravelFlow creates a full itinerary — optimized routes, curated activities, realistic timing — in under 30 seconds. Classic, Wizard, or Surprise Me modes adapt to how you like to plan."
+  "globe": {
+    "accessibility": "Interactive globe preview showing routes from your starting point to colorful trip ideas around the world.",
+    "fallbackTitle": "Interactive globe fallback",
+    "fallbackDescription": "Even without the live globe, you can still preview the travel routes, trip cards, and your starting point.",
+    "origin": {
+      "current": "From {city}",
+      "countryFallback": "From {country}",
+      "fallback": "Start here"
     },
-    "map": {
-      "title": "Interactive Map & Timeline",
-      "description": "Your trip lives on a real map with animated route lines, city markers, and dynamic zoom. Below the map, a visual timeline shows every day at a glance. Switch between satellite, terrain, and minimalist styles."
-    },
-    "editing": {
-      "title": "Drag-and-Drop Editing",
-      "description": "Reorder cities, stretch stay durations, and insert spontaneous stops — all by dragging on the timeline. Dates, connections, and the map update automatically so everything stays in sync."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "Paris Weekend",
+        "detail": "Cafe stops and late museum hours."
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "Fiji Honeymoon",
+        "detail": "Island days and boat hops."
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "Great White Dive",
+        "detail": "Cold water and a huge adrenaline hit."
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "Route 66 Drive",
+        "detail": "West-coast finish with classic motels."
+      }
+    ],
+    "preview": {
+      "title": "30day Backpacking SEA",
+      "alt": "30-day Southeast Asia trip preview"
     }
+  },
+  "bento": {
+    "badge": "Plan with momentum",
+    "title": "The pieces of trip planning finally stay in one place",
+    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "AI route draft",
+        "title": "Start from a route, not a blank page",
+        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
+        "detail": "A first draft your group can react to immediately"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live map edits",
+        "title": "Refine the plan without breaking it",
+        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
+        "detail": "Map and timing stay in sync"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Forkable inspiration",
+        "title": "Borrow proven ideas and make them yours",
+        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
+        "detail": "Start from real travel energy"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew review",
+        "title": "Share something your travel crew can understand fast",
+        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
+        "detail": "No account required"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Booking and handoff",
+        "title": "Leave with a plan that still feels polished",
+        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
+        "detail": "Ready to share, save, or print"
+      }
+    ]
   },
   "workflow": {
-    "title": "How it works",
-    "subtitle": "From idea to itinerary in three steps.",
-    "step1Title": "Choose your destination",
-    "step1Description": "Pick countries, islands, or let Surprise Me suggest the perfect match for your travel window.",
-    "step2Title": "Generate with AI",
-    "step2Description": "Our model drafts a full route with city timing, activities, and logistics. Tweak the result in seconds.",
-    "step3Title": "Refine & share",
-    "step3Description": "Drag cities, adjust durations, add notes. Then share a link — your crew sees the live map and timeline."
-  },
-  "more": {
-    "title": "And so much more",
-    "subtitle": "Every detail is designed to remove friction from trip planning."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "One-Click Sharing",
-      "description": "Generate a link and send it to your travel crew. They see the full map, timeline, and activities — no account needed."
-    },
-    "community": {
-      "title": "Community Inspirations",
-      "description": "Browse curated trips from travelers worldwide. Fork any itinerary as a starting point and make it your own."
-    },
-    "booking": {
-      "title": "Booking Links",
-      "description": "Every AI-suggested activity links to booking platforms — tours, restaurants, transport — so you can reserve without leaving TravelFlow."
-    },
-    "duration": {
-      "title": "Smart Duration Hints",
-      "description": "TravelFlow analyzes seasonal data and travel distances to suggest how long to spend in each city so you never feel rushed."
-    },
-    "mobile": {
-      "title": "Mobile-Optimized",
-      "description": "Plan on the go with a responsive layout tuned for phones and tablets. The map, timeline, and editing all adapt to smaller screens."
-    },
-    "print": {
-      "title": "Print-Ready Itineraries",
-      "description": "Switch to print view for a clean, paper-friendly itinerary with day headers, activity lists, and essential logistics."
-    },
-    "routing": {
-      "title": "Multi-Country Routing",
-      "description": "Select multiple countries or islands and TravelFlow builds a cross-border route with realistic transit between regions."
-    },
-    "history": {
-      "title": "Version History",
-      "description": "Every meaningful change creates a snapshot. Jump back to any previous version of your trip with a single click."
-    },
-    "privacy": {
-      "title": "Privacy-First",
-      "description": "Your trips stay local by default. Optional cloud sync is consent-gated, and analytics only run after explicit opt-in."
-    }
-  },
-  "comparison": {
-    "title": "How TravelFlow compares",
-    "subtitle": "Side-by-side against spreadsheet planning and other trip tools.",
-    "featureHeader": "Feature",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "Spreadsheet",
-    "otherHeader": "Other Tools",
-    "yes": "Yes",
-    "partial": "Partial",
-    "manual": "Manual",
-    "freemium": "Freemium",
-    "rows": {
-      "ai": "AI-generated itinerary",
-      "interactiveMap": "Interactive map",
-      "dragDrop": "Drag-and-drop timeline",
-      "oneClickSharing": "One-click sharing",
-      "bookingLinks": "Booking links",
-      "offlineFirst": "Offline-first / local data",
-      "freeToUse": "Free to use"
+    "badge": "From spark to group-ready plan",
+    "title": "One flow for drafting, shaping, and sharing",
+    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Start with a destination, a vibe, or a copied route",
+        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+      },
+      {
+        "step": "02",
+        "title": "Shape the pacing with the map and timeline together",
+        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+      },
+      {
+        "step": "03",
+        "title": "Share a version that still looks intentional",
+        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+      }
+    ],
+    "glance": {
+      "eyebrow": "What your group sees",
+      "title": "A plan that already looks share-ready",
+      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "items": [
+        "Live route view with pacing context",
+        "Booking-ready activity links when you need them",
+        "A cleaner print layout for the final version"
+      ]
     }
   },
   "cta": {
-    "title": "See it in action",
-    "subtitle": "Create your first AI-powered itinerary in under a minute.",
-    "button": "Start Planning — Free"
+    "badge": "Build it while the idea is still fresh",
+    "title": "Start with the route. Keep the travel mood.",
+    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
+    "button": "Start planning"
   }
 }

--- a/locales/es/features.json
+++ b/locales/es/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "Capacidades del producto",
-    "title": "Planifica mejor, viaja mejor",
-    "description": "TravelFlow reúne generación con IA, edición visual y colaboración en un solo espacio. Esto es todo lo que la plataforma puede hacer por tu próximo viaje."
+    "badge": "Interactive trip planning",
+    "titleBefore": "Build trips that already feel",
+    "titleHighlight": "ready to go",
+    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
+    "primaryCta": "Start planning",
+    "secondaryCta": "See example trips",
+    "proof": [
+      "AI itinerary drafts in seconds",
+      "Drag the route until it feels right",
+      "Share one clean link before the group chat gets chaotic"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "Generación de viajes con IA",
-      "description": "Describe adónde quieres ir y TravelFlow crea un itinerario completo con rutas optimizadas, actividades seleccionadas y tiempos realistas en menos de 30 segundos. Los modos Clásico, Asistente y Sorpréndeme se adaptan a tu forma de planear."
+  "globe": {
+    "accessibility": "Vista previa interactiva del globo con rutas desde tu punto de partida hacia ideas de viaje llenas de color por todo el mundo.",
+    "fallbackTitle": "Vista alternativa del globo",
+    "fallbackDescription": "Incluso sin el globo en vivo, aquí siguen visibles las rutas, las tarjetas del viaje y tu punto de partida.",
+    "origin": {
+      "current": "Desde {city}",
+      "countryFallback": "Desde {country}",
+      "fallback": "Punto de salida"
     },
-    "map": {
-      "title": "Mapa interactivo y línea de tiempo",
-      "description": "Tu viaje vive en un mapa real con rutas animadas, marcadores de ciudad y zoom dinámico. Debajo, una línea de tiempo visual te muestra cada día de un vistazo. Cambia entre estilos satélite, terreno y minimalista."
-    },
-    "editing": {
-      "title": "Edición con arrastrar y soltar",
-      "description": "Reordena ciudades, ajusta duraciones y añade paradas espontáneas arrastrando en la línea de tiempo. Las fechas, conexiones y mapa se actualizan automáticamente para que todo siga sincronizado."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "Escapada Paris",
+        "detail": "Cafe y museos hasta tarde."
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "Luna de miel Fiji",
+        "detail": "Playa, barcos y tiempo lento."
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "Buceo gran blanco",
+        "detail": "Agua fria y adrenalina pura."
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "Ruta 66",
+        "detail": "Moteles clasicos y final en la costa."
+      }
+    ],
+    "preview": {
+      "title": "SEA mochilero 30 dias",
+      "alt": "Vista previa de viaje por el Sudeste Asiatico de 30 dias"
     }
+  },
+  "bento": {
+    "badge": "Plan with momentum",
+    "title": "The pieces of trip planning finally stay in one place",
+    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "AI route draft",
+        "title": "Start from a route, not a blank page",
+        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
+        "detail": "A first draft your group can react to immediately"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live map edits",
+        "title": "Refine the plan without breaking it",
+        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
+        "detail": "Map and timing stay in sync"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Forkable inspiration",
+        "title": "Borrow proven ideas and make them yours",
+        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
+        "detail": "Start from real travel energy"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew review",
+        "title": "Share something your travel crew can understand fast",
+        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
+        "detail": "No account required"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Booking and handoff",
+        "title": "Leave with a plan that still feels polished",
+        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
+        "detail": "Ready to share, save, or print"
+      }
+    ]
   },
   "workflow": {
-    "title": "Cómo funciona",
-    "subtitle": "De la idea al itinerario en tres pasos.",
-    "step1Title": "Elige tu destino",
-    "step1Description": "Selecciona países, islas o deja que Sorpréndeme te proponga la mejor opción para tus fechas.",
-    "step2Title": "Genera con IA",
-    "step2Description": "Nuestro modelo crea una ruta completa con tiempos por ciudad, actividades y logística. Ajusta el resultado en segundos.",
-    "step3Title": "Refina y comparte",
-    "step3Description": "Arrastra ciudades, ajusta duraciones y añade notas. Luego comparte un enlace para que tu grupo vea el mapa y la línea de tiempo en vivo."
-  },
-  "more": {
-    "title": "Y mucho más",
-    "subtitle": "Cada detalle está diseñado para reducir fricción al planear viajes."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "Compartir en un clic",
-      "description": "Genera un enlace y envíalo a tu grupo. Verán el mapa completo, la línea de tiempo y las actividades sin crear cuenta."
-    },
-    "community": {
-      "title": "Inspiración de la comunidad",
-      "description": "Explora viajes seleccionados de viajeros de todo el mundo. Duplica cualquier itinerario y adáptalo a tu estilo."
-    },
-    "booking": {
-      "title": "Enlaces de reserva",
-      "description": "Cada actividad sugerida por IA enlaza a plataformas de reserva, tours, restaurantes y transporte, para reservar sin salir de TravelFlow."
-    },
-    "duration": {
-      "title": "Sugerencias inteligentes de duración",
-      "description": "TravelFlow analiza datos estacionales y distancias para recomendar cuánto tiempo dedicar a cada ciudad sin ir con prisas."
-    },
-    "mobile": {
-      "title": "Optimizado para móvil",
-      "description": "Planifica en movimiento con un diseño adaptable para móvil y tablet. Mapa, línea de tiempo y edición se ajustan a pantallas pequeñas."
-    },
-    "print": {
-      "title": "Itinerarios listos para imprimir",
-      "description": "Cambia a vista de impresión para obtener un itinerario limpio, con días, actividades y logística esencial en formato papel."
-    },
-    "routing": {
-      "title": "Rutas entre varios países",
-      "description": "Selecciona varios países o islas y TravelFlow crea una ruta transfronteriza con traslados realistas entre regiones."
-    },
-    "history": {
-      "title": "Historial de versiones",
-      "description": "Cada cambio importante crea una instantánea. Vuelve a cualquier versión anterior de tu viaje con un clic."
-    },
-    "privacy": {
-      "title": "Privacidad primero",
-      "description": "Tus viajes se guardan en local por defecto. La sincronización en la nube es opcional y requiere consentimiento, y la analítica se activa solo con aceptación explícita."
-    }
-  },
-  "comparison": {
-    "title": "Cómo se compara TravelFlow",
-    "subtitle": "Comparación directa frente a hojas de cálculo y otras herramientas de viaje.",
-    "featureHeader": "Función",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "Hoja de cálculo",
-    "otherHeader": "Otras herramientas",
-    "yes": "Sí",
-    "partial": "Parcial",
-    "manual": "Manual",
-    "freemium": "Freemium",
-    "rows": {
-      "ai": "Itinerario generado por IA",
-      "interactiveMap": "Mapa interactivo",
-      "dragDrop": "Línea de tiempo con arrastrar y soltar",
-      "oneClickSharing": "Compartir en un clic",
-      "bookingLinks": "Enlaces de reserva",
-      "offlineFirst": "Datos locales / prioridad offline",
-      "freeToUse": "Uso gratuito"
+    "badge": "From spark to group-ready plan",
+    "title": "One flow for drafting, shaping, and sharing",
+    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Start with a destination, a vibe, or a copied route",
+        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+      },
+      {
+        "step": "02",
+        "title": "Shape the pacing with the map and timeline together",
+        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+      },
+      {
+        "step": "03",
+        "title": "Share a version that still looks intentional",
+        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+      }
+    ],
+    "glance": {
+      "eyebrow": "What your group sees",
+      "title": "A plan that already looks share-ready",
+      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "items": [
+        "Live route view with pacing context",
+        "Booking-ready activity links when you need them",
+        "A cleaner print layout for the final version"
+      ]
     }
   },
   "cta": {
-    "title": "Míralo en acción",
-    "subtitle": "Crea tu primer itinerario con IA en menos de un minuto.",
-    "button": "Empieza a planear — Gratis"
+    "badge": "Build it while the idea is still fresh",
+    "title": "Start with the route. Keep the travel mood.",
+    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
+    "button": "Start planning"
   }
 }

--- a/locales/es/features.json
+++ b/locales/es/features.json
@@ -1,135 +1,135 @@
 {
   "hero": {
-    "badge": "Interactive trip planning",
-    "titleBefore": "Build trips that already feel",
-    "titleHighlight": "ready to go",
-    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
-    "primaryCta": "Start planning",
-    "secondaryCta": "See example trips",
+    "badge": "Planificación de viajes interactiva",
+    "titleBefore": "Crea viajes que ya se sienten",
+    "titleHighlight": "listos para salir",
+    "description": "TravelFlow convierte ideas de destinos en una ruta a la que tu grupo realmente puede reaccionar. Crea el primer itinerario con IA, ajústalo en un mapa y una línea de tiempo en vivo, y comparte un enlace que siga viéndose pulido cuando llegue el momento de decidir.",
+    "primaryCta": "Empezar a planear",
+    "secondaryCta": "Ver viajes de ejemplo",
     "proof": [
-      "AI itinerary drafts in seconds",
-      "Drag the route until it feels right",
-      "Share one clean link before the group chat gets chaotic"
+      "Borradores de itinerario con IA en segundos",
+      "Ajusta la ruta hasta que encaje",
+      "Un solo enlace claro antes de que el chat explote"
     ]
   },
   "globe": {
-    "accessibility": "Vista previa interactiva del globo con rutas desde tu punto de partida hacia ideas de viaje llenas de color por todo el mundo.",
-    "fallbackTitle": "Vista alternativa del globo",
-    "fallbackDescription": "Incluso sin el globo en vivo, aquí siguen visibles las rutas, las tarjetas del viaje y tu punto de partida.",
+    "accessibility": "Vista previa interactiva del globo con rutas desde tu punto de partida hacia ideas de viaje alrededor del mundo.",
+    "fallbackTitle": "Alternativa al globo interactivo",
+    "fallbackDescription": "Incluso sin el globo en vivo, aún puedes ver las rutas, las tarjetas de viaje y tu punto de partida.",
     "origin": {
       "current": "Desde {city}",
       "countryFallback": "Desde {country}",
-      "fallback": "Punto de salida"
+      "fallback": "Punto de partida"
     },
     "cards": [
       {
         "id": "paris",
         "emoji": "🗼",
-        "title": "Escapada Paris",
-        "detail": "Cafe y museos hasta tarde."
+        "title": "Escapada París",
+        "detail": "Cafés y museos hasta tarde."
       },
       {
         "id": "fiji",
         "emoji": "🌴",
         "title": "Luna de miel Fiji",
-        "detail": "Playa, barcos y tiempo lento."
+        "detail": "Playas, barcos y ritmo lento."
       },
       {
         "id": "south-africa",
         "emoji": "🦈",
         "title": "Buceo gran blanco",
-        "detail": "Agua fria y adrenalina pura."
+        "detail": "Agua fría y adrenalina pura."
       },
       {
         "id": "route66",
         "emoji": "🛣️",
         "title": "Ruta 66",
-        "detail": "Moteles clasicos y final en la costa."
+        "detail": "Moteles clásicos y final en la costa."
       }
     ],
     "preview": {
-      "title": "SEA mochilero 30 dias",
-      "alt": "Vista previa de viaje por el Sudeste Asiatico de 30 dias"
+      "title": "SEA mochilero 30 días",
+      "alt": "Vista previa de un viaje mochilero de 30 días por el Sudeste Asiático"
     }
   },
   "bento": {
-    "badge": "Plan with momentum",
-    "title": "The pieces of trip planning finally stay in one place",
-    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "badge": "Planifica con impulso",
+    "title": "Las piezas del viaje por fin se quedan en un solo lugar",
+    "subtitle": "En vez de saltar entre docs, mapas, capturas y chats a medias, TravelFlow mantiene la ruta, el ritmo y el contexto del viaje juntos.",
     "items": [
       {
         "id": "itinerary",
-        "eyebrow": "AI route draft",
-        "title": "Start from a route, not a blank page",
-        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
-        "detail": "A first draft your group can react to immediately"
+        "eyebrow": "Borrador con IA",
+        "title": "Empieza con una ruta, no con una página en blanco",
+        "description": "Describe el viaje en lenguaje natural y obtén un primer itinerario creíble con flujo entre ciudades, ritmo y contexto ya conectados.",
+        "detail": "Un primer borrador al que tu grupo puede reaccionar enseguida"
       },
       {
         "id": "timeline",
-        "eyebrow": "Live map edits",
-        "title": "Refine the plan without breaking it",
-        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
-        "detail": "Map and timing stay in sync"
+        "eyebrow": "Ediciones en vivo",
+        "title": "Ajusta el plan sin romperlo",
+        "description": "Alarga una estancia, cambia el orden de una ciudad o modifica el ritmo. TravelFlow mantiene mapa y línea de tiempo sincronizados para que cada cambio siga teniendo sentido.",
+        "detail": "Mapa y tiempos siguen sincronizados"
       },
       {
         "id": "inspiration",
-        "eyebrow": "Forkable inspiration",
-        "title": "Borrow proven ideas and make them yours",
-        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
-        "detail": "Start from real travel energy"
+        "eyebrow": "Inspiración reutilizable",
+        "title": "Toma ideas probadas y hazlas tuyas",
+        "description": "Usa rutas con energía real como punto de partida en vez de reconstruir un viaje creíble desde cero cada vez.",
+        "detail": "Empieza con energía de viaje real"
       },
       {
         "id": "sharing",
-        "eyebrow": "Crew review",
-        "title": "Share something your travel crew can understand fast",
-        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
-        "detail": "No account required"
+        "eyebrow": "Revisión del grupo",
+        "title": "Comparte algo que tu grupo entienda rápido",
+        "description": "Envía un solo enlace con la ruta, el ritmo y las notas ya colocadas para que el feedback ocurra sobre el viaje real y no sobre capturas sueltas.",
+        "detail": "Sin cuenta obligatoria"
       },
       {
         "id": "relive",
-        "eyebrow": "Booking and handoff",
-        "title": "Leave with a plan that still feels polished",
-        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
-        "detail": "Ready to share, save, or print"
+        "eyebrow": "Reserva y cierre",
+        "title": "Termina con un plan que siga viéndose pulido",
+        "description": "Cuando la ruta está lista, el contexto práctico sigue ahí: enlaces, notas y una versión más limpia para la entrega final.",
+        "detail": "Listo para compartir, guardar o imprimir"
       }
     ]
   },
   "workflow": {
-    "badge": "From spark to group-ready plan",
-    "title": "One flow for drafting, shaping, and sharing",
-    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "badge": "De la chispa a un plan listo para el grupo",
+    "title": "Un solo flujo para crear, ajustar y compartir",
+    "subtitle": "TravelFlow funciona mejor cuando quieres que la parte emocionante y la parte práctica de planear vivan en el mismo lugar.",
     "steps": [
       {
         "step": "01",
-        "title": "Start with a destination, a vibe, or a copied route",
-        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+        "title": "Empieza con un destino, un mood o una ruta copiada",
+        "description": "Parte de una lista de países, una idea de temporada o un concepto todavía borroso. Aún no necesitas conocer la secuencia perfecta."
       },
       {
         "step": "02",
-        "title": "Shape the pacing with the map and timeline together",
-        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+        "title": "Ajusta el ritmo con mapa y línea de tiempo juntos",
+        "description": "Mira la ruta en el globo y termina de afinarla en la línea de tiempo hasta que encaje con traslados, energía y preferencias del grupo."
       },
       {
         "step": "03",
-        "title": "Share a version that still looks intentional",
-        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+        "title": "Comparte una versión que ya se vea intencional",
+        "description": "Cuando llega el momento de pedir feedback o reservar, el mismo plan ya trae mapa, estructura y el contexto extra que la gente suele pedir."
       }
     ],
     "glance": {
-      "eyebrow": "What your group sees",
-      "title": "A plan that already looks share-ready",
-      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "eyebrow": "Lo que ve tu grupo",
+      "title": "Un plan que ya parece listo para compartir",
+      "description": "Mapa, ritmo por días y contexto práctico se mantienen alineados para que las reacciones lleguen más rápido y con menos confusión.",
       "items": [
-        "Live route view with pacing context",
-        "Booking-ready activity links when you need them",
-        "A cleaner print layout for the final version"
+        "Ruta en vivo con contexto de ritmo",
+        "Enlaces listos para reservar cuando hacen falta",
+        "Una vista de impresión más limpia para la versión final"
       ]
     }
   },
   "cta": {
-    "badge": "Build it while the idea is still fresh",
-    "title": "Start with the route. Keep the travel mood.",
-    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
-    "button": "Start planning"
+    "badge": "Constrúyelo mientras la idea sigue fresca",
+    "title": "Empieza por la ruta. Mantén el mood del viaje.",
+    "subtitle": "Diseña tu próximo viaje en minutos y sigue refinándolo en el mismo lugar en vez de reconstruirlo en cinco herramientas.",
+    "button": "Empezar a planear"
   }
 }

--- a/locales/fa/features.json
+++ b/locales/fa/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "Product Capabilities",
-    "title": "Plan smarter, travel better",
-    "description": "TravelFlow combines AI generation, visual editing, and collaboration into one workspace. Here is everything the platform can do for your next trip."
+    "badge": "Interactive trip planning",
+    "titleBefore": "Build trips that already feel",
+    "titleHighlight": "ready to go",
+    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
+    "primaryCta": "Start planning",
+    "secondaryCta": "See example trips",
+    "proof": [
+      "AI itinerary drafts in seconds",
+      "Drag the route until it feels right",
+      "Share one clean link before the group chat gets chaotic"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "AI Trip Generation",
-      "description": "Describe where you want to go and TravelFlow creates a full itinerary — optimized routes, curated activities, realistic timing — in under 30 seconds. Classic, Wizard, or Surprise Me modes adapt to how you like to plan."
+  "globe": {
+    "accessibility": "پیش‌نمایش تعاملی کره با مسیرهایی از نقطه شروع شما به ایده‌های رنگی سفر در سراسر جهان.",
+    "fallbackTitle": "نمای جایگزین کره",
+    "fallbackDescription": "حتی بدون کره زنده هم مسیرها، کارت‌های سفر و نقطه شروع شما اینجا دیده می‌شوند.",
+    "origin": {
+      "current": "از {city}",
+      "countryFallback": "از {country}",
+      "fallback": "نقطه شروع"
     },
-    "map": {
-      "title": "Interactive Map & Timeline",
-      "description": "Your trip lives on a real map with animated route lines, city markers, and dynamic zoom. Below the map, a visual timeline shows every day at a glance. Switch between satellite, terrain, and minimalist styles."
-    },
-    "editing": {
-      "title": "Drag-and-Drop Editing",
-      "description": "Reorder cities, stretch stay durations, and insert spontaneous stops — all by dragging on the timeline. Dates, connections, and the map update automatically so everything stays in sync."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "آخرهفته پاريس",
+        "detail": "كافه و موزه تا ديروقت."
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "ماه عسل فيجي",
+        "detail": "ساحل، قايق و ريتم آرام."
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "دايو كوسه سفيد",
+        "detail": "آب سرد و هيجان خالص."
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "Route 66",
+        "detail": "متل كلاسيك و پايان در ساحل غربي."
+      }
+    ],
+    "preview": {
+      "title": "30 روز SEA",
+      "alt": "پيش نمايش سفر 30 روزه در آسياي جنوب شرقي"
     }
+  },
+  "bento": {
+    "badge": "Plan with momentum",
+    "title": "The pieces of trip planning finally stay in one place",
+    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "AI route draft",
+        "title": "Start from a route, not a blank page",
+        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
+        "detail": "A first draft your group can react to immediately"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live map edits",
+        "title": "Refine the plan without breaking it",
+        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
+        "detail": "Map and timing stay in sync"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Forkable inspiration",
+        "title": "Borrow proven ideas and make them yours",
+        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
+        "detail": "Start from real travel energy"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew review",
+        "title": "Share something your travel crew can understand fast",
+        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
+        "detail": "No account required"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Booking and handoff",
+        "title": "Leave with a plan that still feels polished",
+        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
+        "detail": "Ready to share, save, or print"
+      }
+    ]
   },
   "workflow": {
-    "title": "How it works",
-    "subtitle": "From idea to itinerary in three steps.",
-    "step1Title": "Choose your destination",
-    "step1Description": "Pick countries, islands, or let Surprise Me suggest the perfect match for your travel window.",
-    "step2Title": "Generate with AI",
-    "step2Description": "Our model drafts a full route with city timing, activities, and logistics. Tweak the result in seconds.",
-    "step3Title": "Refine & share",
-    "step3Description": "Drag cities, adjust durations, add notes. Then share a link — your crew sees the live map and timeline."
-  },
-  "more": {
-    "title": "And so much more",
-    "subtitle": "Every detail is designed to remove friction from trip planning."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "One-Click Sharing",
-      "description": "Generate a link and send it to your travel crew. They see the full map, timeline, and activities — no account needed."
-    },
-    "community": {
-      "title": "Community Inspirations",
-      "description": "Browse curated trips from travelers worldwide. Fork any itinerary as a starting point and make it your own."
-    },
-    "booking": {
-      "title": "Booking Links",
-      "description": "Every AI-suggested activity links to booking platforms — tours, restaurants, transport — so you can reserve without leaving TravelFlow."
-    },
-    "duration": {
-      "title": "Smart Duration Hints",
-      "description": "TravelFlow analyzes seasonal data and travel distances to suggest how long to spend in each city so you never feel rushed."
-    },
-    "mobile": {
-      "title": "Mobile-Optimized",
-      "description": "Plan on the go with a responsive layout tuned for phones and tablets. The map, timeline, and editing all adapt to smaller screens."
-    },
-    "print": {
-      "title": "Print-Ready Itineraries",
-      "description": "Switch to print view for a clean, paper-friendly itinerary with day headers, activity lists, and essential logistics."
-    },
-    "routing": {
-      "title": "Multi-Country Routing",
-      "description": "Select multiple countries or islands and TravelFlow builds a cross-border route with realistic transit between regions."
-    },
-    "history": {
-      "title": "Version History",
-      "description": "Every meaningful change creates a snapshot. Jump back to any previous version of your trip with a single click."
-    },
-    "privacy": {
-      "title": "Privacy-First",
-      "description": "Your trips stay local by default. Optional cloud sync is consent-gated, and analytics only run after explicit opt-in."
-    }
-  },
-  "comparison": {
-    "title": "How TravelFlow compares",
-    "subtitle": "Side-by-side against spreadsheet planning and other trip tools.",
-    "featureHeader": "Feature",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "Spreadsheet",
-    "otherHeader": "Other Tools",
-    "yes": "Yes",
-    "partial": "Partial",
-    "manual": "Manual",
-    "freemium": "Freemium",
-    "rows": {
-      "ai": "AI-generated itinerary",
-      "interactiveMap": "Interactive map",
-      "dragDrop": "Drag-and-drop timeline",
-      "oneClickSharing": "One-click sharing",
-      "bookingLinks": "Booking links",
-      "offlineFirst": "Offline-first / local data",
-      "freeToUse": "Free to use"
+    "badge": "From spark to group-ready plan",
+    "title": "One flow for drafting, shaping, and sharing",
+    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Start with a destination, a vibe, or a copied route",
+        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+      },
+      {
+        "step": "02",
+        "title": "Shape the pacing with the map and timeline together",
+        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+      },
+      {
+        "step": "03",
+        "title": "Share a version that still looks intentional",
+        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+      }
+    ],
+    "glance": {
+      "eyebrow": "What your group sees",
+      "title": "A plan that already looks share-ready",
+      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "items": [
+        "Live route view with pacing context",
+        "Booking-ready activity links when you need them",
+        "A cleaner print layout for the final version"
+      ]
     }
   },
   "cta": {
-    "title": "See it in action",
-    "subtitle": "Create your first AI-powered itinerary in under a minute.",
-    "button": "Start Planning — Free"
+    "badge": "Build it while the idea is still fresh",
+    "title": "Start with the route. Keep the travel mood.",
+    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
+    "button": "Start planning"
   }
 }

--- a/locales/fa/features.json
+++ b/locales/fa/features.json
@@ -1,21 +1,21 @@
 {
   "hero": {
-    "badge": "Interactive trip planning",
-    "titleBefore": "Build trips that already feel",
-    "titleHighlight": "ready to go",
-    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
-    "primaryCta": "Start planning",
-    "secondaryCta": "See example trips",
+    "badge": "برنامه‌ریزی تعاملی سفر",
+    "titleBefore": "سفرهایی بسازید که از همین حالا",
+    "titleHighlight": "آماده رفتن باشند",
+    "description": "TravelFlow ایده‌های مقصد را به مسیری تبدیل می‌کند که گروه شما واقعاً بتواند به آن واکنش نشان دهد. پیش‌نویس اولیه را با هوش مصنوعی بسازید، روی نقشه و تایم‌لاین زنده آن را شکل بدهید و بعد لینکی را به اشتراک بگذارید که وقتی تصمیم‌ها جدی می‌شوند هنوز هم مرتب و روشن به نظر برسد.",
+    "primaryCta": "شروع برنامه‌ریزی",
+    "secondaryCta": "دیدن سفرهای نمونه",
     "proof": [
-      "AI itinerary drafts in seconds",
-      "Drag the route until it feels right",
-      "Share one clean link before the group chat gets chaotic"
+      "پیش‌نویس سفر با هوش مصنوعی در چند ثانیه",
+      "مسیر را تا وقتی درست شود تنظیم کنید",
+      "یک لینک روشن پیش از شلوغ شدن چت گروهی"
     ]
   },
   "globe": {
-    "accessibility": "پیش‌نمایش تعاملی کره با مسیرهایی از نقطه شروع شما به ایده‌های رنگی سفر در سراسر جهان.",
-    "fallbackTitle": "نمای جایگزین کره",
-    "fallbackDescription": "حتی بدون کره زنده هم مسیرها، کارت‌های سفر و نقطه شروع شما اینجا دیده می‌شوند.",
+    "accessibility": "پیش‌نمایش تعاملی کره با مسیرهایی از نقطه شروع شما به ایده‌های سفر در سراسر جهان.",
+    "fallbackTitle": "نمای جایگزین کره تعاملی",
+    "fallbackDescription": "حتی بدون کره زنده هم می‌توانید مسیرها، کارت‌های سفر و نقطه شروع خود را ببینید.",
     "origin": {
       "current": "از {city}",
       "countryFallback": "از {country}",
@@ -25,111 +25,111 @@
       {
         "id": "paris",
         "emoji": "🗼",
-        "title": "آخرهفته پاريس",
-        "detail": "كافه و موزه تا ديروقت."
+        "title": "آخرهفته پاریس",
+        "detail": "کافه و موزه تا دیروقت."
       },
       {
         "id": "fiji",
         "emoji": "🌴",
-        "title": "ماه عسل فيجي",
-        "detail": "ساحل، قايق و ريتم آرام."
+        "title": "ماه عسل فیجی",
+        "detail": "ساحل، قایق و ریتم آرام."
       },
       {
         "id": "south-africa",
         "emoji": "🦈",
-        "title": "دايو كوسه سفيد",
-        "detail": "آب سرد و هيجان خالص."
+        "title": "دایو کوسه سفید",
+        "detail": "آب سرد و هیجان خالص."
       },
       {
         "id": "route66",
         "emoji": "🛣️",
         "title": "Route 66",
-        "detail": "متل كلاسيك و پايان در ساحل غربي."
+        "detail": "متل کلاسیک و پایان در ساحل غربی."
       }
     ],
     "preview": {
-      "title": "30 روز SEA",
-      "alt": "پيش نمايش سفر 30 روزه در آسياي جنوب شرقي"
+      "title": "۳۰ روز SEA",
+      "alt": "پیش‌نمایش سفر کوله‌گردی ۳۰ روزه در آسیای جنوب شرقی"
     }
   },
   "bento": {
-    "badge": "Plan with momentum",
-    "title": "The pieces of trip planning finally stay in one place",
-    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "badge": "با ریتم برنامه‌ریزی کنید",
+    "title": "تکه‌های سفر بالاخره در یک جا می‌مانند",
+    "subtitle": "به‌جای پریدن بین داکیومنت، نقشه، اسکرین‌شات و چت‌های نیمه‌کاره، TravelFlow مسیر، ریتم و زمینه سفر را کنار هم نگه می‌دارد.",
     "items": [
       {
         "id": "itinerary",
-        "eyebrow": "AI route draft",
-        "title": "Start from a route, not a blank page",
-        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
-        "detail": "A first draft your group can react to immediately"
+        "eyebrow": "پیش‌نویس هوش مصنوعی",
+        "title": "از یک مسیر شروع کنید، نه از صفحه خالی",
+        "description": "سفر را با زبان طبیعی توضیح دهید و یک برنامه اولیه قابل‌باور بگیرید که جریان شهرها، ریتم و زمینه از قبل به هم وصل شده‌اند.",
+        "detail": "یک پیش‌نویس اولیه که گروه می‌تواند فوراً به آن واکنش نشان دهد"
       },
       {
         "id": "timeline",
-        "eyebrow": "Live map edits",
-        "title": "Refine the plan without breaking it",
-        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
-        "detail": "Map and timing stay in sync"
+        "eyebrow": "ویرایش زنده",
+        "title": "برنامه را بدون شکستن آن تنظیم کنید",
+        "description": "اقامت را طولانی‌تر کنید، ترتیب شهرها را عوض کنید یا ریتم را تغییر دهید. TravelFlow نقشه و تایم‌لاین را همسو نگه می‌دارد تا هر ویرایش هنوز منسجم بماند.",
+        "detail": "نقشه و زمان‌بندی همسو می‌مانند"
       },
       {
         "id": "inspiration",
-        "eyebrow": "Forkable inspiration",
-        "title": "Borrow proven ideas and make them yours",
-        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
-        "detail": "Start from real travel energy"
+        "eyebrow": "الهام قابل استفاده دوباره",
+        "title": "از ایده‌های خوب شروع کنید و آن را مال خودتان کنید",
+        "description": "به‌جای ساختن دوباره یک سفر قابل‌باور از صفر، از مسیرهایی شروع کنید که از قبل انرژی سفر واقعی دارند.",
+        "detail": "با انرژی واقعی سفر شروع کنید"
       },
       {
         "id": "sharing",
-        "eyebrow": "Crew review",
-        "title": "Share something your travel crew can understand fast",
-        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
-        "detail": "No account required"
+        "eyebrow": "بازخورد گروه",
+        "title": "چیزی را به اشتراک بگذارید که گروه سریع بفهمد",
+        "description": "یک لینک با مسیر، ریتم و یادداشت‌های آماده بفرستید تا بازخورد روی خود سفر شکل بگیرد، نه روی اسکرین‌شات‌های پراکنده.",
+        "detail": "بدون نیاز به حساب کاربری"
       },
       {
         "id": "relive",
-        "eyebrow": "Booking and handoff",
-        "title": "Leave with a plan that still feels polished",
-        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
-        "detail": "Ready to share, save, or print"
+        "eyebrow": "رزرو و تحویل نهایی",
+        "title": "در پایان هم یک برنامه مرتب داشته باشید",
+        "description": "وقتی مسیر آماده شد، زمینه کاربردی هنوز همان‌جاست: لینک‌ها، یادداشت‌ها و نسخه‌ای تمیزتر برای تحویل نهایی.",
+        "detail": "آماده برای اشتراک، ذخیره یا چاپ"
       }
     ]
   },
   "workflow": {
-    "badge": "From spark to group-ready plan",
-    "title": "One flow for drafting, shaping, and sharing",
-    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "badge": "از جرقه تا برنامه آماده برای گروه",
+    "title": "یک جریان برای پیش‌نویس، تنظیم و اشتراک",
+    "subtitle": "TravelFlow وقتی بهترین است که بخواهید بخش هیجان‌انگیز و بخش عملی برنامه‌ریزی را در یک جا نگه دارید.",
     "steps": [
       {
         "step": "01",
-        "title": "Start with a destination, a vibe, or a copied route",
-        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+        "title": "با مقصد، حال‌وهوا یا یک مسیر کپی‌شده شروع کنید",
+        "description": "از فهرست کشورها، یک ایده فصلی یا مفهومی که هنوز مبهم است شروع کنید. هنوز لازم نیست ترتیب دقیق را بدانید."
       },
       {
         "step": "02",
-        "title": "Shape the pacing with the map and timeline together",
-        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+        "title": "ریتم را با نقشه و تایم‌لاین کنار هم تنظیم کنید",
+        "description": "مسیر را روی کره ببینید و بعد روی تایم‌لاین آن‌قدر تنظیمش کنید تا برای جابه‌جایی‌ها، انرژی و سلیقه گروه واقعی به نظر برسد."
       },
       {
         "step": "03",
-        "title": "Share a version that still looks intentional",
-        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+        "title": "نسخه‌ای را به اشتراک بگذارید که از قبل بافکر به نظر می‌رسد",
+        "description": "وقتی وقت گرفتن بازخورد یا رزرو می‌رسد، همان برنامه از قبل نقشه، ساختار و زمینه اضافه‌ای را دارد که معمولاً همه می‌خواهند."
       }
     ],
     "glance": {
-      "eyebrow": "What your group sees",
-      "title": "A plan that already looks share-ready",
-      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "eyebrow": "چیزی که گروه شما می‌بیند",
+      "title": "برنامه‌ای که از قبل آماده اشتراک به نظر می‌رسد",
+      "description": "نقشه، ریتم روزبه‌روز و زمینه عملی کنار هم می‌مانند تا واکنش‌ها سریع‌تر و روشن‌تر برسند.",
       "items": [
-        "Live route view with pacing context",
-        "Booking-ready activity links when you need them",
-        "A cleaner print layout for the final version"
+        "نمای زنده مسیر با زمینه ریتم",
+        "لینک‌های آماده رزرو وقتی لازم شوند",
+        "چیدمان چاپ تمیزتر برای نسخه نهایی"
       ]
     }
   },
   "cta": {
-    "badge": "Build it while the idea is still fresh",
-    "title": "Start with the route. Keep the travel mood.",
-    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
-    "button": "Start planning"
+    "badge": "تا وقتی ایده تازه است بسازیدش",
+    "title": "از مسیر شروع کنید. حال‌وهوای سفر را نگه دارید.",
+    "subtitle": "سفر بعدی را در چند دقیقه پیش‌نویس کنید و بعد همان‌جا به اصلاحش ادامه دهید، نه این‌که آن را در پنج ابزار از نو بسازید.",
+    "button": "شروع برنامه‌ریزی"
   }
 }

--- a/locales/fr/features.json
+++ b/locales/fr/features.json
@@ -1,21 +1,21 @@
 {
   "hero": {
-    "badge": "Interactive trip planning",
-    "titleBefore": "Build trips that already feel",
-    "titleHighlight": "ready to go",
-    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
-    "primaryCta": "Start planning",
-    "secondaryCta": "See example trips",
+    "badge": "Planification de voyage interactive",
+    "titleBefore": "Créez des voyages déjà",
+    "titleHighlight": "prêts à partir",
+    "description": "TravelFlow transforme des idées de destination en un itinéraire auquel votre groupe peut vraiment réagir. Lancez une première version avec l’IA, ajustez-la sur une carte et une timeline en direct, puis partagez un lien qui reste net quand les décisions deviennent concrètes.",
+    "primaryCta": "Commencer à planifier",
+    "secondaryCta": "Voir des voyages exemples",
     "proof": [
-      "AI itinerary drafts in seconds",
-      "Drag the route until it feels right",
-      "Share one clean link before the group chat gets chaotic"
+      "Brouillons d’itinéraire IA en quelques secondes",
+      "Ajustez la route jusqu’à ce qu’elle sonne juste",
+      "Un seul lien clair avant que le groupe s’emballe"
     ]
   },
   "globe": {
-    "accessibility": "Aperçu interactif du globe avec des itinéraires depuis votre point de départ vers des idées de voyage colorées autour du monde.",
+    "accessibility": "Aperçu interactif du globe montrant des routes depuis votre point de départ vers des idées de voyage dans le monde entier.",
     "fallbackTitle": "Version de secours du globe",
-    "fallbackDescription": "Même sans le globe en direct, les trajets, les cartes de voyage et votre point de départ restent visibles.",
+    "fallbackDescription": "Même sans globe en direct, vous pouvez toujours voir les routes, les cartes voyage et votre point de départ.",
     "origin": {
       "current": "Depuis {city}",
       "countryFallback": "Depuis {country}",
@@ -26,7 +26,7 @@
         "id": "paris",
         "emoji": "🗼",
         "title": "Week-end Paris",
-        "detail": "Cafes et musees tardifs."
+        "detail": "Cafés et musées tardifs."
       },
       {
         "id": "fiji",
@@ -37,99 +37,99 @@
       {
         "id": "south-africa",
         "emoji": "🦈",
-        "title": "Plongee grand blanc",
+        "title": "Plongée grand blanc",
         "detail": "Eau froide et gros frisson."
       },
       {
         "id": "route66",
         "emoji": "🛣️",
         "title": "Route 66",
-        "detail": "Motels vintage et fin cote ouest."
+        "detail": "Motels vintage et arrivée côte ouest."
       }
     ],
     "preview": {
-      "title": "SEA sac a dos 30 j",
-      "alt": "Apercu de voyage de 30 jours en Asie du Sud-Est"
+      "title": "SEA sac à dos 30 j",
+      "alt": "Aperçu d’un voyage sac à dos de 30 jours en Asie du Sud-Est"
     }
   },
   "bento": {
-    "badge": "Plan with momentum",
-    "title": "The pieces of trip planning finally stay in one place",
-    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "badge": "Planifiez avec élan",
+    "title": "Les pièces du voyage restent enfin au même endroit",
+    "subtitle": "Au lieu de jongler entre docs, cartes, captures et fils de discussion à moitié finis, TravelFlow garde la route, le rythme et le contexte ensemble.",
     "items": [
       {
         "id": "itinerary",
-        "eyebrow": "AI route draft",
-        "title": "Start from a route, not a blank page",
-        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
-        "detail": "A first draft your group can react to immediately"
+        "eyebrow": "Brouillon IA",
+        "title": "Commencez par une route, pas par une page vide",
+        "description": "Décrivez le voyage en langage naturel et obtenez un premier itinéraire crédible avec enchaînement des villes, rythme et contexte déjà reliés.",
+        "detail": "Un premier brouillon auquel votre groupe peut réagir tout de suite"
       },
       {
         "id": "timeline",
-        "eyebrow": "Live map edits",
-        "title": "Refine the plan without breaking it",
-        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
-        "detail": "Map and timing stay in sync"
+        "eyebrow": "Édits en direct",
+        "title": "Ajustez le plan sans le casser",
+        "description": "Allongez une étape, réordonnez une ville ou changez le rythme. TravelFlow garde la carte et la timeline alignées pour que chaque modification reste cohérente.",
+        "detail": "Carte et timing restent synchronisés"
       },
       {
         "id": "inspiration",
-        "eyebrow": "Forkable inspiration",
-        "title": "Borrow proven ideas and make them yours",
-        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
-        "detail": "Start from real travel energy"
+        "eyebrow": "Inspiration réutilisable",
+        "title": "Prenez de bonnes idées et appropriez-les-vous",
+        "description": "Partez d’itinéraires déjà crédibles au lieu de reconstruire un voyage plausible depuis zéro à chaque fois.",
+        "detail": "Commencez avec une vraie énergie de voyage"
       },
       {
         "id": "sharing",
-        "eyebrow": "Crew review",
-        "title": "Share something your travel crew can understand fast",
-        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
-        "detail": "No account required"
+        "eyebrow": "Retour du groupe",
+        "title": "Partagez quelque chose que le groupe comprend vite",
+        "description": "Envoyez un seul lien avec la route, le rythme et les notes déjà en place pour que les retours portent sur le vrai voyage, pas sur des captures dispersées.",
+        "detail": "Aucun compte requis"
       },
       {
         "id": "relive",
-        "eyebrow": "Booking and handoff",
-        "title": "Leave with a plan that still feels polished",
-        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
-        "detail": "Ready to share, save, or print"
+        "eyebrow": "Réservation et handoff",
+        "title": "Finissez avec un plan qui reste soigné",
+        "description": "Quand la route est prête, le contexte pratique est toujours là : liens, notes et une version plus propre pour le passage final.",
+        "detail": "Prêt à partager, enregistrer ou imprimer"
       }
     ]
   },
   "workflow": {
-    "badge": "From spark to group-ready plan",
-    "title": "One flow for drafting, shaping, and sharing",
-    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "badge": "De l’étincelle à un plan prêt pour le groupe",
+    "title": "Un seul flux pour créer, affiner et partager",
+    "subtitle": "TravelFlow est à son meilleur quand la partie excitante et la partie pratique de la préparation vivent au même endroit.",
     "steps": [
       {
         "step": "01",
-        "title": "Start with a destination, a vibe, or a copied route",
-        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+        "title": "Commencez avec une destination, une vibe ou une route copiée",
+        "description": "Partez d’une liste de pays, d’une idée de saison ou d’un concept encore flou. Vous n’avez pas encore besoin de connaître l’ordre parfait."
       },
       {
         "step": "02",
-        "title": "Shape the pacing with the map and timeline together",
-        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+        "title": "Ajustez le rythme avec carte et timeline ensemble",
+        "description": "Voyez la route sur le globe, puis resserrez-la sur la timeline jusqu’à ce qu’elle semble réaliste pour les transferts, l’énergie et les préférences du groupe."
       },
       {
         "step": "03",
-        "title": "Share a version that still looks intentional",
-        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+        "title": "Partagez une version déjà pensée",
+        "description": "Quand il faut obtenir des retours ou réserver, le même plan contient déjà la carte, la structure et le contexte supplémentaire que tout le monde demande."
       }
     ],
     "glance": {
-      "eyebrow": "What your group sees",
-      "title": "A plan that already looks share-ready",
-      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "eyebrow": "Ce que voit votre groupe",
+      "title": "Un plan qui semble déjà prêt à être partagé",
+      "description": "Carte, rythme jour par jour et détails pratiques restent alignés pour obtenir des réactions plus vite et plus clairement.",
       "items": [
-        "Live route view with pacing context",
-        "Booking-ready activity links when you need them",
-        "A cleaner print layout for the final version"
+        "Vue de route en direct avec contexte de rythme",
+        "Liens prêts à réserver quand il le faut",
+        "Une mise en page impression plus propre pour la version finale"
       ]
     }
   },
   "cta": {
-    "badge": "Build it while the idea is still fresh",
-    "title": "Start with the route. Keep the travel mood.",
-    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
-    "button": "Start planning"
+    "badge": "Construisez-le tant que l’idée est fraîche",
+    "title": "Commencez par la route. Gardez l’ambiance du voyage.",
+    "subtitle": "Esquissez votre prochain voyage en quelques minutes puis continuez à l’affiner au même endroit au lieu de le reconstruire dans cinq outils.",
+    "button": "Commencer à planifier"
   }
 }

--- a/locales/fr/features.json
+++ b/locales/fr/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "Capacites produit",
-    "title": "Planifiez mieux, voyagez mieux",
-    "description": "TravelFlow combines AI generation, visual editing, and collaboration into one workspace. Here is everything the platform can do for your next trip."
+    "badge": "Interactive trip planning",
+    "titleBefore": "Build trips that already feel",
+    "titleHighlight": "ready to go",
+    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
+    "primaryCta": "Start planning",
+    "secondaryCta": "See example trips",
+    "proof": [
+      "AI itinerary drafts in seconds",
+      "Drag the route until it feels right",
+      "Share one clean link before the group chat gets chaotic"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "Génération d'itinéraire par IA",
-      "description": "Describe where you want to go and TravelFlow creates a full itinerary — optimized routes, curated activities, realistic timing — in under 30 seconds. Classic, Wizard, or Surprise Me modes adapt to how you like to plan."
+  "globe": {
+    "accessibility": "Aperçu interactif du globe avec des itinéraires depuis votre point de départ vers des idées de voyage colorées autour du monde.",
+    "fallbackTitle": "Version de secours du globe",
+    "fallbackDescription": "Même sans le globe en direct, les trajets, les cartes de voyage et votre point de départ restent visibles.",
+    "origin": {
+      "current": "Depuis {city}",
+      "countryFallback": "Depuis {country}",
+      "fallback": "Point de départ"
     },
-    "map": {
-      "title": "Carte interactive et timeline",
-      "description": "Your trip lives on a real map with animated route lines, city markers, and dynamic zoom. Below the map, a visual timeline shows every day at a glance. Switch between satellite, terrain, and minimalist styles."
-    },
-    "editing": {
-      "title": "Edition glisser-deposer",
-      "description": "Reorder cities, stretch stay durations, and insert spontaneous stops — all by dragging on the timeline. Dates, connections, and the map update automatically so everything stays in sync."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "Week-end Paris",
+        "detail": "Cafes et musees tardifs."
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "Lune de miel Fiji",
+        "detail": "Plages, bateaux et rythme doux."
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "Plongee grand blanc",
+        "detail": "Eau froide et gros frisson."
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "Route 66",
+        "detail": "Motels vintage et fin cote ouest."
+      }
+    ],
+    "preview": {
+      "title": "SEA sac a dos 30 j",
+      "alt": "Apercu de voyage de 30 jours en Asie du Sud-Est"
     }
+  },
+  "bento": {
+    "badge": "Plan with momentum",
+    "title": "The pieces of trip planning finally stay in one place",
+    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "AI route draft",
+        "title": "Start from a route, not a blank page",
+        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
+        "detail": "A first draft your group can react to immediately"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live map edits",
+        "title": "Refine the plan without breaking it",
+        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
+        "detail": "Map and timing stay in sync"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Forkable inspiration",
+        "title": "Borrow proven ideas and make them yours",
+        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
+        "detail": "Start from real travel energy"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew review",
+        "title": "Share something your travel crew can understand fast",
+        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
+        "detail": "No account required"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Booking and handoff",
+        "title": "Leave with a plan that still feels polished",
+        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
+        "detail": "Ready to share, save, or print"
+      }
+    ]
   },
   "workflow": {
-    "title": "Comment ca marche",
-    "subtitle": "From idea to itinerary in three steps.",
-    "step1Title": "Choose your destination",
-    "step1Description": "Pick countries, islands, or let Surprise Me suggest the perfect match for your travel window.",
-    "step2Title": "Generate with AI",
-    "step2Description": "Our model drafts a full route with city timing, activities, and logistics. Tweak the result in seconds.",
-    "step3Title": "Refine & share",
-    "step3Description": "Drag cities, adjust durations, add notes. Then share a link — your crew sees the live map and timeline."
-  },
-  "more": {
-    "title": "Et bien plus encore",
-    "subtitle": "Every detail is designed to remove friction from trip planning."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "Partage en un clic",
-      "description": "Generate a link and send it to your travel crew. They see the full map, timeline, and activities — no account needed."
-    },
-    "community": {
-      "title": "Inspirations de la communaute",
-      "description": "Browse curated trips from travelers worldwide. Fork any itinerary as a starting point and make it your own."
-    },
-    "booking": {
-      "title": "Liens de reservation",
-      "description": "Every AI-suggested activity links to booking platforms — tours, restaurants, transport — so you can reserve without leaving TravelFlow."
-    },
-    "duration": {
-      "title": "Suggestions de duree intelligentes",
-      "description": "TravelFlow analyzes seasonal data and travel distances to suggest how long to spend in each city so you never feel rushed."
-    },
-    "mobile": {
-      "title": "Optimise mobile",
-      "description": "Plan on the go with a responsive layout tuned for phones and tablets. The map, timeline, and editing all adapt to smaller screens."
-    },
-    "print": {
-      "title": "Itineraires prets a imprimer",
-      "description": "Switch to print view for a clean, paper-friendly itinerary with day headers, activity lists, and essential logistics."
-    },
-    "routing": {
-      "title": "Itineraires multi-pays",
-      "description": "Select multiple countries or islands and TravelFlow builds a cross-border route with realistic transit between regions."
-    },
-    "history": {
-      "title": "Historique des versions",
-      "description": "Every meaningful change creates a snapshot. Jump back to any previous version of your trip with a single click."
-    },
-    "privacy": {
-      "title": "Confidentialite d'abord",
-      "description": "Your trips stay local by default. Optional cloud sync is consent-gated, and analytics only run after explicit opt-in."
-    }
-  },
-  "comparison": {
-    "title": "Comparatif TravelFlow",
-    "subtitle": "Side-by-side against spreadsheet planning and other trip tools.",
-    "featureHeader": "Feature",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "Spreadsheet",
-    "otherHeader": "Other Tools",
-    "yes": "Yes",
-    "partial": "Partial",
-    "manual": "Manual",
-    "freemium": "Freemium",
-    "rows": {
-      "ai": "AI-generated itinerary",
-      "interactiveMap": "Interactive map",
-      "dragDrop": "Drag-and-drop timeline",
-      "oneClickSharing": "One-click sharing",
-      "bookingLinks": "Booking links",
-      "offlineFirst": "Offline-first / local data",
-      "freeToUse": "Free to use"
+    "badge": "From spark to group-ready plan",
+    "title": "One flow for drafting, shaping, and sharing",
+    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Start with a destination, a vibe, or a copied route",
+        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+      },
+      {
+        "step": "02",
+        "title": "Shape the pacing with the map and timeline together",
+        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+      },
+      {
+        "step": "03",
+        "title": "Share a version that still looks intentional",
+        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+      }
+    ],
+    "glance": {
+      "eyebrow": "What your group sees",
+      "title": "A plan that already looks share-ready",
+      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "items": [
+        "Live route view with pacing context",
+        "Booking-ready activity links when you need them",
+        "A cleaner print layout for the final version"
+      ]
     }
   },
   "cta": {
-    "title": "Voir le produit en action",
-    "subtitle": "Create your first AI-powered itinerary in under a minute.",
-    "button": "Start Planning — Free"
+    "badge": "Build it while the idea is still fresh",
+    "title": "Start with the route. Keep the travel mood.",
+    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
+    "button": "Start planning"
   }
 }

--- a/locales/it/features.json
+++ b/locales/it/features.json
@@ -1,21 +1,21 @@
 {
   "hero": {
-    "badge": "Interactive trip planning",
-    "titleBefore": "Build trips that already feel",
-    "titleHighlight": "ready to go",
-    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
-    "primaryCta": "Start planning",
-    "secondaryCta": "See example trips",
+    "badge": "Pianificazione di viaggi interattiva",
+    "titleBefore": "Crea viaggi che sembrano già",
+    "titleHighlight": "pronti a partire",
+    "description": "TravelFlow trasforma idee di destinazioni in un percorso su cui il tuo gruppo può davvero reagire. Crea la prima bozza con l’IA, modellala su una mappa e una timeline live e condividi un link che resta curato quando le decisioni diventano reali.",
+    "primaryCta": "Inizia a pianificare",
+    "secondaryCta": "Vedi viaggi esempio",
     "proof": [
-      "AI itinerary drafts in seconds",
-      "Drag the route until it feels right",
-      "Share one clean link before the group chat gets chaotic"
+      "Bozze di itinerario IA in pochi secondi",
+      "Trascina la rotta finché non sembra giusta",
+      "Un solo link chiaro prima che il gruppo vada nel caos"
     ]
   },
   "globe": {
-    "accessibility": "Anteprima interattiva del globo con rotte dal tuo punto di partenza verso idee di viaggio colorate in tutto il mondo.",
-    "fallbackTitle": "Versione alternativa del globo",
-    "fallbackDescription": "Anche senza il globo live, qui restano visibili le rotte, le card del viaggio e il tuo punto di partenza.",
+    "accessibility": "Anteprima interattiva del globo con rotte dal tuo punto di partenza verso idee di viaggio in tutto il mondo.",
+    "fallbackTitle": "Fallback del globo interattivo",
+    "fallbackDescription": "Anche senza il globo live puoi comunque vedere rotte, card di viaggio e il tuo punto di partenza.",
     "origin": {
       "current": "Da {city}",
       "countryFallback": "Da {country}",
@@ -26,7 +26,7 @@
         "id": "paris",
         "emoji": "🗼",
         "title": "Weekend a Parigi",
-        "detail": "Cafe e musei fino a tardi."
+        "detail": "Caffè e musei fino a tardi."
       },
       {
         "id": "fiji",
@@ -37,7 +37,7 @@
       {
         "id": "south-africa",
         "emoji": "🦈",
-        "title": "Dive squalo bianco",
+        "title": "Dive con squalo bianco",
         "detail": "Acqua fredda e adrenalina pura."
       },
       {
@@ -49,87 +49,87 @@
     ],
     "preview": {
       "title": "SEA zaino 30 giorni",
-      "alt": "Anteprima di viaggio di 30 giorni nel Sud-est asiatico"
+      "alt": "Anteprima di un viaggio zaino in spalla di 30 giorni nel Sud-est asiatico"
     }
   },
   "bento": {
-    "badge": "Plan with momentum",
-    "title": "The pieces of trip planning finally stay in one place",
-    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "badge": "Pianifica con slancio",
+    "title": "I pezzi del viaggio finalmente restano nello stesso posto",
+    "subtitle": "Invece di saltare tra documenti, mappe, screenshot e chat mezze finite, TravelFlow tiene insieme rotta, ritmo e contesto del viaggio.",
     "items": [
       {
         "id": "itinerary",
-        "eyebrow": "AI route draft",
-        "title": "Start from a route, not a blank page",
-        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
-        "detail": "A first draft your group can react to immediately"
+        "eyebrow": "Bozza IA",
+        "title": "Parti da una rotta, non da una pagina vuota",
+        "description": "Descrivi il viaggio in linguaggio naturale e ottieni un primo itinerario credibile con flusso tra città, ritmo e contesto già collegati.",
+        "detail": "Una prima bozza su cui il gruppo può reagire subito"
       },
       {
         "id": "timeline",
-        "eyebrow": "Live map edits",
-        "title": "Refine the plan without breaking it",
-        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
-        "detail": "Map and timing stay in sync"
+        "eyebrow": "Modifiche live",
+        "title": "Rifinisci il piano senza romperlo",
+        "description": "Allunga una tappa, riordina una città o cambia il ritmo. TravelFlow tiene mappa e timeline allineate così ogni modifica resta coerente.",
+        "detail": "Mappa e tempi restano sincronizzati"
       },
       {
         "id": "inspiration",
-        "eyebrow": "Forkable inspiration",
-        "title": "Borrow proven ideas and make them yours",
-        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
-        "detail": "Start from real travel energy"
+        "eyebrow": "Ispirazione riutilizzabile",
+        "title": "Prendi idee già buone e falle tue",
+        "description": "Usa percorsi già credibili come punto di partenza invece di ricostruire ogni volta un viaggio plausibile da zero.",
+        "detail": "Parti da vera energia di viaggio"
       },
       {
         "id": "sharing",
-        "eyebrow": "Crew review",
-        "title": "Share something your travel crew can understand fast",
-        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
-        "detail": "No account required"
+        "eyebrow": "Revisione del gruppo",
+        "title": "Condividi qualcosa che il gruppo capisce subito",
+        "description": "Invia un solo link con rotta, ritmo e note già al loro posto, così il feedback arriva sul viaggio reale e non su screenshot sparsi.",
+        "detail": "Nessun account richiesto"
       },
       {
         "id": "relive",
-        "eyebrow": "Booking and handoff",
-        "title": "Leave with a plan that still feels polished",
-        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
-        "detail": "Ready to share, save, or print"
+        "eyebrow": "Prenotazione e handoff",
+        "title": "Chiudi con un piano che resta curato",
+        "description": "Quando la rotta è pronta, il contesto pratico resta lì: link, note e una versione più pulita per il passaggio finale.",
+        "detail": "Pronto da condividere, salvare o stampare"
       }
     ]
   },
   "workflow": {
-    "badge": "From spark to group-ready plan",
-    "title": "One flow for drafting, shaping, and sharing",
-    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "badge": "Dall’idea a un piano pronto per il gruppo",
+    "title": "Un solo flusso per creare, rifinire e condividere",
+    "subtitle": "TravelFlow funziona al meglio quando vuoi tenere nello stesso posto sia la parte entusiasmante sia quella pratica della pianificazione.",
     "steps": [
       {
         "step": "01",
-        "title": "Start with a destination, a vibe, or a copied route",
-        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+        "title": "Parti da una destinazione, da un mood o da una rotta copiata",
+        "description": "Inizia da una lista di paesi, da un’idea stagionale o da un concetto ancora sfocato. Non serve già conoscere la sequenza perfetta."
       },
       {
         "step": "02",
-        "title": "Shape the pacing with the map and timeline together",
-        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+        "title": "Sistema il ritmo con mappa e timeline insieme",
+        "description": "Guarda la rotta sul globo e poi stringila sulla timeline finché non sembra realistica per trasferimenti, energie e preferenze del gruppo."
       },
       {
         "step": "03",
-        "title": "Share a version that still looks intentional",
-        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+        "title": "Condividi una versione che appare già intenzionale",
+        "description": "Quando arriva il momento di chiedere feedback o prenotare, lo stesso piano contiene già mappa, struttura e contesto extra che tutti chiedono."
       }
     ],
     "glance": {
-      "eyebrow": "What your group sees",
-      "title": "A plan that already looks share-ready",
-      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "eyebrow": "Cosa vede il gruppo",
+      "title": "Un piano che sembra già pronto da condividere",
+      "description": "Mappa, ritmo giorno per giorno e contesto pratico restano allineati così le reazioni arrivano prima e con meno confusione.",
       "items": [
-        "Live route view with pacing context",
-        "Booking-ready activity links when you need them",
-        "A cleaner print layout for the final version"
+        "Vista live della rotta con contesto di ritmo",
+        "Link pronti per prenotare quando servono",
+        "Una stampa più pulita per la versione finale"
       ]
     }
   },
   "cta": {
-    "badge": "Build it while the idea is still fresh",
-    "title": "Start with the route. Keep the travel mood.",
-    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
-    "button": "Start planning"
+    "badge": "Costruiscilo finché l’idea è ancora fresca",
+    "title": "Inizia dalla rotta. Tieni il mood del viaggio.",
+    "subtitle": "Butta giù il tuo prossimo viaggio in pochi minuti e continua a rifinirlo nello stesso posto invece di ricostruirlo in cinque strumenti.",
+    "button": "Inizia a pianificare"
   }
 }

--- a/locales/it/features.json
+++ b/locales/it/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "Funzionalità prodotto",
-    "title": "Pianifica meglio, viaggia meglio",
-    "description": "TravelFlow combines AI generation, visual editing, and collaboration into one workspace. Here is everything the platform can do for your next trip."
+    "badge": "Interactive trip planning",
+    "titleBefore": "Build trips that already feel",
+    "titleHighlight": "ready to go",
+    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
+    "primaryCta": "Start planning",
+    "secondaryCta": "See example trips",
+    "proof": [
+      "AI itinerary drafts in seconds",
+      "Drag the route until it feels right",
+      "Share one clean link before the group chat gets chaotic"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "Generazione itinerario con IA",
-      "description": "Describe where you want to go and TravelFlow creates a full itinerary — optimized routes, curated activities, realistic timing — in under 30 seconds. Classic, Wizard, or Surprise Me modes adapt to how you like to plan."
+  "globe": {
+    "accessibility": "Anteprima interattiva del globo con rotte dal tuo punto di partenza verso idee di viaggio colorate in tutto il mondo.",
+    "fallbackTitle": "Versione alternativa del globo",
+    "fallbackDescription": "Anche senza il globo live, qui restano visibili le rotte, le card del viaggio e il tuo punto di partenza.",
+    "origin": {
+      "current": "Da {city}",
+      "countryFallback": "Da {country}",
+      "fallback": "Punto di partenza"
     },
-    "map": {
-      "title": "Mappa interattiva e timeline",
-      "description": "Your trip lives on a real map with animated route lines, city markers, and dynamic zoom. Below the map, a visual timeline shows every day at a glance. Switch between satellite, terrain, and minimalist styles."
-    },
-    "editing": {
-      "title": "Modifica drag-and-drop",
-      "description": "Reorder cities, stretch stay durations, and insert spontaneous stops — all by dragging on the timeline. Dates, connections, and the map update automatically so everything stays in sync."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "Weekend a Parigi",
+        "detail": "Cafe e musei fino a tardi."
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "Luna di miele Fiji",
+        "detail": "Spiagge, barche e ritmo lento."
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "Dive squalo bianco",
+        "detail": "Acqua fredda e adrenalina pura."
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "Route 66",
+        "detail": "Motel classici e finale sulla costa."
+      }
+    ],
+    "preview": {
+      "title": "SEA zaino 30 giorni",
+      "alt": "Anteprima di viaggio di 30 giorni nel Sud-est asiatico"
     }
+  },
+  "bento": {
+    "badge": "Plan with momentum",
+    "title": "The pieces of trip planning finally stay in one place",
+    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "AI route draft",
+        "title": "Start from a route, not a blank page",
+        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
+        "detail": "A first draft your group can react to immediately"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live map edits",
+        "title": "Refine the plan without breaking it",
+        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
+        "detail": "Map and timing stay in sync"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Forkable inspiration",
+        "title": "Borrow proven ideas and make them yours",
+        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
+        "detail": "Start from real travel energy"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew review",
+        "title": "Share something your travel crew can understand fast",
+        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
+        "detail": "No account required"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Booking and handoff",
+        "title": "Leave with a plan that still feels polished",
+        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
+        "detail": "Ready to share, save, or print"
+      }
+    ]
   },
   "workflow": {
-    "title": "Come funziona",
-    "subtitle": "From idea to itinerary in three steps.",
-    "step1Title": "Choose your destination",
-    "step1Description": "Pick countries, islands, or let Surprise Me suggest the perfect match for your travel window.",
-    "step2Title": "Generate with AI",
-    "step2Description": "Our model drafts a full route with city timing, activities, and logistics. Tweak the result in seconds.",
-    "step3Title": "Refine & share",
-    "step3Description": "Drag cities, adjust durations, add notes. Then share a link — your crew sees the live map and timeline."
-  },
-  "more": {
-    "title": "E molto altro",
-    "subtitle": "Every detail is designed to remove friction from trip planning."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "Condivisione con un clic",
-      "description": "Generate a link and send it to your travel crew. They see the full map, timeline, and activities — no account needed."
-    },
-    "community": {
-      "title": "Ispirazioni dalla community",
-      "description": "Browse curated trips from travelers worldwide. Fork any itinerary as a starting point and make it your own."
-    },
-    "booking": {
-      "title": "Link di prenotazione",
-      "description": "Every AI-suggested activity links to booking platforms — tours, restaurants, transport — so you can reserve without leaving TravelFlow."
-    },
-    "duration": {
-      "title": "Suggerimenti intelligenti sulla durata",
-      "description": "TravelFlow analyzes seasonal data and travel distances to suggest how long to spend in each city so you never feel rushed."
-    },
-    "mobile": {
-      "title": "Ottimizzato per mobile",
-      "description": "Plan on the go with a responsive layout tuned for phones and tablets. The map, timeline, and editing all adapt to smaller screens."
-    },
-    "print": {
-      "title": "Itinerari pronti da stampare",
-      "description": "Switch to print view for a clean, paper-friendly itinerary with day headers, activity lists, and essential logistics."
-    },
-    "routing": {
-      "title": "Routing multi-paese",
-      "description": "Select multiple countries or islands and TravelFlow builds a cross-border route with realistic transit between regions."
-    },
-    "history": {
-      "title": "Cronologia versioni",
-      "description": "Every meaningful change creates a snapshot. Jump back to any previous version of your trip with a single click."
-    },
-    "privacy": {
-      "title": "Privacy al primo posto",
-      "description": "Your trips stay local by default. Optional cloud sync is consent-gated, and analytics only run after explicit opt-in."
-    }
-  },
-  "comparison": {
-    "title": "Come si confronta TravelFlow",
-    "subtitle": "Side-by-side against spreadsheet planning and other trip tools.",
-    "featureHeader": "Feature",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "Spreadsheet",
-    "otherHeader": "Other Tools",
-    "yes": "Yes",
-    "partial": "Partial",
-    "manual": "Manual",
-    "freemium": "Freemium",
-    "rows": {
-      "ai": "AI-generated itinerary",
-      "interactiveMap": "Interactive map",
-      "dragDrop": "Drag-and-drop timeline",
-      "oneClickSharing": "One-click sharing",
-      "bookingLinks": "Booking links",
-      "offlineFirst": "Offline-first / local data",
-      "freeToUse": "Free to use"
+    "badge": "From spark to group-ready plan",
+    "title": "One flow for drafting, shaping, and sharing",
+    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Start with a destination, a vibe, or a copied route",
+        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+      },
+      {
+        "step": "02",
+        "title": "Shape the pacing with the map and timeline together",
+        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+      },
+      {
+        "step": "03",
+        "title": "Share a version that still looks intentional",
+        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+      }
+    ],
+    "glance": {
+      "eyebrow": "What your group sees",
+      "title": "A plan that already looks share-ready",
+      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "items": [
+        "Live route view with pacing context",
+        "Booking-ready activity links when you need them",
+        "A cleaner print layout for the final version"
+      ]
     }
   },
   "cta": {
-    "title": "Guardalo in azione",
-    "subtitle": "Create your first AI-powered itinerary in under a minute.",
-    "button": "Start Planning — Free"
+    "badge": "Build it while the idea is still fresh",
+    "title": "Start with the route. Keep the travel mood.",
+    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
+    "button": "Start planning"
   }
 }

--- a/locales/ko/features.json
+++ b/locales/ko/features.json
@@ -1,24 +1,24 @@
 {
   "hero": {
-    "badge": "Interactive trip planning",
-    "titleBefore": "Build trips that already feel",
-    "titleHighlight": "ready to go",
-    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
-    "primaryCta": "Start planning",
-    "secondaryCta": "See example trips",
+    "badge": "인터랙티브 여행 계획",
+    "titleBefore": "이미 떠날 준비가 된 듯한 여행을",
+    "titleHighlight": "만드세요",
+    "description": "TravelFlow는 목적지 아이디어를 그룹이 바로 반응할 수 있는 경로로 바꿔 줍니다. AI로 첫 일정을 만들고, 실시간 지도와 타임라인에서 다듬은 뒤, 실제 결정 단계에서도 완성도 있게 보이는 링크를 공유하세요.",
+    "primaryCta": "여행 계획 시작",
+    "secondaryCta": "예시 여행 보기",
     "proof": [
-      "AI itinerary drafts in seconds",
-      "Drag the route until it feels right",
-      "Share one clean link before the group chat gets chaotic"
+      "AI 일정 초안을 몇 초 만에",
+      "딱 맞을 때까지 경로 조정",
+      "단체 채팅이 복잡해지기 전 깔끔한 링크 하나"
     ]
   },
   "globe": {
-    "accessibility": "출발 지점에서 전 세계의 다채로운 여행 아이디어로 이어지는 경로를 보여주는 인터랙티브 글로브 미리보기입니다.",
-    "fallbackTitle": "글로브 대체 보기",
-    "fallbackDescription": "라이브 글로브가 없어도 여행 경로, 트립 카드, 출발 지점을 여기서 계속 볼 수 있습니다.",
+    "accessibility": "사용자 출발점에서 전 세계 여행 아이디어로 이어지는 경로를 보여 주는 인터랙티브 글로브 미리보기입니다.",
+    "fallbackTitle": "인터랙티브 글로브 대체 보기",
+    "fallbackDescription": "실시간 글로브가 없어도 경로, 여행 카드, 출발 지점을 계속 확인할 수 있습니다.",
     "origin": {
-      "current": "{city}에서 출발",
-      "countryFallback": "{country}에서 출발",
+      "current": "{city}에서",
+      "countryFallback": "{country}에서",
       "fallback": "출발 지점"
     },
     "cards": [
@@ -44,92 +44,92 @@
         "id": "route66",
         "emoji": "🛣️",
         "title": "루트66 드라이브",
-        "detail": "모텔과 함께 서해안으로 마무리."
+        "detail": "클래식 모텔과 서해안 피날레."
       }
     ],
     "preview": {
       "title": "30일 SEA 배낭",
-      "alt": "30일 동남아 배낭여행 미리보기"
+      "alt": "동남아시아 30일 배낭여행 미리보기"
     }
   },
   "bento": {
-    "badge": "Plan with momentum",
-    "title": "The pieces of trip planning finally stay in one place",
-    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "badge": "흐름 있게 계획하기",
+    "title": "여행 계획의 핵심이 드디어 한곳에 머뭅니다",
+    "subtitle": "문서, 지도, 스크린샷, 덜 끝난 채팅을 오가는 대신 TravelFlow는 경로, 페이스, 여행 맥락을 함께 묶어 둡니다.",
     "items": [
       {
         "id": "itinerary",
-        "eyebrow": "AI route draft",
-        "title": "Start from a route, not a blank page",
-        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
-        "detail": "A first draft your group can react to immediately"
+        "eyebrow": "AI 초안",
+        "title": "빈 페이지가 아니라 경로에서 시작하세요",
+        "description": "자연어로 여행을 설명하면 도시 흐름, 페이스, 맥락이 이미 연결된 믿을 만한 첫 일정이 만들어집니다.",
+        "detail": "그룹이 바로 반응할 수 있는 첫 초안"
       },
       {
         "id": "timeline",
-        "eyebrow": "Live map edits",
-        "title": "Refine the plan without breaking it",
-        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
-        "detail": "Map and timing stay in sync"
+        "eyebrow": "실시간 수정",
+        "title": "계획을 망치지 않고 다듬으세요",
+        "description": "체류를 늘리거나 도시 순서를 바꾸거나 페이스를 조정해도 됩니다. TravelFlow는 지도와 타임라인을 맞춰 두어 모든 수정이 여전히 자연스럽게 보이게 합니다.",
+        "detail": "지도와 일정 흐름이 계속 맞춰집니다"
       },
       {
         "id": "inspiration",
-        "eyebrow": "Forkable inspiration",
-        "title": "Borrow proven ideas and make them yours",
-        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
-        "detail": "Start from real travel energy"
+        "eyebrow": "재활용 가능한 영감",
+        "title": "검증된 아이디어를 가져와 내 여행으로 만드세요",
+        "description": "매번 처음부터 설득력 있는 여행을 다시 짜는 대신, 이미 좋은 에너지가 있는 루트를 출발점으로 쓰세요.",
+        "detail": "진짜 여행 감각에서 출발"
       },
       {
         "id": "sharing",
-        "eyebrow": "Crew review",
-        "title": "Share something your travel crew can understand fast",
-        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
-        "detail": "No account required"
+        "eyebrow": "그룹 리뷰",
+        "title": "그룹이 빠르게 이해할 수 있는 것을 공유하세요",
+        "description": "경로, 페이스, 노트가 이미 들어간 링크 하나만 보내면 피드백이 흩어진 스크린샷이 아니라 실제 여행 계획 위에서 이뤄집니다.",
+        "detail": "계정 없이도 가능"
       },
       {
         "id": "relive",
-        "eyebrow": "Booking and handoff",
-        "title": "Leave with a plan that still feels polished",
-        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
-        "detail": "Ready to share, save, or print"
+        "eyebrow": "예약과 마무리",
+        "title": "끝까지 완성도 있는 계획으로 남기세요",
+        "description": "경로가 준비된 뒤에도 실용적인 맥락은 그대로 남습니다. 링크, 메모, 그리고 최종 전달용으로 더 정돈된 버전까지 함께요.",
+        "detail": "공유·저장·출력 준비 완료"
       }
     ]
   },
   "workflow": {
-    "badge": "From spark to group-ready plan",
-    "title": "One flow for drafting, shaping, and sharing",
-    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "badge": "아이디어에서 그룹용 계획까지",
+    "title": "초안, 조정, 공유를 위한 하나의 흐름",
+    "subtitle": "TravelFlow는 여행의 설레는 부분과 실무적인 부분을 같은 곳에 두고 싶을 때 가장 잘 맞습니다.",
     "steps": [
       {
         "step": "01",
-        "title": "Start with a destination, a vibe, or a copied route",
-        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+        "title": "목적지, 무드, 복사한 루트로 시작하세요",
+        "description": "국가 목록, 계절 아이디어, 아직 흐릿한 여행 콘셉트에서 출발해도 됩니다. 완벽한 순서는 아직 몰라도 괜찮습니다."
       },
       {
         "step": "02",
-        "title": "Shape the pacing with the map and timeline together",
-        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+        "title": "지도와 타임라인을 함께 보며 페이스를 다듬으세요",
+        "description": "글로브에서 경로를 본 뒤, 이동과 에너지, 그룹 취향에 맞게 타임라인에서 현실감 있게 조정하세요."
       },
       {
         "step": "03",
-        "title": "Share a version that still looks intentional",
-        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+        "title": "이미 의도가 느껴지는 버전을 공유하세요",
+        "description": "피드백이나 예약이 필요한 순간이 오면 같은 계획 안에 지도, 구조, 추가 맥락이 이미 다 들어 있습니다."
       }
     ],
     "glance": {
-      "eyebrow": "What your group sees",
-      "title": "A plan that already looks share-ready",
-      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "eyebrow": "그룹이 보게 되는 것",
+      "title": "이미 공유할 준비가 된 것처럼 보이는 계획",
+      "description": "지도, 날짜별 흐름, 실용 정보가 함께 정렬되어 반응이 더 빠르고 덜 헷갈리게 들어옵니다.",
       "items": [
-        "Live route view with pacing context",
-        "Booking-ready activity links when you need them",
-        "A cleaner print layout for the final version"
+        "페이스 맥락이 있는 실시간 경로 보기",
+        "필요할 때 바로 쓰는 예약 링크",
+        "최종본을 위한 더 깔끔한 인쇄 레이아웃"
       ]
     }
   },
   "cta": {
-    "badge": "Build it while the idea is still fresh",
-    "title": "Start with the route. Keep the travel mood.",
-    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
-    "button": "Start planning"
+    "badge": "아이디어가 생생할 때 바로 시작하세요",
+    "title": "경로부터 시작하세요. 여행 무드는 그대로 두세요.",
+    "subtitle": "다음 여행을 몇 분 안에 초안으로 만들고, 다섯 개의 도구를 오가며 다시 짜지 말고 같은 곳에서 계속 다듬으세요.",
+    "button": "여행 계획 시작"
   }
 }

--- a/locales/ko/features.json
+++ b/locales/ko/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "제품 기능",
-    "title": "더 똑똑하게 계획하고, 더 멋지게 여행하세요",
-    "description": "TravelFlow는 AI 일정 생성, 시각적 편집, 실시간 공유를 하나의 공간에서 제공합니다. 다음 여행에 필요한 모든 기능을 확인하세요."
+    "badge": "Interactive trip planning",
+    "titleBefore": "Build trips that already feel",
+    "titleHighlight": "ready to go",
+    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
+    "primaryCta": "Start planning",
+    "secondaryCta": "See example trips",
+    "proof": [
+      "AI itinerary drafts in seconds",
+      "Drag the route until it feels right",
+      "Share one clean link before the group chat gets chaotic"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "AI 여행 생성",
-      "description": "가고 싶은 곳을 알려 주세요. TravelFlow가 최적화된 경로, 엄선된 활동, 현실적인 일정을 포함한 전체 일정을 30초 이내에 만들어 드립니다. 클래식, 위저드, 서프라이즈 모드 중 선택할 수 있습니다."
+  "globe": {
+    "accessibility": "출발 지점에서 전 세계의 다채로운 여행 아이디어로 이어지는 경로를 보여주는 인터랙티브 글로브 미리보기입니다.",
+    "fallbackTitle": "글로브 대체 보기",
+    "fallbackDescription": "라이브 글로브가 없어도 여행 경로, 트립 카드, 출발 지점을 여기서 계속 볼 수 있습니다.",
+    "origin": {
+      "current": "{city}에서 출발",
+      "countryFallback": "{country}에서 출발",
+      "fallback": "출발 지점"
     },
-    "map": {
-      "title": "인터랙티브 지도 & 타임라인",
-      "description": "여행이 실시간 지도 위에 표시됩니다. 애니메이션 경로, 도시 마커, 동적 줌 기능을 제공하며, 지도 아래에는 하루하루를 한눈에 볼 수 있는 시각적 타임라인이 펼쳐집니다."
-    },
-    "editing": {
-      "title": "드래그 앤 드롭 편집",
-      "description": "도시 순서 변경, 체류 기간 조정, 즉흥 정류지 추가까지 모두 타임라인에서 드래그로 처리하세요. 날짜, 연결, 지도가 자동으로 동기화됩니다."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "파리 주말",
+        "detail": "카페와 야간 박물관 코스."
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "피지 허니문",
+        "detail": "해변과 보트 이동이 있는 느린 일정."
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "백상아리 다이브",
+        "detail": "차가운 바다와 강한 아드레날린."
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "루트66 드라이브",
+        "detail": "모텔과 함께 서해안으로 마무리."
+      }
+    ],
+    "preview": {
+      "title": "30일 SEA 배낭",
+      "alt": "30일 동남아 배낭여행 미리보기"
     }
+  },
+  "bento": {
+    "badge": "Plan with momentum",
+    "title": "The pieces of trip planning finally stay in one place",
+    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "AI route draft",
+        "title": "Start from a route, not a blank page",
+        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
+        "detail": "A first draft your group can react to immediately"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live map edits",
+        "title": "Refine the plan without breaking it",
+        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
+        "detail": "Map and timing stay in sync"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Forkable inspiration",
+        "title": "Borrow proven ideas and make them yours",
+        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
+        "detail": "Start from real travel energy"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew review",
+        "title": "Share something your travel crew can understand fast",
+        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
+        "detail": "No account required"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Booking and handoff",
+        "title": "Leave with a plan that still feels polished",
+        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
+        "detail": "Ready to share, save, or print"
+      }
+    ]
   },
   "workflow": {
-    "title": "사용 방법",
-    "subtitle": "아이디어에서 일정까지 3단계면 충분합니다.",
-    "step1Title": "여행지 선택",
-    "step1Description": "국가, 섬을 고르거나 서프라이즈 기능으로 여행 기간에 맞는 최적의 목적지를 추천받으세요.",
-    "step2Title": "AI로 생성",
-    "step2Description": "AI가 도시 일정, 활동, 이동 계획이 포함된 전체 경로를 설계합니다. 몇 초 만에 수정할 수 있습니다.",
-    "step3Title": "수정 & 공유",
-    "step3Description": "도시를 드래그하고, 일정을 조정하고, 메모를 추가하세요. 링크를 공유하면 일행이 실시간으로 지도와 타임라인을 확인할 수 있습니다."
-  },
-  "more": {
-    "title": "이 밖에도 다양한 기능",
-    "subtitle": "여행 계획의 모든 불편함을 없애도록 세심하게 설계되었습니다."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "원클릭 공유",
-      "description": "링크를 만들어 일행에게 보내세요. 계정 없이도 지도, 타임라인, 활동 목록을 함께 볼 수 있습니다."
-    },
-    "community": {
-      "title": "커뮤니티 영감",
-      "description": "전 세계 여행자들이 만든 일정을 둘러보세요. 마음에 드는 일정을 복제해서 나만의 여행으로 꾸밀 수 있습니다."
-    },
-    "booking": {
-      "title": "예약 링크",
-      "description": "AI가 추천하는 모든 활동에 예약 플랫폼 링크가 연결되어 있어, TravelFlow를 벗어나지 않고 투어, 레스토랑, 교통편을 예약할 수 있습니다."
-    },
-    "duration": {
-      "title": "스마트 체류 기간 추천",
-      "description": "TravelFlow가 계절 데이터와 이동 거리를 분석하여 각 도시에서 적절한 체류 기간을 제안합니다."
-    },
-    "mobile": {
-      "title": "모바일 최적화",
-      "description": "스마트폰과 태블릿에 맞춘 반응형 레이아웃으로 이동 중에도 계획할 수 있습니다. 지도, 타임라인, 편집 기능 모두 작은 화면에 적응합니다."
-    },
-    "print": {
-      "title": "인쇄용 일정표",
-      "description": "인쇄 보기로 전환하면 일자별 헤더, 활동 목록, 핵심 물류 정보가 포함된 깔끔한 일정표를 만들 수 있습니다."
-    },
-    "routing": {
-      "title": "다국가 경로 설계",
-      "description": "여러 국가나 섬을 선택하면 TravelFlow가 지역 간 현실적인 이동을 포함한 국경 횡단 경로를 만들어 줍니다."
-    },
-    "history": {
-      "title": "버전 기록",
-      "description": "의미 있는 변경마다 스냅샷이 생성됩니다. 클릭 한 번으로 이전 버전의 여행으로 돌아갈 수 있습니다."
-    },
-    "privacy": {
-      "title": "프라이버시 우선",
-      "description": "여행 데이터는 기본적으로 로컬에 저장됩니다. 클라우드 동기화는 동의 후에만 활성화되고, 분석은 명시적 동의 후에만 실행됩니다."
-    }
-  },
-  "comparison": {
-    "title": "TravelFlow 비교",
-    "subtitle": "스프레드시트 및 다른 여행 도구와 나란히 비교해 보세요.",
-    "featureHeader": "기능",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "스프레드시트",
-    "otherHeader": "기타 도구",
-    "yes": "지원",
-    "partial": "부분 지원",
-    "manual": "수동",
-    "freemium": "부분 무료",
-    "rows": {
-      "ai": "AI 기반 일정 생성",
-      "interactiveMap": "인터랙티브 지도",
-      "dragDrop": "드래그 앤 드롭 타임라인",
-      "oneClickSharing": "원클릭 공유",
-      "bookingLinks": "예약 링크",
-      "offlineFirst": "오프라인 우선 / 로컬 데이터",
-      "freeToUse": "무료 이용"
+    "badge": "From spark to group-ready plan",
+    "title": "One flow for drafting, shaping, and sharing",
+    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Start with a destination, a vibe, or a copied route",
+        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+      },
+      {
+        "step": "02",
+        "title": "Shape the pacing with the map and timeline together",
+        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+      },
+      {
+        "step": "03",
+        "title": "Share a version that still looks intentional",
+        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+      }
+    ],
+    "glance": {
+      "eyebrow": "What your group sees",
+      "title": "A plan that already looks share-ready",
+      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "items": [
+        "Live route view with pacing context",
+        "Booking-ready activity links when you need them",
+        "A cleaner print layout for the final version"
+      ]
     }
   },
   "cta": {
-    "title": "직접 확인해 보세요",
-    "subtitle": "1분 이내에 AI 기반 일정을 만들어 보세요.",
-    "button": "무료로 시작하기"
+    "badge": "Build it while the idea is still fresh",
+    "title": "Start with the route. Keep the travel mood.",
+    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
+    "button": "Start planning"
   }
 }

--- a/locales/pl/features.json
+++ b/locales/pl/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "Możliwości produktu",
-    "title": "Planuj mądrzej, podróżuj lepiej",
-    "description": "TravelFlow łączy generowanie AI, wizualną edycję i współpracę w jednym miejscu. Oto wszystko, co platforma potrafi zrobić dla Twojej kolejnej podróży."
+    "badge": "Interactive trip planning",
+    "titleBefore": "Build trips that already feel",
+    "titleHighlight": "ready to go",
+    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
+    "primaryCta": "Start planning",
+    "secondaryCta": "See example trips",
+    "proof": [
+      "AI itinerary drafts in seconds",
+      "Drag the route until it feels right",
+      "Share one clean link before the group chat gets chaotic"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "Generowanie planu przez AI",
-      "description": "Opisz, dokąd chcesz jechać, a TravelFlow utworzy cały plan — zoptymalizowane trasy, dobrane atrakcje i realistyczny timing — w mniej niż 30 sekund. Tryby Classic, Wizard i Surprise Me dopasowują się do Twojego stylu planowania."
+  "globe": {
+    "accessibility": "Interaktywny glob pokazujący trasy z twojego punktu startowego do kolorowych pomysłów na podróże po całym świecie.",
+    "fallbackTitle": "Zapasowy widok globu",
+    "fallbackDescription": "Nawet bez aktywnego globu nadal widać tutaj trasy, karty podróży i twój punkt startowy.",
+    "origin": {
+      "current": "Z {city}",
+      "countryFallback": "Z {country}",
+      "fallback": "Punkt startowy"
     },
-    "map": {
-      "title": "Interaktywna mapa i oś czasu",
-      "description": "Twoja podróż żyje na prawdziwej mapie z animowanymi liniami tras, markerami miast i dynamicznym przybliżeniem. Pod mapą wizualna oś czasu pokazuje każdy dzień na pierwszy rzut oka. Przełączaj style: satelita, teren i minimal."
-    },
-    "editing": {
-      "title": "Edycja metodą przeciągnij i upuść",
-      "description": "Zmieniaj kolejność miast, wydłużaj pobyty i dodawaj spontaniczne przystanki — wszystko przez przeciąganie na osi czasu. Daty, połączenia i mapa aktualizują się automatycznie, więc wszystko pozostaje spójne."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "Weekend w Paryzu",
+        "detail": "Kawiarnie i muzea do pozna."
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "Miodowy na Fiji",
+        "detail": "Plaza, lodzie i wolne tempo."
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "Bialy rekin dive",
+        "detail": "Zimna woda i mocny dreszcz."
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "Route 66",
+        "detail": "Klasyczne motele i koniec nad oceanem."
+      }
+    ],
+    "preview": {
+      "title": "SEA 30 dni",
+      "alt": "Podglad 30-dniowej podrozy po Azji Poludniowo-Wschodniej"
     }
+  },
+  "bento": {
+    "badge": "Plan with momentum",
+    "title": "The pieces of trip planning finally stay in one place",
+    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "AI route draft",
+        "title": "Start from a route, not a blank page",
+        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
+        "detail": "A first draft your group can react to immediately"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live map edits",
+        "title": "Refine the plan without breaking it",
+        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
+        "detail": "Map and timing stay in sync"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Forkable inspiration",
+        "title": "Borrow proven ideas and make them yours",
+        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
+        "detail": "Start from real travel energy"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew review",
+        "title": "Share something your travel crew can understand fast",
+        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
+        "detail": "No account required"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Booking and handoff",
+        "title": "Leave with a plan that still feels polished",
+        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
+        "detail": "Ready to share, save, or print"
+      }
+    ]
   },
   "workflow": {
-    "title": "Jak to działa",
-    "subtitle": "Od pomysłu do planu podróży w trzech krokach.",
-    "step1Title": "Wybierz kierunek",
-    "step1Description": "Wskaż kraje, wyspy albo pozwól trybowi Surprise Me zaproponować idealne miejsce na Twój termin.",
-    "step2Title": "Wygeneruj z AI",
-    "step2Description": "Nasz model szkicuje pełną trasę z rozkładem miast, atrakcjami i logistyką. Efekt dopracujesz w kilka sekund.",
-    "step3Title": "Dopracuj i udostępnij",
-    "step3Description": "Przeciągaj miasta, zmieniaj czas pobytu, dodawaj notatki. Potem udostępnij link — Twoja ekipa zobaczy mapę i oś czasu na żywo."
-  },
-  "more": {
-    "title": "I znacznie więcej",
-    "subtitle": "Każdy detal zaprojektowano tak, by usunąć tarcie z planowania podróży."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "Udostępnianie jednym kliknięciem",
-      "description": "Wygeneruj link i wyślij go ekipie. Zobaczą pełną mapę, oś czasu i atrakcje — bez zakładania konta."
-    },
-    "community": {
-      "title": "Inspiracje społeczności",
-      "description": "Przeglądaj wyselekcjonowane podróże z całego świata. Skopiuj dowolny plan jako punkt startowy i dopasuj go do siebie."
-    },
-    "booking": {
-      "title": "Linki do rezerwacji",
-      "description": "Każda atrakcja sugerowana przez AI ma link do platform rezerwacyjnych — wycieczki, restauracje, transport — więc zarezerwujesz wszystko bez wychodzenia z TravelFlow."
-    },
-    "duration": {
-      "title": "Sprytne podpowiedzi czasu pobytu",
-      "description": "TravelFlow analizuje sezonowość i dystanse, by podpowiedzieć, ile czasu spędzić w każdym mieście, żeby podróż nie była zbyt napięta."
-    },
-    "mobile": {
-      "title": "Zoptymalizowane pod mobile",
-      "description": "Planuj w ruchu dzięki responsywnemu układowi dopracowanemu pod telefony i tablety. Mapa, oś czasu i edycja dopasowują się do mniejszych ekranów."
-    },
-    "print": {
-      "title": "Plany gotowe do druku",
-      "description": "Przełącz się na widok wydruku, by otrzymać czytelny plan podróży z nagłówkami dni, listą atrakcji i kluczową logistyką."
-    },
-    "routing": {
-      "title": "Trasy przez wiele krajów",
-      "description": "Wybierz kilka krajów lub wysp, a TravelFlow ułoży trasę między regionami z realistycznym czasem przejazdów."
-    },
-    "history": {
-      "title": "Historia wersji",
-      "description": "Każda istotna zmiana tworzy migawkę. Jednym kliknięciem wrócisz do wcześniejszej wersji podróży."
-    },
-    "privacy": {
-      "title": "Prywatność przede wszystkim",
-      "description": "Twoje podróże domyślnie zostają lokalnie. Opcjonalna synchronizacja w chmurze działa po zgodzie, a analityka uruchamia się dopiero po wyraźnym opt-in."
-    }
-  },
-  "comparison": {
-    "title": "Jak TravelFlow wypada na tle innych",
-    "subtitle": "Porównanie obok arkuszy kalkulacyjnych i innych narzędzi podróżniczych.",
-    "featureHeader": "Funkcja",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "Arkusz",
-    "otherHeader": "Inne narzędzia",
-    "yes": "Tak",
-    "partial": "Częściowo",
-    "manual": "Ręcznie",
-    "freemium": "Freemium",
-    "rows": {
-      "ai": "Plan wygenerowany przez AI",
-      "interactiveMap": "Interaktywna mapa",
-      "dragDrop": "Oś czasu drag-and-drop",
-      "oneClickSharing": "Udostępnianie jednym kliknięciem",
-      "bookingLinks": "Linki do rezerwacji",
-      "offlineFirst": "Offline-first / dane lokalne",
-      "freeToUse": "Darmowe w użyciu"
+    "badge": "From spark to group-ready plan",
+    "title": "One flow for drafting, shaping, and sharing",
+    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Start with a destination, a vibe, or a copied route",
+        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+      },
+      {
+        "step": "02",
+        "title": "Shape the pacing with the map and timeline together",
+        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+      },
+      {
+        "step": "03",
+        "title": "Share a version that still looks intentional",
+        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+      }
+    ],
+    "glance": {
+      "eyebrow": "What your group sees",
+      "title": "A plan that already looks share-ready",
+      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "items": [
+        "Live route view with pacing context",
+        "Booking-ready activity links when you need them",
+        "A cleaner print layout for the final version"
+      ]
     }
   },
   "cta": {
-    "title": "Zobacz to w praktyce",
-    "subtitle": "Utwórz swój pierwszy plan podróży z AI w mniej niż minutę.",
-    "button": "Zacznij planować — za darmo"
+    "badge": "Build it while the idea is still fresh",
+    "title": "Start with the route. Keep the travel mood.",
+    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
+    "button": "Start planning"
   }
 }

--- a/locales/pl/features.json
+++ b/locales/pl/features.json
@@ -1,21 +1,21 @@
 {
   "hero": {
-    "badge": "Interactive trip planning",
-    "titleBefore": "Build trips that already feel",
-    "titleHighlight": "ready to go",
-    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
-    "primaryCta": "Start planning",
-    "secondaryCta": "See example trips",
+    "badge": "Interaktywne planowanie podróży",
+    "titleBefore": "Planuj podróże, które już",
+    "titleHighlight": "wydają się gotowe",
+    "description": "TravelFlow zamienia pomysły na kierunki w trasę, na którą Twoja grupa naprawdę może zareagować. Zrób pierwszy szkic z AI, dopracuj go na żywej mapie i osi czasu, a potem udostępnij link, który nadal wygląda spójnie, gdy decyzje stają się konkretne.",
+    "primaryCta": "Zacznij planować",
+    "secondaryCta": "Zobacz przykładowe wyjazdy",
     "proof": [
-      "AI itinerary drafts in seconds",
-      "Drag the route until it feels right",
-      "Share one clean link before the group chat gets chaotic"
+      "Szkice itinerarium AI w kilka sekund",
+      "Dopracuj trasę, aż będzie pasować",
+      "Jeden czytelny link zanim czat zrobi się chaotyczny"
     ]
   },
   "globe": {
-    "accessibility": "Interaktywny glob pokazujący trasy z twojego punktu startowego do kolorowych pomysłów na podróże po całym świecie.",
+    "accessibility": "Interaktywna kula ziemska z trasami od Twojego punktu startowego do pomysłów na podróż po całym świecie.",
     "fallbackTitle": "Zapasowy widok globu",
-    "fallbackDescription": "Nawet bez aktywnego globu nadal widać tutaj trasy, karty podróży i twój punkt startowy.",
+    "fallbackDescription": "Nawet bez żywego globu nadal zobaczysz trasy, karty podróży i punkt startowy.",
     "origin": {
       "current": "Z {city}",
       "countryFallback": "Z {country}",
@@ -25,111 +25,111 @@
       {
         "id": "paris",
         "emoji": "🗼",
-        "title": "Weekend w Paryzu",
-        "detail": "Kawiarnie i muzea do pozna."
+        "title": "Weekend w Paryżu",
+        "detail": "Kawiarnie i muzea do późna."
       },
       {
         "id": "fiji",
         "emoji": "🌴",
-        "title": "Miodowy na Fiji",
-        "detail": "Plaza, lodzie i wolne tempo."
+        "title": "Miesiąc miodowy Fiji",
+        "detail": "Plaże, łódki i spokojne tempo."
       },
       {
         "id": "south-africa",
         "emoji": "🦈",
-        "title": "Bialy rekin dive",
-        "detail": "Zimna woda i mocny dreszcz."
+        "title": "Nurkowanie z białym rekinem",
+        "detail": "Zimna woda i czysta adrenalina."
       },
       {
         "id": "route66",
         "emoji": "🛣️",
         "title": "Route 66",
-        "detail": "Klasyczne motele i koniec nad oceanem."
+        "detail": "Klasyczne motele i finał nad oceanem."
       }
     ],
     "preview": {
       "title": "SEA 30 dni",
-      "alt": "Podglad 30-dniowej podrozy po Azji Poludniowo-Wschodniej"
+      "alt": "Podgląd 30-dniowej podróży backpackerskiej po Azji Południowo-Wschodniej"
     }
   },
   "bento": {
-    "badge": "Plan with momentum",
-    "title": "The pieces of trip planning finally stay in one place",
-    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "badge": "Planuj z rozpędem",
+    "title": "Elementy wyjazdu wreszcie zostają w jednym miejscu",
+    "subtitle": "Zamiast skakać między dokumentami, mapami, screenami i niedokończonymi rozmowami, TravelFlow trzyma trasę, tempo i kontekst razem.",
     "items": [
       {
         "id": "itinerary",
-        "eyebrow": "AI route draft",
-        "title": "Start from a route, not a blank page",
-        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
-        "detail": "A first draft your group can react to immediately"
+        "eyebrow": "Szkic AI",
+        "title": "Zacznij od trasy, nie od pustej strony",
+        "description": "Opisz podróż zwykłym językiem i od razu otrzymaj wiarygodny pierwszy plan z połączonym rytmem, miastami i kontekstem.",
+        "detail": "Pierwszy szkic, na który grupa może od razu zareagować"
       },
       {
         "id": "timeline",
-        "eyebrow": "Live map edits",
-        "title": "Refine the plan without breaking it",
-        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
-        "detail": "Map and timing stay in sync"
+        "eyebrow": "Edycje na żywo",
+        "title": "Dopracuj plan bez jego psucia",
+        "description": "Wydłuż pobyt, przestaw miasto albo zmień tempo. TravelFlow utrzymuje mapę i oś czasu w synchronizacji, więc każda zmiana nadal ma sens.",
+        "detail": "Mapa i timing pozostają zsynchronizowane"
       },
       {
         "id": "inspiration",
-        "eyebrow": "Forkable inspiration",
-        "title": "Borrow proven ideas and make them yours",
-        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
-        "detail": "Start from real travel energy"
+        "eyebrow": "Inspiracja do rozwinięcia",
+        "title": "Bierz sprawdzone pomysły i rób je po swojemu",
+        "description": "Użyj już wiarygodnych tras jako punktu wyjścia zamiast za każdym razem składać sensowny wyjazd od zera.",
+        "detail": "Zacznij od prawdziwej energii podróży"
       },
       {
         "id": "sharing",
-        "eyebrow": "Crew review",
-        "title": "Share something your travel crew can understand fast",
-        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
-        "detail": "No account required"
+        "eyebrow": "Przegląd grupy",
+        "title": "Udostępnij coś, co grupa szybko zrozumie",
+        "description": "Wyślij jeden link z trasą, tempem i notatkami na miejscu, żeby feedback dotyczył prawdziwego wyjazdu, a nie porozrzucanych screenów.",
+        "detail": "Bez obowiązkowego konta"
       },
       {
         "id": "relive",
-        "eyebrow": "Booking and handoff",
-        "title": "Leave with a plan that still feels polished",
-        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
-        "detail": "Ready to share, save, or print"
+        "eyebrow": "Rezerwacja i finalizacja",
+        "title": "Domknij planem, który nadal wygląda dopracowanie",
+        "description": "Gdy trasa jest gotowa, praktyczny kontekst wciąż tam jest: linki, notatki i czystsza wersja do finalnego przekazania.",
+        "detail": "Gotowe do udostępnienia, zapisania lub wydruku"
       }
     ]
   },
   "workflow": {
-    "badge": "From spark to group-ready plan",
-    "title": "One flow for drafting, shaping, and sharing",
-    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "badge": "Od iskry do planu gotowego dla grupy",
+    "title": "Jeden przepływ do szkicu, dopracowania i udostępnienia",
+    "subtitle": "TravelFlow działa najlepiej, gdy chcesz trzymać ekscytującą i praktyczną stronę planowania w tym samym miejscu.",
     "steps": [
       {
         "step": "01",
-        "title": "Start with a destination, a vibe, or a copied route",
-        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+        "title": "Zacznij od kierunku, klimatu albo skopiowanej trasy",
+        "description": "Startuj od listy krajów, sezonowego pomysłu albo jeszcze nieostrej koncepcji. Nie musisz jeszcze znać idealnej kolejności."
       },
       {
         "step": "02",
-        "title": "Shape the pacing with the map and timeline together",
-        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+        "title": "Dopnij tempo na mapie i osi czasu razem",
+        "description": "Zobacz trasę na globie, a potem dopracuj ją na osi czasu, aż będzie realistyczna dla transferów, energii i preferencji grupy."
       },
       {
         "step": "03",
-        "title": "Share a version that still looks intentional",
-        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+        "title": "Udostępnij wersję, która już wygląda świadomie",
+        "description": "Kiedy przychodzi moment na feedback albo rezerwacje, ten sam plan ma już mapę, strukturę i dodatkowy kontekst, o który ludzie zwykle pytają."
       }
     ],
     "glance": {
-      "eyebrow": "What your group sees",
-      "title": "A plan that already looks share-ready",
-      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "eyebrow": "Co widzi Twoja grupa",
+      "title": "Plan, który już wygląda jak gotowy do wysłania",
+      "description": "Mapa, rytm dzień po dniu i praktyczny kontekst pozostają zgrane, więc reakcje przychodzą szybciej i z mniejszym zamieszaniem.",
       "items": [
-        "Live route view with pacing context",
-        "Booking-ready activity links when you need them",
-        "A cleaner print layout for the final version"
+        "Widok trasy na żywo z kontekstem tempa",
+        "Linki gotowe do rezerwacji, gdy ich potrzebujesz",
+        "Czystszy układ do druku dla finalnej wersji"
       ]
     }
   },
   "cta": {
-    "badge": "Build it while the idea is still fresh",
-    "title": "Start with the route. Keep the travel mood.",
-    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
-    "button": "Start planning"
+    "badge": "Zbuduj to, póki pomysł jest świeży",
+    "title": "Zacznij od trasy. Zachowaj klimat podróży.",
+    "subtitle": "Naszkicuj następną podróż w kilka minut i dalej dopracowuj ją w tym samym miejscu zamiast składać ją od nowa w pięciu narzędziach.",
+    "button": "Zacznij planować"
   }
 }

--- a/locales/pt/features.json
+++ b/locales/pt/features.json
@@ -1,24 +1,24 @@
 {
   "hero": {
-    "badge": "Interactive trip planning",
-    "titleBefore": "Build trips that already feel",
-    "titleHighlight": "ready to go",
-    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
-    "primaryCta": "Start planning",
-    "secondaryCta": "See example trips",
+    "badge": "Planeamento de viagem interativo",
+    "titleBefore": "Crie viagens que já parecem",
+    "titleHighlight": "prontas a partir",
+    "description": "O TravelFlow transforma ideias de destino numa rota à qual o seu grupo consegue realmente reagir. Faça o primeiro rascunho com IA, ajuste-o num mapa e numa timeline em direto e partilhe um link que continua polido quando chega a hora de decidir.",
+    "primaryCta": "Começar a planear",
+    "secondaryCta": "Ver viagens exemplo",
     "proof": [
-      "AI itinerary drafts in seconds",
-      "Drag the route until it feels right",
-      "Share one clean link before the group chat gets chaotic"
+      "Rascunhos de itinerário com IA em segundos",
+      "Ajuste a rota até parecer certa",
+      "Um link claro antes de o chat ficar caótico"
     ]
   },
   "globe": {
-    "accessibility": "Prévia interativa do globo mostrando rotas do seu ponto de partida para ideias de viagem coloridas pelo mundo.",
-    "fallbackTitle": "Versão alternativa do globo",
-    "fallbackDescription": "Mesmo sem o globo ao vivo, as rotas, os cartões de viagem e o seu ponto de partida continuam visíveis.",
+    "accessibility": "Pré-visualização interativa do globo com rotas desde o seu ponto de partida até ideias de viagem pelo mundo.",
+    "fallbackTitle": "Fallback do globo interativo",
+    "fallbackDescription": "Mesmo sem o globo em direto, continua a poder ver as rotas, os cartões de viagem e o seu ponto de partida.",
     "origin": {
-      "current": "Saindo de {city}",
-      "countryFallback": "Saindo de {country}",
+      "current": "A partir de {city}",
+      "countryFallback": "A partir de {country}",
       "fallback": "Ponto de partida"
     },
     "cards": [
@@ -26,110 +26,110 @@
         "id": "paris",
         "emoji": "🗼",
         "title": "Paris fim de semana",
-        "detail": "Cafe e museus ate tarde."
+        "detail": "Cafés e museus até tarde."
       },
       {
         "id": "fiji",
         "emoji": "🌴",
         "title": "Lua de mel Fiji",
-        "detail": "Praia, barcos e ritmo calmo."
+        "detail": "Praias, barcos e ritmo calmo."
       },
       {
         "id": "south-africa",
         "emoji": "🦈",
-        "title": "Mergulho tubarao branco",
-        "detail": "Agua fria e adrenalina total."
+        "title": "Mergulho tubarão branco",
+        "detail": "Água fria e adrenalina total."
       },
       {
         "id": "route66",
         "emoji": "🛣️",
         "title": "Route 66",
-        "detail": "Moteis classicos e fim na costa."
+        "detail": "Motéis clássicos e final na costa."
       }
     ],
     "preview": {
-      "title": "Mochilao SEA 30 dias",
-      "alt": "Previa de viagem de 30 dias pelo Sudeste Asiatico"
+      "title": "Mochilão SEA 30 dias",
+      "alt": "Pré-visualização de uma viagem de mochila de 30 dias pelo Sudeste Asiático"
     }
   },
   "bento": {
-    "badge": "Plan with momentum",
-    "title": "The pieces of trip planning finally stay in one place",
-    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "badge": "Planeie com ritmo",
+    "title": "As peças da viagem finalmente ficam no mesmo sítio",
+    "subtitle": "Em vez de saltar entre docs, mapas, capturas e conversas a meio, o TravelFlow mantém a rota, o ritmo e o contexto juntos.",
     "items": [
       {
         "id": "itinerary",
-        "eyebrow": "AI route draft",
-        "title": "Start from a route, not a blank page",
-        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
-        "detail": "A first draft your group can react to immediately"
+        "eyebrow": "Rascunho com IA",
+        "title": "Comece por uma rota, não por uma página em branco",
+        "description": "Descreva a viagem em linguagem natural e receba um primeiro itinerário credível com fluxo entre cidades, ritmo e contexto já ligados.",
+        "detail": "Um primeiro rascunho ao qual o grupo pode reagir de imediato"
       },
       {
         "id": "timeline",
-        "eyebrow": "Live map edits",
-        "title": "Refine the plan without breaking it",
-        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
-        "detail": "Map and timing stay in sync"
+        "eyebrow": "Edições em direto",
+        "title": "Ajuste o plano sem o partir",
+        "description": "Alongue uma estadia, troque a ordem de uma cidade ou mude o ritmo. O TravelFlow mantém mapa e timeline alinhados para que cada edição continue coerente.",
+        "detail": "Mapa e tempos continuam sincronizados"
       },
       {
         "id": "inspiration",
-        "eyebrow": "Forkable inspiration",
-        "title": "Borrow proven ideas and make them yours",
-        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
-        "detail": "Start from real travel energy"
+        "eyebrow": "Inspiração reaproveitável",
+        "title": "Pegue em boas ideias e torne-as suas",
+        "description": "Use rotas já convincentes como ponto de partida em vez de reconstruir uma viagem credível do zero sempre que começa.",
+        "detail": "Comece com energia de viagem real"
       },
       {
         "id": "sharing",
-        "eyebrow": "Crew review",
-        "title": "Share something your travel crew can understand fast",
-        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
-        "detail": "No account required"
+        "eyebrow": "Revisão do grupo",
+        "title": "Partilhe algo que o grupo entende depressa",
+        "description": "Envie um único link com rota, ritmo e notas já no lugar para que o feedback aconteça sobre a viagem real e não sobre capturas espalhadas.",
+        "detail": "Sem conta obrigatória"
       },
       {
         "id": "relive",
-        "eyebrow": "Booking and handoff",
-        "title": "Leave with a plan that still feels polished",
-        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
-        "detail": "Ready to share, save, or print"
+        "eyebrow": "Reserva e entrega",
+        "title": "Acabe com um plano que continua polido",
+        "description": "Quando a rota está pronta, o contexto prático continua lá: links, notas e uma versão mais limpa para a entrega final.",
+        "detail": "Pronto para partilhar, guardar ou imprimir"
       }
     ]
   },
   "workflow": {
-    "badge": "From spark to group-ready plan",
-    "title": "One flow for drafting, shaping, and sharing",
-    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "badge": "Da faísca a um plano pronto para o grupo",
+    "title": "Um só fluxo para criar, ajustar e partilhar",
+    "subtitle": "O TravelFlow funciona melhor quando quer manter a parte emocionante e a parte prática do planeamento no mesmo lugar.",
     "steps": [
       {
         "step": "01",
-        "title": "Start with a destination, a vibe, or a copied route",
-        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+        "title": "Comece com um destino, um mood ou uma rota copiada",
+        "description": "Parta de uma lista de países, de uma ideia sazonal ou de um conceito ainda difuso. Ainda não precisa de saber a sequência perfeita."
       },
       {
         "step": "02",
-        "title": "Shape the pacing with the map and timeline together",
-        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+        "title": "Acerte o ritmo com mapa e timeline juntos",
+        "description": "Veja a rota no globo e depois aperte-a na timeline até parecer realista para transferes, energia e preferências do grupo."
       },
       {
         "step": "03",
-        "title": "Share a version that still looks intentional",
-        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+        "title": "Partilhe uma versão que já parece intencional",
+        "description": "Quando chega a hora de pedir feedback ou reservar, o mesmo plano já inclui mapa, estrutura e o contexto extra que as pessoas costumam pedir."
       }
     ],
     "glance": {
-      "eyebrow": "What your group sees",
-      "title": "A plan that already looks share-ready",
-      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "eyebrow": "O que o grupo vê",
+      "title": "Um plano que já parece pronto a partilhar",
+      "description": "Mapa, ritmo dia a dia e contexto prático mantêm-se alinhados para que as reações cheguem mais depressa e com menos confusão.",
       "items": [
-        "Live route view with pacing context",
-        "Booking-ready activity links when you need them",
-        "A cleaner print layout for the final version"
+        "Vista de rota em direto com contexto de ritmo",
+        "Links prontos para reservar quando precisa",
+        "Uma versão de impressão mais limpa para o plano final"
       ]
     }
   },
   "cta": {
-    "badge": "Build it while the idea is still fresh",
-    "title": "Start with the route. Keep the travel mood.",
-    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
-    "button": "Start planning"
+    "badge": "Construa enquanto a ideia ainda está fresca",
+    "title": "Comece pela rota. Guarde o mood da viagem.",
+    "subtitle": "Esboce a sua próxima viagem em minutos e continue a refiná-la no mesmo lugar em vez de a reconstruir em cinco ferramentas.",
+    "button": "Começar a planear"
   }
 }

--- a/locales/pt/features.json
+++ b/locales/pt/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "Capacidades do produto",
-    "title": "Planeie melhor, viaje melhor",
-    "description": "O TravelFlow combina geração com IA, edição visual e colaboração num único espaço. Aqui está tudo o que a plataforma pode fazer pela sua próxima viagem."
+    "badge": "Interactive trip planning",
+    "titleBefore": "Build trips that already feel",
+    "titleHighlight": "ready to go",
+    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
+    "primaryCta": "Start planning",
+    "secondaryCta": "See example trips",
+    "proof": [
+      "AI itinerary drafts in seconds",
+      "Drag the route until it feels right",
+      "Share one clean link before the group chat gets chaotic"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "Geração de viagens com IA",
-      "description": "Descreva para onde quer ir e o TravelFlow cria um itinerário completo com rotas otimizadas, atividades selecionadas e tempos realistas em menos de 30 segundos. Os modos Clássico, Assistente e Surpreenda-me adaptam-se ao seu estilo de planeamento."
+  "globe": {
+    "accessibility": "Prévia interativa do globo mostrando rotas do seu ponto de partida para ideias de viagem coloridas pelo mundo.",
+    "fallbackTitle": "Versão alternativa do globo",
+    "fallbackDescription": "Mesmo sem o globo ao vivo, as rotas, os cartões de viagem e o seu ponto de partida continuam visíveis.",
+    "origin": {
+      "current": "Saindo de {city}",
+      "countryFallback": "Saindo de {country}",
+      "fallback": "Ponto de partida"
     },
-    "map": {
-      "title": "Mapa interativo e timeline",
-      "description": "A sua viagem vive num mapa real com linhas de rota animadas, marcadores de cidade e zoom dinâmico. Abaixo, uma timeline visual mostra cada dia de relance. Alterne entre estilos satélite, terreno e minimalista."
-    },
-    "editing": {
-      "title": "Edição com arrastar e largar",
-      "description": "Reordene cidades, ajuste durações e adicione paragens espontâneas arrastando na timeline. Datas, ligações e mapa atualizam automaticamente para manter tudo sincronizado."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "Paris fim de semana",
+        "detail": "Cafe e museus ate tarde."
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "Lua de mel Fiji",
+        "detail": "Praia, barcos e ritmo calmo."
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "Mergulho tubarao branco",
+        "detail": "Agua fria e adrenalina total."
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "Route 66",
+        "detail": "Moteis classicos e fim na costa."
+      }
+    ],
+    "preview": {
+      "title": "Mochilao SEA 30 dias",
+      "alt": "Previa de viagem de 30 dias pelo Sudeste Asiatico"
     }
+  },
+  "bento": {
+    "badge": "Plan with momentum",
+    "title": "The pieces of trip planning finally stay in one place",
+    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "AI route draft",
+        "title": "Start from a route, not a blank page",
+        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
+        "detail": "A first draft your group can react to immediately"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live map edits",
+        "title": "Refine the plan without breaking it",
+        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
+        "detail": "Map and timing stay in sync"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Forkable inspiration",
+        "title": "Borrow proven ideas and make them yours",
+        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
+        "detail": "Start from real travel energy"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew review",
+        "title": "Share something your travel crew can understand fast",
+        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
+        "detail": "No account required"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Booking and handoff",
+        "title": "Leave with a plan that still feels polished",
+        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
+        "detail": "Ready to share, save, or print"
+      }
+    ]
   },
   "workflow": {
-    "title": "Como funciona",
-    "subtitle": "Da ideia ao itinerário em três passos.",
-    "step1Title": "Escolha o destino",
-    "step1Description": "Selecione países, ilhas ou deixe o modo Surpreenda-me sugerir a melhor opção para o seu período de viagem.",
-    "step2Title": "Gerar com IA",
-    "step2Description": "O nosso modelo cria uma rota completa com tempos por cidade, atividades e logística. Ajuste o resultado em segundos.",
-    "step3Title": "Refinar e partilhar",
-    "step3Description": "Arraste cidades, ajuste durações e adicione notas. Depois partilhe um link para que o seu grupo veja o mapa e a timeline em direto."
-  },
-  "more": {
-    "title": "E muito mais",
-    "subtitle": "Cada detalhe foi desenhado para remover fricção no planeamento de viagens."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "Partilha com um clique",
-      "description": "Gere um link e envie-o ao seu grupo. Eles veem mapa, timeline e atividades sem necessidade de conta."
-    },
-    "community": {
-      "title": "Inspiração da comunidade",
-      "description": "Explore viagens selecionadas de viajantes de todo o mundo. Duplique qualquer itinerário e adapte-o ao seu estilo."
-    },
-    "booking": {
-      "title": "Links de reserva",
-      "description": "Cada atividade sugerida pela IA liga a plataformas de reserva de tours, restaurantes e transportes para reservar sem sair do TravelFlow."
-    },
-    "duration": {
-      "title": "Sugestões inteligentes de duração",
-      "description": "O TravelFlow analisa dados sazonais e distâncias para sugerir quanto tempo passar em cada cidade, sem correria."
-    },
-    "mobile": {
-      "title": "Otimizado para móvel",
-      "description": "Planeie em movimento com um layout responsivo para telemóveis e tablets. Mapa, timeline e edição adaptam-se a ecrãs menores."
-    },
-    "print": {
-      "title": "Itinerários prontos para impressão",
-      "description": "Mude para vista de impressão para obter um itinerário limpo, com dias, atividades e logística essencial em papel."
-    },
-    "routing": {
-      "title": "Rotas entre vários países",
-      "description": "Selecione vários países ou ilhas e o TravelFlow cria uma rota transfronteiriça com deslocações realistas entre regiões."
-    },
-    "history": {
-      "title": "Histórico de versões",
-      "description": "Cada alteração importante cria um snapshot. Volte a qualquer versão anterior da sua viagem com um clique."
-    },
-    "privacy": {
-      "title": "Privacidade em primeiro lugar",
-      "description": "As suas viagens ficam locais por defeito. A sincronização na cloud é opcional e depende de consentimento, e a analítica só é ativada com aceitação explícita."
-    }
-  },
-  "comparison": {
-    "title": "Como o TravelFlow se compara",
-    "subtitle": "Comparação lado a lado com folhas de cálculo e outras ferramentas de viagem.",
-    "featureHeader": "Funcionalidade",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "Folha de cálculo",
-    "otherHeader": "Outras ferramentas",
-    "yes": "Sim",
-    "partial": "Parcial",
-    "manual": "Manual",
-    "freemium": "Freemium",
-    "rows": {
-      "ai": "Itinerário gerado por IA",
-      "interactiveMap": "Mapa interativo",
-      "dragDrop": "Timeline com arrastar e largar",
-      "oneClickSharing": "Partilha com um clique",
-      "bookingLinks": "Links de reserva",
-      "offlineFirst": "Dados locais / prioridade offline",
-      "freeToUse": "Gratuito"
+    "badge": "From spark to group-ready plan",
+    "title": "One flow for drafting, shaping, and sharing",
+    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Start with a destination, a vibe, or a copied route",
+        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+      },
+      {
+        "step": "02",
+        "title": "Shape the pacing with the map and timeline together",
+        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+      },
+      {
+        "step": "03",
+        "title": "Share a version that still looks intentional",
+        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+      }
+    ],
+    "glance": {
+      "eyebrow": "What your group sees",
+      "title": "A plan that already looks share-ready",
+      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "items": [
+        "Live route view with pacing context",
+        "Booking-ready activity links when you need them",
+        "A cleaner print layout for the final version"
+      ]
     }
   },
   "cta": {
-    "title": "Veja em ação",
-    "subtitle": "Crie o seu primeiro itinerário com IA em menos de um minuto.",
-    "button": "Começar a planear — Grátis"
+    "badge": "Build it while the idea is still fresh",
+    "title": "Start with the route. Keep the travel mood.",
+    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
+    "button": "Start planning"
   }
 }

--- a/locales/ru/features.json
+++ b/locales/ru/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "Возможности продукта",
-    "title": "Планируйте умнее, путешествуйте лучше",
-    "description": "TravelFlow combines AI generation, visual editing, and collaboration into one workspace. Here is everything the platform can do for your next trip."
+    "badge": "Interactive trip planning",
+    "titleBefore": "Build trips that already feel",
+    "titleHighlight": "ready to go",
+    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
+    "primaryCta": "Start planning",
+    "secondaryCta": "See example trips",
+    "proof": [
+      "AI itinerary drafts in seconds",
+      "Drag the route until it feels right",
+      "Share one clean link before the group chat gets chaotic"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "Создание маршрута с ИИ",
-      "description": "Describe where you want to go and TravelFlow creates a full itinerary — optimized routes, curated activities, realistic timing — in under 30 seconds. Classic, Wizard, or Surprise Me modes adapt to how you like to plan."
+  "globe": {
+    "accessibility": "Интерактивный глобус с маршрутами от вашей стартовой точки к ярким идеям поездок по всему миру.",
+    "fallbackTitle": "Резервный вариант глобуса",
+    "fallbackDescription": "Даже без живого глобуса здесь остаются видны маршруты, карточки поездок и ваша стартовая точка.",
+    "origin": {
+      "current": "Из {city}",
+      "countryFallback": "Из {country}",
+      "fallback": "Точка старта"
     },
-    "map": {
-      "title": "Интерактивная карта и таймлайн",
-      "description": "Your trip lives on a real map with animated route lines, city markers, and dynamic zoom. Below the map, a visual timeline shows every day at a glance. Switch between satellite, terrain, and minimalist styles."
-    },
-    "editing": {
-      "title": "Редактирование drag-and-drop",
-      "description": "Reorder cities, stretch stay durations, and insert spontaneous stops — all by dragging on the timeline. Dates, connections, and the map update automatically so everything stays in sync."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "Uikend v Parizhe",
+        "detail": "Kafe i muzei dopozdna."
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "Medovyy mesyats Fiji",
+        "detail": "Plyazh, lodki i medlennyy temp."
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "Dayv s beloy akuloy",
+        "detail": "Kholodnaya voda i silnyy adrenalina."
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "Route 66",
+        "detail": "Klassicheskie moteli i finisher u okeana."
+      }
+    ],
+    "preview": {
+      "title": "30 dney SEA",
+      "alt": "Predprosmotr 30-dnevnogo puteshestviya po Yugo-Vostochnoy Azii"
     }
+  },
+  "bento": {
+    "badge": "Plan with momentum",
+    "title": "The pieces of trip planning finally stay in one place",
+    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "AI route draft",
+        "title": "Start from a route, not a blank page",
+        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
+        "detail": "A first draft your group can react to immediately"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live map edits",
+        "title": "Refine the plan without breaking it",
+        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
+        "detail": "Map and timing stay in sync"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Forkable inspiration",
+        "title": "Borrow proven ideas and make them yours",
+        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
+        "detail": "Start from real travel energy"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew review",
+        "title": "Share something your travel crew can understand fast",
+        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
+        "detail": "No account required"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Booking and handoff",
+        "title": "Leave with a plan that still feels polished",
+        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
+        "detail": "Ready to share, save, or print"
+      }
+    ]
   },
   "workflow": {
-    "title": "Как это работает",
-    "subtitle": "From idea to itinerary in three steps.",
-    "step1Title": "Choose your destination",
-    "step1Description": "Pick countries, islands, or let Surprise Me suggest the perfect match for your travel window.",
-    "step2Title": "Generate with AI",
-    "step2Description": "Our model drafts a full route with city timing, activities, and logistics. Tweak the result in seconds.",
-    "step3Title": "Refine & share",
-    "step3Description": "Drag cities, adjust durations, add notes. Then share a link — your crew sees the live map and timeline."
-  },
-  "more": {
-    "title": "И это еще не все",
-    "subtitle": "Every detail is designed to remove friction from trip planning."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "Поделиться в один клик",
-      "description": "Generate a link and send it to your travel crew. They see the full map, timeline, and activities — no account needed."
-    },
-    "community": {
-      "title": "Идеи от сообщества",
-      "description": "Browse curated trips from travelers worldwide. Fork any itinerary as a starting point and make it your own."
-    },
-    "booking": {
-      "title": "Ссылки на бронирование",
-      "description": "Every AI-suggested activity links to booking platforms — tours, restaurants, transport — so you can reserve without leaving TravelFlow."
-    },
-    "duration": {
-      "title": "Умные подсказки по длительности",
-      "description": "TravelFlow analyzes seasonal data and travel distances to suggest how long to spend in each city so you never feel rushed."
-    },
-    "mobile": {
-      "title": "Оптимизация для мобильных",
-      "description": "Plan on the go with a responsive layout tuned for phones and tablets. The map, timeline, and editing all adapt to smaller screens."
-    },
-    "print": {
-      "title": "Маршруты для печати",
-      "description": "Switch to print view for a clean, paper-friendly itinerary with day headers, activity lists, and essential logistics."
-    },
-    "routing": {
-      "title": "Маршруты через несколько стран",
-      "description": "Select multiple countries or islands and TravelFlow builds a cross-border route with realistic transit between regions."
-    },
-    "history": {
-      "title": "История версий",
-      "description": "Every meaningful change creates a snapshot. Jump back to any previous version of your trip with a single click."
-    },
-    "privacy": {
-      "title": "Конфиденциальность прежде всего",
-      "description": "Your trips stay local by default. Optional cloud sync is consent-gated, and analytics only run after explicit opt-in."
-    }
-  },
-  "comparison": {
-    "title": "Сравнение TravelFlow",
-    "subtitle": "Side-by-side against spreadsheet planning and other trip tools.",
-    "featureHeader": "Feature",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "Spreadsheet",
-    "otherHeader": "Other Tools",
-    "yes": "Yes",
-    "partial": "Partial",
-    "manual": "Manual",
-    "freemium": "Freemium",
-    "rows": {
-      "ai": "AI-generated itinerary",
-      "interactiveMap": "Interactive map",
-      "dragDrop": "Drag-and-drop timeline",
-      "oneClickSharing": "One-click sharing",
-      "bookingLinks": "Booking links",
-      "offlineFirst": "Offline-first / local data",
-      "freeToUse": "Free to use"
+    "badge": "From spark to group-ready plan",
+    "title": "One flow for drafting, shaping, and sharing",
+    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Start with a destination, a vibe, or a copied route",
+        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+      },
+      {
+        "step": "02",
+        "title": "Shape the pacing with the map and timeline together",
+        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+      },
+      {
+        "step": "03",
+        "title": "Share a version that still looks intentional",
+        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+      }
+    ],
+    "glance": {
+      "eyebrow": "What your group sees",
+      "title": "A plan that already looks share-ready",
+      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "items": [
+        "Live route view with pacing context",
+        "Booking-ready activity links when you need them",
+        "A cleaner print layout for the final version"
+      ]
     }
   },
   "cta": {
-    "title": "Посмотрите в действии",
-    "subtitle": "Create your first AI-powered itinerary in under a minute.",
-    "button": "Start Planning — Free"
+    "badge": "Build it while the idea is still fresh",
+    "title": "Start with the route. Keep the travel mood.",
+    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
+    "button": "Start planning"
   }
 }

--- a/locales/ru/features.json
+++ b/locales/ru/features.json
@@ -1,21 +1,21 @@
 {
   "hero": {
-    "badge": "Interactive trip planning",
-    "titleBefore": "Build trips that already feel",
-    "titleHighlight": "ready to go",
-    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
-    "primaryCta": "Start planning",
-    "secondaryCta": "See example trips",
+    "badge": "Интерактивное планирование поездок",
+    "titleBefore": "Собирайте поездки, которые уже",
+    "titleHighlight": "кажутся готовыми",
+    "description": "TravelFlow превращает идеи о направлениях в маршрут, на который ваша группа действительно может отреагировать. Соберите первый вариант с помощью ИИ, доработайте его на живой карте и таймлайне, а затем поделитесь ссылкой, которая остаётся аккуратной, когда дело доходит до реальных решений.",
+    "primaryCta": "Начать планировать",
+    "secondaryCta": "Смотреть примеры",
     "proof": [
-      "AI itinerary drafts in seconds",
-      "Drag the route until it feels right",
-      "Share one clean link before the group chat gets chaotic"
+      "Черновики маршрута с ИИ за секунды",
+      "Подтяните маршрут, пока он не станет точным",
+      "Одна понятная ссылка до того, как чат станет хаосом"
     ]
   },
   "globe": {
-    "accessibility": "Интерактивный глобус с маршрутами от вашей стартовой точки к ярким идеям поездок по всему миру.",
-    "fallbackTitle": "Резервный вариант глобуса",
-    "fallbackDescription": "Даже без живого глобуса здесь остаются видны маршруты, карточки поездок и ваша стартовая точка.",
+    "accessibility": "Интерактивный глобус с маршрутами от вашей стартовой точки к идеям поездок по всему миру.",
+    "fallbackTitle": "Запасной вариант глобуса",
+    "fallbackDescription": "Даже без живого глобуса вы всё равно увидите маршруты, карточки поездок и стартовую точку.",
     "origin": {
       "current": "Из {city}",
       "countryFallback": "Из {country}",
@@ -25,111 +25,111 @@
       {
         "id": "paris",
         "emoji": "🗼",
-        "title": "Uikend v Parizhe",
-        "detail": "Kafe i muzei dopozdna."
+        "title": "Уикенд в Париже",
+        "detail": "Кафе и музеи допоздна."
       },
       {
         "id": "fiji",
         "emoji": "🌴",
-        "title": "Medovyy mesyats Fiji",
-        "detail": "Plyazh, lodki i medlennyy temp."
+        "title": "Медовый месяц на Фиджи",
+        "detail": "Пляжи, лодки и спокойный ритм."
       },
       {
         "id": "south-africa",
         "emoji": "🦈",
-        "title": "Dayv s beloy akuloy",
-        "detail": "Kholodnaya voda i silnyy adrenalina."
+        "title": "Дайв с белой акулой",
+        "detail": "Холодная вода и чистый адреналин."
       },
       {
         "id": "route66",
         "emoji": "🛣️",
-        "title": "Route 66",
-        "detail": "Klassicheskie moteli i finisher u okeana."
+        "title": "Маршрут 66",
+        "detail": "Классические мотели и финиш у океана."
       }
     ],
     "preview": {
-      "title": "30 dney SEA",
-      "alt": "Predprosmotr 30-dnevnogo puteshestviya po Yugo-Vostochnoy Azii"
+      "title": "SEA на 30 дней",
+      "alt": "Превью 30-дневного бэкпэкинг-маршрута по Юго-Восточной Азии"
     }
   },
   "bento": {
-    "badge": "Plan with momentum",
-    "title": "The pieces of trip planning finally stay in one place",
-    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "badge": "Планируйте с темпом",
+    "title": "Все части поездки наконец остаются в одном месте",
+    "subtitle": "Вместо прыжков между документами, картами, скриншотами и незавершёнными чатами TravelFlow держит маршрут, темп и контекст вместе.",
     "items": [
       {
         "id": "itinerary",
-        "eyebrow": "AI route draft",
-        "title": "Start from a route, not a blank page",
-        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
-        "detail": "A first draft your group can react to immediately"
+        "eyebrow": "Черновик ИИ",
+        "title": "Начинайте с маршрута, а не с пустой страницы",
+        "description": "Опишите поездку обычным языком и получите правдоподобный первый маршрут, где города, ритм и контекст уже связаны.",
+        "detail": "Первый черновик, на который группа может сразу отреагировать"
       },
       {
         "id": "timeline",
-        "eyebrow": "Live map edits",
-        "title": "Refine the plan without breaking it",
-        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
-        "detail": "Map and timing stay in sync"
+        "eyebrow": "Правки вживую",
+        "title": "Правьте план, не ломая его",
+        "description": "Продлите остановку, переставьте город или измените темп. TravelFlow держит карту и таймлайн синхронными, чтобы каждое изменение оставалось цельным.",
+        "detail": "Карта и тайминг остаются синхронными"
       },
       {
         "id": "inspiration",
-        "eyebrow": "Forkable inspiration",
-        "title": "Borrow proven ideas and make them yours",
-        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
-        "detail": "Start from real travel energy"
+        "eyebrow": "Готовое вдохновение",
+        "title": "Берите удачные идеи и делайте их своими",
+        "description": "Используйте уже убедительные маршруты как старт, вместо того чтобы каждый раз собирать правдоподобную поездку с нуля.",
+        "detail": "Начните с живой энергии путешествия"
       },
       {
         "id": "sharing",
-        "eyebrow": "Crew review",
-        "title": "Share something your travel crew can understand fast",
-        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
-        "detail": "No account required"
+        "eyebrow": "Обсуждение с группой",
+        "title": "Поделитесь тем, что группа поймёт сразу",
+        "description": "Отправьте одну ссылку с маршрутом, темпом и заметками, чтобы обсуждение шло вокруг настоящей поездки, а не вокруг разрозненных скриншотов.",
+        "detail": "Без обязательного аккаунта"
       },
       {
         "id": "relive",
-        "eyebrow": "Booking and handoff",
-        "title": "Leave with a plan that still feels polished",
-        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
-        "detail": "Ready to share, save, or print"
+        "eyebrow": "Бронь и финальная версия",
+        "title": "Заканчивайте планом, который всё ещё выглядит собранно",
+        "description": "Когда маршрут готов, практический контекст остаётся рядом: ссылки, заметки и более чистая версия для финальной передачи.",
+        "detail": "Готово к отправке, сохранению или печати"
       }
     ]
   },
   "workflow": {
-    "badge": "From spark to group-ready plan",
-    "title": "One flow for drafting, shaping, and sharing",
-    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "badge": "От искры к маршруту для всей группы",
+    "title": "Один поток для черновика, правок и шаринга",
+    "subtitle": "TravelFlow особенно полезен, когда вдохновение и практическая часть планирования должны жить в одном месте.",
     "steps": [
       {
         "step": "01",
-        "title": "Start with a destination, a vibe, or a copied route",
-        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+        "title": "Начните с направления, настроения или готового маршрута",
+        "description": "Стартуйте со списка стран, сезонной идеи или ещё размытой концепции. Идеальную последовательность пока знать не нужно."
       },
       {
         "step": "02",
-        "title": "Shape the pacing with the map and timeline together",
-        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+        "title": "Доведите темп с картой и таймлайном вместе",
+        "description": "Посмотрите маршрут на глобусе, а затем подтяните его на таймлайне, пока он не станет реалистичным для переездов, энергии и предпочтений группы."
       },
       {
         "step": "03",
-        "title": "Share a version that still looks intentional",
-        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+        "title": "Поделитесь версией, которая уже выглядит собранной",
+        "description": "Когда приходит время получать отзывы или бронировать, тот же план уже содержит карту, структуру и дополнительный контекст, который обычно все спрашивают."
       }
     ],
     "glance": {
-      "eyebrow": "What your group sees",
-      "title": "A plan that already looks share-ready",
-      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "eyebrow": "Что видит группа",
+      "title": "План, который уже выглядит готовым к отправке",
+      "description": "Карта, ритм по дням и практический контекст остаются согласованными, поэтому реакции приходят быстрее и понятнее.",
       "items": [
-        "Live route view with pacing context",
-        "Booking-ready activity links when you need them",
-        "A cleaner print layout for the final version"
+        "Живой маршрут с контекстом темпа",
+        "Ссылки для бронирования, когда они нужны",
+        "Более чистая печатная версия для финала"
       ]
     }
   },
   "cta": {
-    "badge": "Build it while the idea is still fresh",
-    "title": "Start with the route. Keep the travel mood.",
-    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
-    "button": "Start planning"
+    "badge": "Собирайте, пока идея ещё свежая",
+    "title": "Начните с маршрута. Сохраните настроение поездки.",
+    "subtitle": "Набросайте следующую поездку за несколько минут и продолжайте дорабатывать её в одном месте, а не пересобирать в пяти инструментах.",
+    "button": "Начать планировать"
   }
 }

--- a/locales/ur/features.json
+++ b/locales/ur/features.json
@@ -1,38 +1,38 @@
 {
   "hero": {
-    "badge": "Interactive trip planning",
-    "titleBefore": "Build trips that already feel",
-    "titleHighlight": "ready to go",
-    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
-    "primaryCta": "Start planning",
-    "secondaryCta": "See example trips",
+    "badge": "انٹرایکٹو ٹرپ پلاننگ",
+    "titleBefore": "ایسے سفر بنائیں جو پہلے ہی",
+    "titleHighlight": "روانہ ہونے کے لیے تیار لگیں",
+    "description": "TravelFlow منزل کے خیالات کو ایک ایسے روٹ میں بدل دیتا ہے جس پر آپ کا گروپ واقعی ردِعمل دے سکے۔ AI سے پہلا ڈرافٹ بنائیں، اسے لائیو میپ اور ٹائم لائن پر بہتر کریں، پھر ایسا لنک شیئر کریں جو فیصلے سنجیدہ ہونے پر بھی صاف اور پالشڈ لگے۔",
+    "primaryCta": "پلاننگ شروع کریں",
+    "secondaryCta": "نمونہ ٹرپس دیکھیں",
     "proof": [
-      "AI itinerary drafts in seconds",
-      "Drag the route until it feels right",
-      "Share one clean link before the group chat gets chaotic"
+      "AI سفر ڈرافٹس چند سیکنڈ میں",
+      "روٹ کو تب تک ایڈجسٹ کریں جب تک وہ درست نہ لگے",
+      "گروپ چیٹ بکھرنے سے پہلے ایک صاف لنک"
     ]
   },
   "globe": {
-    "accessibility": "ایک انٹرایکٹو گلوب پری ویو جو آپ کے آغاز کے مقام سے دنیا بھر کی رنگین سفری آئیڈیاز تک راستے دکھاتا ہے۔",
-    "fallbackTitle": "گلوب کا متبادل منظر",
-    "fallbackDescription": "لائیو گلوب نہ بھی ہو تو بھی یہاں روٹس، ٹرپ کارڈز اور آپ کا آغازی مقام نظر آتا رہتا ہے۔",
+    "accessibility": "انٹرایکٹو گلوب پری ویو جو آپ کے نقطۂ آغاز سے دنیا بھر کی ٹرپ آئیڈیاز تک روٹس دکھاتی ہے۔",
+    "fallbackTitle": "انٹرایکٹو گلوب کا متبادل منظر",
+    "fallbackDescription": "لائیو گلوب نہ ہو تب بھی آپ روٹس، ٹرپ کارڈز اور اپنا نقطۂ آغاز دیکھ سکتے ہیں۔",
     "origin": {
       "current": "{city} سے",
       "countryFallback": "{country} سے",
-      "fallback": "آغازی مقام"
+      "fallback": "نقطۂ آغاز"
     },
     "cards": [
       {
         "id": "paris",
         "emoji": "🗼",
-        "title": "پیرس ویکینڈ",
+        "title": "پیرس ویک اینڈ",
         "detail": "کیفے اور دیر تک میوزیم۔"
       },
       {
         "id": "fiji",
         "emoji": "🌴",
         "title": "فجی ہنی مون",
-        "detail": "بیچ، بوٹ اور نرم رفتار۔"
+        "detail": "ساحل، بوٹ اور نرم رفتار۔"
       },
       {
         "id": "south-africa",
@@ -49,87 +49,87 @@
     ],
     "preview": {
       "title": "30 دن SEA",
-      "alt": "جنوب مشرقی ایشیا کے 30 دن کے سفر کا پیش نظارہ"
+      "alt": "جنوب مشرقی ایشیا کے 30 دن کے بیک پیکنگ سفر کا پیش نظارہ"
     }
   },
   "bento": {
-    "badge": "Plan with momentum",
-    "title": "The pieces of trip planning finally stay in one place",
-    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "badge": "رفتار کے ساتھ پلان کریں",
+    "title": "سفر کے حصے آخرکار ایک ہی جگہ رہتے ہیں",
+    "subtitle": "ڈاکس، میپس، اسکرین شاٹس اور ادھوری چیٹس کے درمیان بھاگنے کے بجائے TravelFlow روٹ، رفتار اور سفر کے تناظر کو ایک ساتھ رکھتا ہے۔",
     "items": [
       {
         "id": "itinerary",
-        "eyebrow": "AI route draft",
-        "title": "Start from a route, not a blank page",
-        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
-        "detail": "A first draft your group can react to immediately"
+        "eyebrow": "AI ڈرافٹ",
+        "title": "خالی صفحے سے نہیں، روٹ سے شروع کریں",
+        "description": "عام زبان میں سفر بیان کریں اور ایک قابلِ یقین پہلا itinerary حاصل کریں جس میں شہروں کا بہاؤ، رفتار اور تناظر پہلے ہی جڑا ہوا ہو۔",
+        "detail": "ایک پہلا ڈرافٹ جس پر آپ کا گروپ فوراً ردِعمل دے سکے"
       },
       {
         "id": "timeline",
-        "eyebrow": "Live map edits",
-        "title": "Refine the plan without breaking it",
-        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
-        "detail": "Map and timing stay in sync"
+        "eyebrow": "لائیو ایڈیٹس",
+        "title": "پلان کو توڑے بغیر بہتر کریں",
+        "description": "قیام بڑھائیں، شہر بدلیں یا رفتار تبدیل کریں۔ TravelFlow میپ اور ٹائم لائن کو ہم آہنگ رکھتا ہے تاکہ ہر تبدیلی پھر بھی مربوط لگے۔",
+        "detail": "میپ اور ٹائمنگ ساتھ رہتے ہیں"
       },
       {
         "id": "inspiration",
-        "eyebrow": "Forkable inspiration",
-        "title": "Borrow proven ideas and make them yours",
-        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
-        "detail": "Start from real travel energy"
+        "eyebrow": "دوبارہ استعمال ہونے والی انسپیریشن",
+        "title": "اچھی آئیڈیاز لیں اور انہیں اپنا بنائیں",
+        "description": "ہر بار صفر سے قابلِ یقین سفر بنانے کے بجائے ایسے روٹس سے شروع کریں جن میں پہلے ہی اصلی ٹریول انرجی ہو۔",
+        "detail": "حقیقی سفر کی انرجی سے آغاز کریں"
       },
       {
         "id": "sharing",
-        "eyebrow": "Crew review",
-        "title": "Share something your travel crew can understand fast",
-        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
-        "detail": "No account required"
+        "eyebrow": "گروپ ریویو",
+        "title": "ایسی چیز شیئر کریں جسے گروپ جلدی سمجھ لے",
+        "description": "ایک ہی لنک بھیجیں جس میں روٹ، رفتار اور نوٹس پہلے سے موجود ہوں تاکہ فیڈبیک اصل سفر پر آئے، بکھری ہوئی اسکرین شاٹس پر نہیں۔",
+        "detail": "اکاؤنٹ کے بغیر بھی"
       },
       {
         "id": "relive",
-        "eyebrow": "Booking and handoff",
-        "title": "Leave with a plan that still feels polished",
-        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
-        "detail": "Ready to share, save, or print"
+        "eyebrow": "بکنگ اور فائنل ہینڈ آف",
+        "title": "آخر میں بھی ایک پالشڈ پلان رکھیں",
+        "description": "جب روٹ تیار ہو جائے تو عملی تناظر ساتھ رہتا ہے: لنکس، نوٹس اور آخری ہینڈ آف کے لیے زیادہ صاف ورژن۔",
+        "detail": "شیئر، محفوظ یا پرنٹ کرنے کے لیے تیار"
       }
     ]
   },
   "workflow": {
-    "badge": "From spark to group-ready plan",
-    "title": "One flow for drafting, shaping, and sharing",
-    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "badge": "خیال سے گروپ ریڈی پلان تک",
+    "title": "ڈرافٹ، ریفائن اور شیئر کے لیے ایک ہی فلو",
+    "subtitle": "TravelFlow تب سب سے بہتر کام کرتا ہے جب آپ سفر کی پُرجوش اور عملی دونوں پلاننگ ایک ہی جگہ رکھنا چاہتے ہوں۔",
     "steps": [
       {
         "step": "01",
-        "title": "Start with a destination, a vibe, or a copied route",
-        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+        "title": "منزل، موڈ یا کاپی شدہ روٹ سے شروع کریں",
+        "description": "ملکوں کی فہرست، موسمی خیال یا ابھی دھندلے سفر کے تصور سے آغاز کریں۔ ابھی آپ کو بہترین ترتیب جاننا ضروری نہیں۔"
       },
       {
         "step": "02",
-        "title": "Shape the pacing with the map and timeline together",
-        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+        "title": "میپ اور ٹائم لائن کو ساتھ رکھ کر رفتار درست کریں",
+        "description": "گلوب پر روٹ دیکھیں، پھر ٹائم لائن پر اسے اس وقت تک بہتر کریں جب تک وہ ٹرانسفرز، انرجی اور گروپ ترجیحات کے لیے حقیقت پسندانہ نہ لگے۔"
       },
       {
         "step": "03",
-        "title": "Share a version that still looks intentional",
-        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+        "title": "ایسا ورژن شیئر کریں جو پہلے ہی سوچا سمجھا لگے",
+        "description": "جب فیڈبیک یا بکنگ کا وقت آئے، تو اسی پلان میں پہلے سے میپ، ساخت اور وہ اضافی تناظر موجود ہو جو لوگ عام طور پر پوچھتے ہیں۔"
       }
     ],
     "glance": {
-      "eyebrow": "What your group sees",
-      "title": "A plan that already looks share-ready",
-      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "eyebrow": "آپ کے گروپ کو کیا دکھتا ہے",
+      "title": "ایسا پلان جو پہلے ہی شیئر کے لیے تیار لگے",
+      "description": "میپ، دن بہ دن رفتار اور عملی تناظر ایک ساتھ رہتے ہیں تاکہ ردِعمل زیادہ تیزی اور کم الجھن کے ساتھ آئیں۔",
       "items": [
-        "Live route view with pacing context",
-        "Booking-ready activity links when you need them",
-        "A cleaner print layout for the final version"
+        "رفتار کے تناظر کے ساتھ لائیو روٹ ویو",
+        "ضرورت پڑنے پر بکنگ کے لیے تیار لنکس",
+        "آخری ورژن کے لیے زیادہ صاف پرنٹ لے آؤٹ"
       ]
     }
   },
   "cta": {
-    "badge": "Build it while the idea is still fresh",
-    "title": "Start with the route. Keep the travel mood.",
-    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
-    "button": "Start planning"
+    "badge": "خیال تازہ ہو تو اسی وقت بنائیں",
+    "title": "روٹ سے شروع کریں۔ سفر کا موڈ برقرار رکھیں۔",
+    "subtitle": "اپنا اگلا سفر چند منٹ میں ڈرافٹ کریں اور پھر اسے وہیں بہتر کرتے رہیں، بجائے اس کے کہ پانچ ٹولز میں دوبارہ بنائیں۔",
+    "button": "پلاننگ شروع کریں"
   }
 }

--- a/locales/ur/features.json
+++ b/locales/ur/features.json
@@ -1,99 +1,135 @@
 {
   "hero": {
-    "pill": "Product Capabilities",
-    "title": "Plan smarter, travel better",
-    "description": "TravelFlow combines AI generation, visual editing, and collaboration into one workspace. Here is everything the platform can do for your next trip."
+    "badge": "Interactive trip planning",
+    "titleBefore": "Build trips that already feel",
+    "titleHighlight": "ready to go",
+    "description": "TravelFlow turns destination ideas into a route your group can actually react to. Draft the itinerary with AI, shape it on a live map and timeline, then share a link that still feels polished when decisions get real.",
+    "primaryCta": "Start planning",
+    "secondaryCta": "See example trips",
+    "proof": [
+      "AI itinerary drafts in seconds",
+      "Drag the route until it feels right",
+      "Share one clean link before the group chat gets chaotic"
+    ]
   },
-  "heroCards": {
-    "ai": {
-      "title": "AI Trip Generation",
-      "description": "Describe where you want to go and TravelFlow creates a full itinerary — optimized routes, curated activities, realistic timing — in under 30 seconds. Classic, Wizard, or Surprise Me modes adapt to how you like to plan."
+  "globe": {
+    "accessibility": "ایک انٹرایکٹو گلوب پری ویو جو آپ کے آغاز کے مقام سے دنیا بھر کی رنگین سفری آئیڈیاز تک راستے دکھاتا ہے۔",
+    "fallbackTitle": "گلوب کا متبادل منظر",
+    "fallbackDescription": "لائیو گلوب نہ بھی ہو تو بھی یہاں روٹس، ٹرپ کارڈز اور آپ کا آغازی مقام نظر آتا رہتا ہے۔",
+    "origin": {
+      "current": "{city} سے",
+      "countryFallback": "{country} سے",
+      "fallback": "آغازی مقام"
     },
-    "map": {
-      "title": "Interactive Map & Timeline",
-      "description": "Your trip lives on a real map with animated route lines, city markers, and dynamic zoom. Below the map, a visual timeline shows every day at a glance. Switch between satellite, terrain, and minimalist styles."
-    },
-    "editing": {
-      "title": "Drag-and-Drop Editing",
-      "description": "Reorder cities, stretch stay durations, and insert spontaneous stops — all by dragging on the timeline. Dates, connections, and the map update automatically so everything stays in sync."
+    "cards": [
+      {
+        "id": "paris",
+        "emoji": "🗼",
+        "title": "پیرس ویکینڈ",
+        "detail": "کیفے اور دیر تک میوزیم۔"
+      },
+      {
+        "id": "fiji",
+        "emoji": "🌴",
+        "title": "فجی ہنی مون",
+        "detail": "بیچ، بوٹ اور نرم رفتار۔"
+      },
+      {
+        "id": "south-africa",
+        "emoji": "🦈",
+        "title": "گریٹ وائٹ ڈائیو",
+        "detail": "ٹھنڈا پانی اور زبردست سنسنی۔"
+      },
+      {
+        "id": "route66",
+        "emoji": "🛣️",
+        "title": "روٹ 66",
+        "detail": "کلاسک موٹلز اور ویسٹ کوسٹ اختتام۔"
+      }
+    ],
+    "preview": {
+      "title": "30 دن SEA",
+      "alt": "جنوب مشرقی ایشیا کے 30 دن کے سفر کا پیش نظارہ"
     }
+  },
+  "bento": {
+    "badge": "Plan with momentum",
+    "title": "The pieces of trip planning finally stay in one place",
+    "subtitle": "Instead of jumping between docs, maps, screenshots, and half-finished chat threads, TravelFlow keeps the route, timing, and trip context moving together.",
+    "items": [
+      {
+        "id": "itinerary",
+        "eyebrow": "AI route draft",
+        "title": "Start from a route, not a blank page",
+        "description": "Describe the trip you want in plain language and get a believable first itinerary with city flow, pacing, and activity context already connected.",
+        "detail": "A first draft your group can react to immediately"
+      },
+      {
+        "id": "timeline",
+        "eyebrow": "Live map edits",
+        "title": "Refine the plan without breaking it",
+        "description": "Stretch a stay, reorder a city, or change the pace. TravelFlow keeps the map and timeline aligned so every edit still feels coherent.",
+        "detail": "Map and timing stay in sync"
+      },
+      {
+        "id": "inspiration",
+        "eyebrow": "Forkable inspiration",
+        "title": "Borrow proven ideas and make them yours",
+        "description": "Use community-style routes and inspiration as a smart starting point instead of rebuilding a believable trip from scratch.",
+        "detail": "Start from real travel energy"
+      },
+      {
+        "id": "sharing",
+        "eyebrow": "Crew review",
+        "title": "Share something your travel crew can understand fast",
+        "description": "Send one link with the route, the pacing, and the notes already in place so feedback happens on the actual trip, not on disconnected screenshots.",
+        "detail": "No account required"
+      },
+      {
+        "id": "relive",
+        "eyebrow": "Booking and handoff",
+        "title": "Leave with a plan that still feels polished",
+        "description": "When the route is ready, the practical context is still there: booking links, notes, and a cleaner print-friendly version for the final handoff.",
+        "detail": "Ready to share, save, or print"
+      }
+    ]
   },
   "workflow": {
-    "title": "How it works",
-    "subtitle": "From idea to itinerary in three steps.",
-    "step1Title": "Choose your destination",
-    "step1Description": "Pick countries, islands, or let Surprise Me suggest the perfect match for your travel window.",
-    "step2Title": "Generate with AI",
-    "step2Description": "Our model drafts a full route with city timing, activities, and logistics. Tweak the result in seconds.",
-    "step3Title": "Refine & share",
-    "step3Description": "Drag cities, adjust durations, add notes. Then share a link — your crew sees the live map and timeline."
-  },
-  "more": {
-    "title": "And so much more",
-    "subtitle": "Every detail is designed to remove friction from trip planning."
-  },
-  "secondary": {
-    "sharing": {
-      "title": "One-Click Sharing",
-      "description": "Generate a link and send it to your travel crew. They see the full map, timeline, and activities — no account needed."
-    },
-    "community": {
-      "title": "Community Inspirations",
-      "description": "Browse curated trips from travelers worldwide. Fork any itinerary as a starting point and make it your own."
-    },
-    "booking": {
-      "title": "Booking Links",
-      "description": "Every AI-suggested activity links to booking platforms — tours, restaurants, transport — so you can reserve without leaving TravelFlow."
-    },
-    "duration": {
-      "title": "Smart Duration Hints",
-      "description": "TravelFlow analyzes seasonal data and travel distances to suggest how long to spend in each city so you never feel rushed."
-    },
-    "mobile": {
-      "title": "Mobile-Optimized",
-      "description": "Plan on the go with a responsive layout tuned for phones and tablets. The map, timeline, and editing all adapt to smaller screens."
-    },
-    "print": {
-      "title": "Print-Ready Itineraries",
-      "description": "Switch to print view for a clean, paper-friendly itinerary with day headers, activity lists, and essential logistics."
-    },
-    "routing": {
-      "title": "Multi-Country Routing",
-      "description": "Select multiple countries or islands and TravelFlow builds a cross-border route with realistic transit between regions."
-    },
-    "history": {
-      "title": "Version History",
-      "description": "Every meaningful change creates a snapshot. Jump back to any previous version of your trip with a single click."
-    },
-    "privacy": {
-      "title": "Privacy-First",
-      "description": "Your trips stay local by default. Optional cloud sync is consent-gated, and analytics only run after explicit opt-in."
-    }
-  },
-  "comparison": {
-    "title": "How TravelFlow compares",
-    "subtitle": "Side-by-side against spreadsheet planning and other trip tools.",
-    "featureHeader": "Feature",
-    "travelflowHeader": "TravelFlow",
-    "spreadsheetHeader": "Spreadsheet",
-    "otherHeader": "Other Tools",
-    "yes": "Yes",
-    "partial": "Partial",
-    "manual": "Manual",
-    "freemium": "Freemium",
-    "rows": {
-      "ai": "AI-generated itinerary",
-      "interactiveMap": "Interactive map",
-      "dragDrop": "Drag-and-drop timeline",
-      "oneClickSharing": "One-click sharing",
-      "bookingLinks": "Booking links",
-      "offlineFirst": "Offline-first / local data",
-      "freeToUse": "Free to use"
+    "badge": "From spark to group-ready plan",
+    "title": "One flow for drafting, shaping, and sharing",
+    "subtitle": "TravelFlow works best when you want the exciting part of planning and the practical part of planning to live in the same place.",
+    "steps": [
+      {
+        "step": "01",
+        "title": "Start with a destination, a vibe, or a copied route",
+        "description": "Begin from a country list, a seasonal idea, or a travel concept that is still fuzzy. You do not need to know the perfect sequence yet."
+      },
+      {
+        "step": "02",
+        "title": "Shape the pacing with the map and timeline together",
+        "description": "See the route on the globe, then tighten the trip on the timeline until it feels realistic for transfers, energy, and group preferences."
+      },
+      {
+        "step": "03",
+        "title": "Share a version that still looks intentional",
+        "description": "When it is time to get feedback or book, the same plan already has the map, the structure, and the extra context people usually ask for."
+      }
+    ],
+    "glance": {
+      "eyebrow": "What your group sees",
+      "title": "A plan that already looks share-ready",
+      "description": "Maps, day-by-day timing, and the practical context stay aligned so reactions come faster and with less confusion.",
+      "items": [
+        "Live route view with pacing context",
+        "Booking-ready activity links when you need them",
+        "A cleaner print layout for the final version"
+      ]
     }
   },
   "cta": {
-    "title": "See it in action",
-    "subtitle": "Create your first AI-powered itinerary in under a minute.",
-    "button": "Start Planning — Free"
+    "badge": "Build it while the idea is still fresh",
+    "title": "Start with the route. Keep the travel mood.",
+    "subtitle": "Draft your next trip in minutes, then keep refining it in the same place instead of rebuilding it across five tools.",
+    "button": "Start planning"
   }
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -41,6 +41,10 @@ exit 1
   function = "health"
 
 [[edge_functions]]
+  path = "/api/runtime/location"
+  function = "runtime-location"
+
+[[edge_functions]]
   path = "/api/billing/paddle/config"
   function = "paddle-config"
 

--- a/netlify/edge-functions/runtime-location.ts
+++ b/netlify/edge-functions/runtime-location.ts
@@ -1,0 +1,102 @@
+import {
+  buildRuntimeLocationPayload,
+  createEmptyRuntimeLocation,
+  type RuntimeLocation,
+  type RuntimeLocationPayload,
+} from '../../shared/runtimeLocation.ts';
+
+interface RuntimeLocationGeoContext {
+  city?: unknown;
+  country?: {
+    code?: unknown;
+    name?: unknown;
+  } | null;
+  latitude?: unknown;
+  longitude?: unknown;
+  subdivision?: {
+    code?: unknown;
+    name?: unknown;
+  } | null;
+  timezone?: unknown;
+  postalCode?: unknown;
+}
+
+interface RuntimeLocationContext {
+  geo?: RuntimeLocationGeoContext | null;
+}
+
+const JSON_HEADERS = {
+  'content-type': 'application/json; charset=utf-8',
+  'cache-control': 'no-store',
+};
+
+const asNullableString = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const asNullableNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const json = (status: number, payload: RuntimeLocationPayload) => new Response(JSON.stringify(payload), {
+  status,
+  headers: JSON_HEADERS,
+});
+
+const getNormalizedRuntimeLocation = (context: RuntimeLocationContext): RuntimeLocation => {
+  const location = createEmptyRuntimeLocation();
+  const geo = context.geo;
+
+  if (!geo) return location;
+
+  return {
+    city: asNullableString(geo.city),
+    countryCode: asNullableString(geo.country?.code),
+    countryName: asNullableString(geo.country?.name),
+    subdivisionCode: asNullableString(geo.subdivision?.code),
+    subdivisionName: asNullableString(geo.subdivision?.name),
+    latitude: asNullableNumber(geo.latitude),
+    longitude: asNullableNumber(geo.longitude),
+    timezone: asNullableString(geo.timezone),
+    postalCode: asNullableString(geo.postalCode),
+  };
+};
+
+export default async (request: Request, context: RuntimeLocationContext): Promise<Response> => {
+  if (request.method !== 'GET') {
+    return new Response(JSON.stringify({
+      ok: false,
+      error: 'Method not allowed',
+    }), {
+      status: 405,
+      headers: {
+        ...JSON_HEADERS,
+        allow: 'GET',
+      },
+    });
+  }
+
+  try {
+    const payload = buildRuntimeLocationPayload({
+      source: 'netlify-context',
+      fetchedAt: new Date().toISOString(),
+      location: getNormalizedRuntimeLocation(context),
+    });
+    return json(200, payload);
+  } catch {
+    return json(200, buildRuntimeLocationPayload({
+      source: 'error',
+      fetchedAt: new Date().toISOString(),
+      location: createEmptyRuntimeLocation(),
+    }));
+  }
+};

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "blurhash": "^2.0.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cobe": "2.0.0",
     "diff": "^8.0.3",
     "flagpack": "^1.0.5",
     "framer-motion": "^12.34.3",

--- a/pages/FeaturesPage.tsx
+++ b/pages/FeaturesPage.tsx
@@ -1,246 +1,200 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import {
-    Sparkle,
-    MapTrifold,
-    SlidersHorizontal,
-    UsersThree,
-    ShareNetwork,
-    LinkSimple,
-    Timer,
-    DeviceMobile,
-    Printer,
-    Globe,
-    ArrowsClockwise,
-    ShieldCheck,
-} from '@phosphor-icons/react';
-import type { Icon } from '@phosphor-icons/react';
+import { ArrowsClockwise, Printer, Sparkle } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
+import { FeaturesBentoGrid, type FeatureBentoItem } from '../components/marketing/features/FeaturesBentoGrid';
+import { FeaturesGlobe } from '../components/marketing/features/FeaturesGlobe';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
+import { Card, CardContent } from '../components/ui/card';
+import { normalizeLocale } from '../config/locales';
+import { buildLocalizedMarketingPath, buildPath } from '../config/routes';
 import { getAnalyticsDebugAttributes, trackEvent } from '../services/analyticsService';
-import { buildPath } from '../config/routes';
+import { warmRouteAssets } from '../services/navigationPrefetch';
 
-interface Feature {
-    icon: Icon;
+interface WorkflowStep {
+    step: string;
     title: string;
     description: string;
-    color: string;
 }
 
-const ComparisonCell: React.FC<{ value: boolean | string; yesLabel: string }> = ({ value, yesLabel }) => {
-    if (value === true) return <span className="text-emerald-600 font-bold">{yesLabel}</span>;
-    if (value === false) return <span className="text-slate-300">-</span>;
-    return <span className="text-amber-600 text-xs font-medium">{value}</span>;
-};
+interface WorkflowGlance {
+    eyebrow: string;
+    title: string;
+    description: string;
+    items: string[];
+}
+
+const workflowIconMap = [Sparkle, ArrowsClockwise, Printer];
 
 export const FeaturesPage: React.FC = () => {
-    const { t } = useTranslation('features');
+    const { t, i18n } = useTranslation('features');
+    const activeLocale = normalizeLocale(i18n.resolvedLanguage || i18n.language);
+    const inspirationsPath = buildLocalizedMarketingPath('inspirations', activeLocale);
+    const bentoItems = t('bento.items', { returnObjects: true }) as FeatureBentoItem[];
+    const workflowSteps = t('workflow.steps', { returnObjects: true }) as WorkflowStep[];
+    const workflowGlance = t('workflow.glance', { returnObjects: true }) as WorkflowGlance;
 
-    const heroFeatures: Feature[] = [
-        {
-            icon: Sparkle,
-            title: t('heroCards.ai.title'),
-            description: t('heroCards.ai.description'),
-            color: 'bg-violet-50 text-violet-600 ring-violet-100',
-        },
-        {
-            icon: MapTrifold,
-            title: t('heroCards.map.title'),
-            description: t('heroCards.map.description'),
-            color: 'bg-sky-50 text-sky-600 ring-sky-100',
-        },
-        {
-            icon: SlidersHorizontal,
-            title: t('heroCards.editing.title'),
-            description: t('heroCards.editing.description'),
-            color: 'bg-amber-50 text-amber-600 ring-amber-100',
-        },
-    ];
-
-    const secondaryFeatures: { icon: Icon; title: string; description: string }[] = [
-        {
-            icon: ShareNetwork,
-            title: t('secondary.sharing.title'),
-            description: t('secondary.sharing.description'),
-        },
-        {
-            icon: UsersThree,
-            title: t('secondary.community.title'),
-            description: t('secondary.community.description'),
-        },
-        {
-            icon: LinkSimple,
-            title: t('secondary.booking.title'),
-            description: t('secondary.booking.description'),
-        },
-        {
-            icon: Timer,
-            title: t('secondary.duration.title'),
-            description: t('secondary.duration.description'),
-        },
-        {
-            icon: DeviceMobile,
-            title: t('secondary.mobile.title'),
-            description: t('secondary.mobile.description'),
-        },
-        {
-            icon: Printer,
-            title: t('secondary.print.title'),
-            description: t('secondary.print.description'),
-        },
-        {
-            icon: Globe,
-            title: t('secondary.routing.title'),
-            description: t('secondary.routing.description'),
-        },
-        {
-            icon: ArrowsClockwise,
-            title: t('secondary.history.title'),
-            description: t('secondary.history.description'),
-        },
-        {
-            icon: ShieldCheck,
-            title: t('secondary.privacy.title'),
-            description: t('secondary.privacy.description'),
-        },
-    ];
-
-    const comparisonRows = [
-        { feature: t('comparison.rows.ai'), travelflow: true, spreadsheet: false, other: t('comparison.partial') },
-        { feature: t('comparison.rows.interactiveMap'), travelflow: true, spreadsheet: false, other: true },
-        { feature: t('comparison.rows.dragDrop'), travelflow: true, spreadsheet: false, other: false },
-        { feature: t('comparison.rows.oneClickSharing'), travelflow: true, spreadsheet: t('comparison.manual'), other: true },
-        { feature: t('comparison.rows.bookingLinks'), travelflow: true, spreadsheet: false, other: t('comparison.partial') },
-        { feature: t('comparison.rows.offlineFirst'), travelflow: true, spreadsheet: false, other: false },
-        { feature: t('comparison.rows.freeToUse'), travelflow: true, spreadsheet: true, other: t('comparison.freemium') },
-    ];
+    const prewarmCreateTripRoute = () => {
+        void warmRouteAssets(buildPath('createTrip'), 'manual');
+    };
 
     return (
         <MarketingLayout>
-            <section className="pt-8 pb-16 md:pt-14 md:pb-24 animate-hero-entrance">
-                <span className="inline-flex items-center gap-1.5 rounded-full border border-accent-200 bg-accent-50 px-3.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-accent-700">
-                    {t('hero.pill')}
-                </span>
-                <h1 className="mt-5 text-4xl font-black tracking-tight text-slate-900 md:text-6xl" style={{ fontFamily: 'var(--tf-font-heading)' }}>
-                    {t('hero.title')}
-                </h1>
-                <p className="mt-5 max-w-2xl text-lg leading-relaxed text-slate-600">
-                    {t('hero.description')}
-                </p>
-            </section>
-
-            <section className="grid gap-6 md:grid-cols-3 pb-20">
-                {heroFeatures.map((feature, index) => {
-                    const IconComponent = feature.icon;
-                    return (
-                        <article
-                            key={feature.title}
-                            className="animate-scroll-blur-in rounded-3xl border border-slate-200 bg-white p-7 shadow-sm transition-all hover:shadow-lg hover:-translate-y-1"
-                            style={{ animationDelay: `${index * 80}ms` }}
-                        >
-                            <div className={`inline-flex h-12 w-12 items-center justify-center rounded-2xl ring-1 ${feature.color}`}>
-                                <IconComponent size={24} weight="duotone" />
-                            </div>
-                            <h2 className="mt-5 text-lg font-bold text-slate-900">{feature.title}</h2>
-                            <p className="mt-2 text-sm leading-relaxed text-slate-600">{feature.description}</p>
-                        </article>
-                    );
-                })}
-            </section>
-
-            <section className="py-16 md:py-24 border-t border-slate-200">
-                <div className="animate-scroll-blur-in text-center">
-                    <h2 className="text-3xl font-black tracking-tight text-slate-900 md:text-4xl">{t('workflow.title')}</h2>
-                    <p className="mx-auto mt-3 max-w-lg text-base text-slate-600">{t('workflow.subtitle')}</p>
-                </div>
-
-                <div className="mt-14 grid gap-8 md:grid-cols-3">
-                    {[
-                        { step: '01', title: t('workflow.step1Title'), description: t('workflow.step1Description') },
-                        { step: '02', title: t('workflow.step2Title'), description: t('workflow.step2Description') },
-                        { step: '03', title: t('workflow.step3Title'), description: t('workflow.step3Description') },
-                    ].map((item, index) => (
-                        <div key={item.step} className="animate-scroll-fade-up text-center" style={{ animationDelay: `${index * 100}ms` }}>
-                            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-accent-600 text-white text-lg font-black">
-                                {item.step}
-                            </div>
-                            <h3 className="mt-4 text-base font-bold text-slate-900">{item.title}</h3>
-                            <p className="mt-2 text-sm leading-relaxed text-slate-500">{item.description}</p>
-                        </div>
-                    ))}
-                </div>
-            </section>
-
-            <section className="py-16 md:py-24 border-t border-slate-200">
-                <div className="animate-scroll-blur-in">
-                    <h2 className="text-3xl font-black tracking-tight text-slate-900 md:text-4xl">{t('more.title')}</h2>
-                    <p className="mt-3 max-w-xl text-base text-slate-600">{t('more.subtitle')}</p>
-                </div>
-
-                <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                    {secondaryFeatures.map((feature) => {
-                        const IconComponent = feature.icon;
-                        return (
-                            <div
-                                key={feature.title}
-                                className="animate-scroll-fade-up rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition-all hover:shadow-md"
+            <section className="relative overflow-hidden pb-20 pt-8 md:pb-28 md:pt-14">
+                <div className="relative grid gap-12 lg:grid-cols-[minmax(0,1.02fr)_minmax(460px,560px)] lg:items-center">
+                    <div className="max-w-3xl">
+                        <div className="animate-hero-stagger" style={{ '--stagger': '0ms' } as React.CSSProperties}>
+                            <h1
+                                className="max-w-4xl text-5xl font-black tracking-tight text-slate-950 md:text-7xl"
+                                style={{ fontFamily: 'var(--tf-font-heading)' }}
                             >
-                                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent-50 text-accent-600">
-                                    <IconComponent size={22} weight="duotone" />
-                                </div>
-                                <h3 className="mt-4 text-sm font-bold text-slate-900">{feature.title}</h3>
-                                <p className="mt-1.5 text-sm leading-relaxed text-slate-500">{feature.description}</p>
-                            </div>
-                        );
-                    })}
+                                {t('hero.titleBefore')}{' '}
+                                <span className="text-accent-700">{t('hero.titleHighlight')}</span>
+                            </h1>
+                        </div>
+
+                        <div className="animate-hero-stagger" style={{ '--stagger': '80ms' } as React.CSSProperties}>
+                            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-600 md:text-xl">
+                                {t('hero.description')}
+                            </p>
+                        </div>
+
+                        <div
+                            className="mt-10 flex flex-wrap items-center gap-4 animate-hero-stagger"
+                            style={{ '--stagger': '160ms' } as React.CSSProperties}
+                        >
+                            <Link
+                                to={buildPath('createTrip')}
+                                onClick={() => trackEvent('features__hero_cta--start_planning')}
+                                onMouseEnter={prewarmCreateTripRoute}
+                                onFocus={prewarmCreateTripRoute}
+                                onTouchStart={prewarmCreateTripRoute}
+                                className="rounded-lg bg-accent-600 px-7 py-3.5 text-base font-bold text-white shadow-sm shadow-accent-200 transition-all hover:-translate-y-0.5 hover:bg-accent-700 hover:shadow-md hover:shadow-accent-200 active:translate-y-0"
+                                {...getAnalyticsDebugAttributes('features__hero_cta--start_planning')}
+                            >
+                                {t('hero.primaryCta')}
+                            </Link>
+                            <Link
+                                to={inspirationsPath}
+                                onClick={() => trackEvent('features__hero_cta--see_examples')}
+                                className="rounded-lg border border-slate-300 bg-white px-7 py-3.5 text-base font-bold text-slate-700 shadow-sm transition-all hover:-translate-y-0.5 hover:border-slate-400 hover:text-slate-950 hover:shadow-md active:translate-y-0"
+                                {...getAnalyticsDebugAttributes('features__hero_cta--see_examples')}
+                            >
+                                {t('hero.secondaryCta')}
+                            </Link>
+                        </div>
+                    </div>
+
+                    <div className="animate-hero-stagger" style={{ '--stagger': '240ms' } as React.CSSProperties}>
+                        <FeaturesGlobe />
+                    </div>
                 </div>
             </section>
 
-            <section className="py-16 md:py-24 border-t border-slate-200">
-                <div className="animate-scroll-blur-in">
-                    <h2 className="text-3xl font-black tracking-tight text-slate-900 md:text-4xl">{t('comparison.title')}</h2>
-                    <p className="mt-3 max-w-xl text-base text-slate-600">{t('comparison.subtitle')}</p>
+            <section className="border-t border-slate-200/80 py-16 md:py-24">
+                <div className="animate-scroll-blur-in max-w-3xl">
+                    <h2 className="text-3xl font-black tracking-tight text-slate-950 md:text-5xl">
+                        {t('bento.title')}
+                    </h2>
+                    <p className="mt-4 max-w-2xl text-base leading-relaxed text-slate-600 md:text-lg">
+                        {t('bento.subtitle')}
+                    </p>
                 </div>
 
-                <div className="mt-10 overflow-x-auto animate-scroll-fade-up">
-                    <table className="w-full min-w-[540px] text-sm">
-                        <thead>
-                            <tr className="border-b border-slate-200 text-left">
-                                <th className="py-3 pr-4 font-semibold text-slate-500">{t('comparison.featureHeader')}</th>
-                                <th className="py-3 px-4 font-bold text-accent-700">{t('comparison.travelflowHeader')}</th>
-                                <th className="py-3 px-4 font-semibold text-slate-500">{t('comparison.spreadsheetHeader')}</th>
-                                <th className="py-3 px-4 font-semibold text-slate-500">{t('comparison.otherHeader')}</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {comparisonRows.map((row) => (
-                                <tr key={row.feature} className="border-b border-slate-100">
-                                    <td className="py-3 pr-4 text-slate-700">{row.feature}</td>
-                                    <td className="py-3 px-4"><ComparisonCell value={row.travelflow} yesLabel={t('comparison.yes')} /></td>
-                                    <td className="py-3 px-4"><ComparisonCell value={row.spreadsheet} yesLabel={t('comparison.yes')} /></td>
-                                    <td className="py-3 px-4"><ComparisonCell value={row.other} yesLabel={t('comparison.yes')} /></td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
+                <div className="mt-12">
+                    <FeaturesBentoGrid items={bentoItems} />
+                </div>
+            </section>
+
+            <section className="border-t border-slate-200/80 py-16 md:py-24">
+                <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] lg:items-start">
+                    <div>
+                        <div className="animate-scroll-blur-in max-w-3xl">
+                            <h2 className="text-3xl font-black tracking-tight text-slate-950 md:text-5xl">
+                                {t('workflow.title')}
+                            </h2>
+                            <p className="mt-4 max-w-2xl text-base leading-relaxed text-slate-600 md:text-lg">
+                                {t('workflow.subtitle')}
+                            </p>
+                        </div>
+
+                        <div className="mt-10 grid gap-4">
+                            {workflowSteps.map((step, index) => {
+                                const IconComponent = workflowIconMap[index] || Sparkle;
+                                return (
+                                    <article
+                                        key={`${step.step}-${step.title}`}
+                                        className="animate-scroll-fade-up rounded-[18px] border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/70 transition-transform hover:-translate-y-0.5"
+                                        style={{ animationDelay: `${index * 90}ms` }}
+                                    >
+                                        <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+                                            <div className="flex items-center gap-3">
+                                                <div className="flex size-11 items-center justify-center rounded-lg border border-slate-200 bg-slate-50 text-accent-700">
+                                                    <IconComponent size={18} weight="duotone" />
+                                                </div>
+                                            </div>
+                                            <div className="min-w-0">
+                                                <h3 className="text-lg font-bold text-slate-950">{step.title}</h3>
+                                                <p className="mt-2 text-sm leading-relaxed text-slate-600 md:text-base">
+                                                    {step.description}
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </article>
+                                );
+                            })}
+                        </div>
+                    </div>
+
+                    <Card className="animate-scroll-scale-in overflow-hidden rounded-[18px] border-slate-200 bg-white py-0 shadow-sm shadow-slate-200/70">
+                        <div className="relative h-56 overflow-hidden border-b border-slate-200/80">
+                            <img
+                                src="/images/trip-maps/japan-spring.png"
+                                alt=""
+                                aria-hidden="true"
+                                className="h-full w-full object-cover"
+                                loading="lazy"
+                            />
+                        </div>
+
+                        <CardContent className="px-6 pb-6 pt-6">
+                            <p className="text-xl font-bold text-slate-950">{workflowGlance.title}</p>
+                            <p className="text-sm leading-relaxed text-slate-600">
+                                {workflowGlance.description}
+                            </p>
+                            <div className="mt-5 grid gap-3">
+                                {workflowGlance.items.map((item) => (
+                                    <div
+                                        key={item}
+                                        className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700"
+                                    >
+                                        {item}
+                                    </div>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
                 </div>
             </section>
 
             <section className="pb-16 md:pb-24 animate-scroll-scale-in">
-                <div className="relative rounded-3xl bg-gradient-to-br from-accent-600 to-accent-800 px-8 py-14 text-center md:px-16 md:py-20 overflow-hidden">
-                    <div className="pointer-events-none absolute -top-20 -right-20 h-60 w-60 rounded-full bg-white/10 blur-[60px]" />
-                    <div className="pointer-events-none absolute -bottom-16 -left-16 h-48 w-48 rounded-full bg-accent-400/20 blur-[50px]" />
-
-                    <h2 className="relative text-3xl font-black tracking-tight text-white md:text-5xl" style={{ fontFamily: 'var(--tf-font-heading)' }}>
+                <div className="relative overflow-hidden rounded-[18px] border border-slate-200 bg-slate-50 px-8 py-14 text-center shadow-sm shadow-slate-200/70 md:px-16 md:py-20">
+                    <h2
+                        className="relative text-3xl font-black tracking-tight text-slate-950 md:text-5xl"
+                        style={{ fontFamily: 'var(--tf-font-heading)' }}
+                    >
                         {t('cta.title')}
                     </h2>
-                    <p className="relative mx-auto mt-4 max-w-xl text-base text-accent-100 md:text-lg">
+                    <p className="relative mx-auto mt-4 max-w-2xl text-base leading-relaxed text-slate-600 md:text-lg">
                         {t('cta.subtitle')}
                     </p>
                     <Link
                         to={buildPath('createTrip')}
                         onClick={() => trackEvent('features__bottom_cta')}
-                        className="relative mt-8 inline-block rounded-2xl bg-white px-8 py-3.5 text-base font-bold text-accent-700 shadow-lg transition-all hover:shadow-xl hover:bg-accent-50 hover:scale-[1.03] active:scale-[0.98]"
+                        onMouseEnter={prewarmCreateTripRoute}
+                        onFocus={prewarmCreateTripRoute}
+                        onTouchStart={prewarmCreateTripRoute}
+                        className="relative mt-8 inline-flex items-center justify-center rounded-lg bg-accent-600 px-8 py-3.5 text-base font-bold text-white shadow-sm shadow-accent-200 transition-all hover:-translate-y-0.5 hover:bg-accent-700 hover:shadow-md active:translate-y-0"
                         {...getAnalyticsDebugAttributes('features__bottom_cta')}
                     >
                         {t('cta.button')}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cobe:
+        specifier: 2.0.0
+        version: 2.0.0
       diff:
         specifier: ^8.0.3
         version: 8.0.3
@@ -3705,6 +3708,9 @@ packages:
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
+
+  cobe@2.0.0:
+    resolution: {integrity: sha512-jEnMaFBEPiH4y/4mIp/gegs1x/uD2+U96Rm2CZkzdketfxEuExiErAhMpr+aDZRaEnDlMTwyhPX2bX87cL8iHA==}
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -11537,6 +11543,8 @@ snapshots:
 
   cluster-key-slot@1.1.2:
     optional: true
+
+  cobe@2.0.0: {}
 
   code-block-writer@13.0.3: {}
 

--- a/services/runtimeLocationService.ts
+++ b/services/runtimeLocationService.ts
@@ -1,0 +1,197 @@
+import {
+  readSessionStorageItem,
+  removeSessionStorageItem,
+  writeSessionStorageItem,
+} from './browserStorageService';
+import {
+  buildRuntimeLocationPayload,
+  createEmptyRuntimeLocation,
+  normalizeRuntimeLocationPayload,
+  type RuntimeLocationPayload,
+} from '../shared/runtimeLocation';
+
+export interface RuntimeLocationStoreSnapshot extends RuntimeLocationPayload {
+  loading: boolean;
+}
+
+export const RUNTIME_LOCATION_SESSION_STORAGE_KEY = 'tf_runtime_location_v1';
+export const RUNTIME_LOCATION_EVENT = 'tf:runtime-location';
+export const RUNTIME_LOCATION_ENDPOINT = '/api/runtime/location';
+
+const buildDefaultSnapshot = (): RuntimeLocationStoreSnapshot => ({
+  ...buildRuntimeLocationPayload({
+    source: 'unavailable',
+    fetchedAt: null,
+    location: createEmptyRuntimeLocation(),
+  }),
+  loading: false,
+});
+
+const isBrowser = (): boolean => typeof window !== 'undefined';
+
+const readStoredPayload = (): RuntimeLocationPayload | null => {
+  if (!isBrowser()) return null;
+  try {
+    const raw = readSessionStorageItem(RUNTIME_LOCATION_SESSION_STORAGE_KEY);
+    if (!raw) return null;
+    return normalizeRuntimeLocationPayload(JSON.parse(raw), 'unavailable');
+  } catch {
+    return null;
+  }
+};
+
+const persistPayload = (payload: RuntimeLocationPayload | null): void => {
+  if (!isBrowser()) return;
+  try {
+    if (!payload) {
+      removeSessionStorageItem(RUNTIME_LOCATION_SESSION_STORAGE_KEY);
+      return;
+    }
+    writeSessionStorageItem(RUNTIME_LOCATION_SESSION_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Ignore storage failures so runtime lookups stay non-blocking.
+  }
+};
+
+let inFlightRuntimeLocationPromise: Promise<RuntimeLocationStoreSnapshot> | null = null;
+let runtimeLocationSnapshot: RuntimeLocationStoreSnapshot = (() => {
+  const stored = readStoredPayload();
+  if (!stored) return buildDefaultSnapshot();
+  return {
+    ...stored,
+    source: 'session-cache',
+    loading: false,
+  };
+})();
+
+const emitRuntimeLocationSnapshot = () => {
+  if (!isBrowser()) return;
+  window.dispatchEvent(new CustomEvent<RuntimeLocationStoreSnapshot>(RUNTIME_LOCATION_EVENT, {
+    detail: runtimeLocationSnapshot,
+  }));
+};
+
+const setRuntimeLocationSnapshot = (
+  next: RuntimeLocationStoreSnapshot,
+  options?: { persist?: boolean },
+): RuntimeLocationStoreSnapshot => {
+  runtimeLocationSnapshot = next;
+  if (options?.persist !== false) {
+    if (next.source === 'error') {
+      persistPayload(null);
+    } else {
+      persistPayload({
+        available: next.available,
+        source: next.source === 'session-cache' ? 'netlify-context' : next.source,
+        fetchedAt: next.fetchedAt,
+        location: next.location,
+      });
+    }
+  }
+  emitRuntimeLocationSnapshot();
+  return runtimeLocationSnapshot;
+};
+
+const normalizeStoreSnapshot = (
+  payload: unknown,
+  fallbackSource: RuntimeLocationPayload['source'],
+): RuntimeLocationStoreSnapshot => ({
+  ...normalizeRuntimeLocationPayload(payload, fallbackSource),
+  loading: false,
+});
+
+const createLoadingSnapshot = (): RuntimeLocationStoreSnapshot => ({
+  ...runtimeLocationSnapshot,
+  loading: true,
+});
+
+const fetchRuntimeLocation = async (
+  fetchImpl: typeof fetch = fetch,
+): Promise<RuntimeLocationStoreSnapshot> => {
+  try {
+    const response = await fetchImpl(RUNTIME_LOCATION_ENDPOINT, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+      },
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      return normalizeStoreSnapshot({
+        available: false,
+        source: 'unavailable',
+        fetchedAt: new Date().toISOString(),
+        location: createEmptyRuntimeLocation(),
+      }, 'unavailable');
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('application/json')) {
+      return normalizeStoreSnapshot({
+        available: false,
+        source: 'unavailable',
+        fetchedAt: new Date().toISOString(),
+        location: createEmptyRuntimeLocation(),
+      }, 'unavailable');
+    }
+
+    const payload = await response.json();
+    return normalizeStoreSnapshot(payload, 'error');
+  } catch {
+    return normalizeStoreSnapshot({
+      available: false,
+      source: 'error',
+      fetchedAt: new Date().toISOString(),
+      location: createEmptyRuntimeLocation(),
+    }, 'error');
+  }
+};
+
+export const getRuntimeLocationSnapshot = (): RuntimeLocationStoreSnapshot => runtimeLocationSnapshot;
+
+export const subscribeRuntimeLocation = (
+  listener: (snapshot: RuntimeLocationStoreSnapshot) => void,
+): (() => void) => {
+  listener(runtimeLocationSnapshot);
+  if (!isBrowser()) return () => undefined;
+
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent<RuntimeLocationStoreSnapshot | undefined>).detail;
+    listener(detail ?? runtimeLocationSnapshot);
+  };
+
+  window.addEventListener(RUNTIME_LOCATION_EVENT, handler as EventListener);
+  return () => {
+    window.removeEventListener(RUNTIME_LOCATION_EVENT, handler as EventListener);
+  };
+};
+
+export const ensureRuntimeLocationLoaded = async (
+  fetchImpl: typeof fetch = fetch,
+): Promise<RuntimeLocationStoreSnapshot> => {
+  if (runtimeLocationSnapshot.source === 'session-cache') return runtimeLocationSnapshot;
+  if (runtimeLocationSnapshot.loading && inFlightRuntimeLocationPromise) return inFlightRuntimeLocationPromise;
+
+  setRuntimeLocationSnapshot(createLoadingSnapshot(), { persist: false });
+  inFlightRuntimeLocationPromise = fetchRuntimeLocation(fetchImpl)
+    .then((next) => setRuntimeLocationSnapshot(next))
+    .finally(() => {
+      inFlightRuntimeLocationPromise = null;
+    });
+
+  return inFlightRuntimeLocationPromise;
+};
+
+export const refreshRuntimeLocation = async (
+  fetchImpl: typeof fetch = fetch,
+): Promise<RuntimeLocationStoreSnapshot> => {
+  setRuntimeLocationSnapshot(createLoadingSnapshot(), { persist: false });
+  inFlightRuntimeLocationPromise = fetchRuntimeLocation(fetchImpl)
+    .then((next) => setRuntimeLocationSnapshot(next))
+    .finally(() => {
+      inFlightRuntimeLocationPromise = null;
+    });
+
+  return inFlightRuntimeLocationPromise;
+};

--- a/shared/runtimeLocation.ts
+++ b/shared/runtimeLocation.ts
@@ -1,0 +1,143 @@
+export interface RuntimeLocation {
+  city: string | null;
+  countryCode: string | null;
+  countryName: string | null;
+  subdivisionCode: string | null;
+  subdivisionName: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  timezone: string | null;
+  postalCode: string | null;
+}
+
+export type RuntimeLocationSource = 'netlify-context' | 'session-cache' | 'unavailable' | 'error';
+
+export interface RuntimeLocationPayload {
+  available: boolean;
+  source: RuntimeLocationSource;
+  fetchedAt: string | null;
+  location: RuntimeLocation;
+}
+
+const EMPTY_LOCATION: RuntimeLocation = {
+  city: null,
+  countryCode: null,
+  countryName: null,
+  subdivisionCode: null,
+  subdivisionName: null,
+  latitude: null,
+  longitude: null,
+  timezone: null,
+  postalCode: null,
+};
+
+const asNullableString = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const asNullableNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => (
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+);
+
+const hasMeaningfulLocationValue = (location: RuntimeLocation): boolean => (
+  Boolean(
+    location.city
+    || location.countryCode
+    || location.countryName
+    || location.subdivisionCode
+    || location.subdivisionName
+    || location.timezone
+    || location.postalCode
+    || location.latitude !== null
+    || location.longitude !== null
+  )
+);
+
+export const createEmptyRuntimeLocation = (): RuntimeLocation => ({ ...EMPTY_LOCATION });
+
+export const normalizeRuntimeLocation = (value: unknown): RuntimeLocation => {
+  const typed = asRecord(value);
+  if (!typed) return createEmptyRuntimeLocation();
+
+  return {
+    city: asNullableString(typed.city),
+    countryCode: asNullableString(typed.countryCode),
+    countryName: asNullableString(typed.countryName),
+    subdivisionCode: asNullableString(typed.subdivisionCode),
+    subdivisionName: asNullableString(typed.subdivisionName),
+    latitude: asNullableNumber(typed.latitude),
+    longitude: asNullableNumber(typed.longitude),
+    timezone: asNullableString(typed.timezone),
+    postalCode: asNullableString(typed.postalCode),
+  };
+};
+
+export const normalizeRuntimeLocationPayload = (
+  value: unknown,
+  fallbackSource: RuntimeLocationSource = 'unavailable',
+): RuntimeLocationPayload => {
+  const typed = asRecord(value);
+  const normalizedLocation = normalizeRuntimeLocation(typed?.location);
+  const normalizedFetchedAt = asNullableString(typed?.fetchedAt);
+  const normalizedSourceRaw = asNullableString(typed?.source);
+  const normalizedSource: RuntimeLocationSource = (
+    normalizedSourceRaw === 'netlify-context'
+    || normalizedSourceRaw === 'session-cache'
+    || normalizedSourceRaw === 'unavailable'
+    || normalizedSourceRaw === 'error'
+  )
+    ? normalizedSourceRaw
+    : fallbackSource;
+
+  const explicitAvailable = typeof typed?.available === 'boolean' ? typed.available : null;
+  const available = explicitAvailable ?? hasMeaningfulLocationValue(normalizedLocation);
+
+  return {
+    available,
+    source: available
+      ? normalizedSource
+      : (
+        normalizedSource === 'session-cache' || normalizedSource === 'unavailable' || normalizedSource === 'error'
+          ? normalizedSource
+          : fallbackSource
+      ),
+    fetchedAt: normalizedFetchedAt,
+    location: normalizedLocation,
+  };
+};
+
+export const buildRuntimeLocationPayload = (params: {
+  source: RuntimeLocationSource;
+  fetchedAt?: string | null;
+  location?: RuntimeLocation;
+}): RuntimeLocationPayload => {
+  const location = params.location || createEmptyRuntimeLocation();
+  const available = hasMeaningfulLocationValue(location);
+  return {
+    available,
+    source: available
+      ? params.source
+      : (
+        params.source === 'session-cache' || params.source === 'error'
+          ? params.source
+          : 'unavailable'
+      ),
+    fetchedAt: asNullableString(params.fetchedAt) || null,
+    location,
+  };
+};

--- a/styles/deferred-routes.css
+++ b/styles/deferred-routes.css
@@ -13,7 +13,9 @@
 @source "../components/marketing/EarlyAccessBanner.tsx";
 @source "../components/marketing/TranslationNoticeBanner.tsx";
 @source "../components/marketing/SiteFooter.tsx";
+@source "../components/marketing/features/**/*.tsx";
 @source "../components/flags/FlagIcon.tsx";
+@source "../components/ui/card.tsx";
 @source "../components/admin/**/*.tsx";
 @source "../node_modules/@tremor/react/dist/**/*.{js,cjs}";
 @source "../pages/Admin*.tsx";

--- a/test/browser/marketing/FeaturesPage.browser.test.tsx
+++ b/test/browser/marketing/FeaturesPage.browser.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import featuresLocale from '../../../locales/en/features.json';
+
+const trackEventMock = vi.fn();
+const warmRouteAssetsMock = vi.fn();
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+const { runtimeLocationSnapshot } = vi.hoisted(() => ({
+    runtimeLocationSnapshot: {
+        available: false,
+        source: 'unavailable' as const,
+        fetchedAt: null,
+        loading: false,
+        location: {
+            city: null,
+            countryCode: null,
+            countryName: null,
+            subdivisionCode: null,
+            subdivisionName: null,
+            latitude: null,
+            longitude: null,
+            timezone: null,
+            postalCode: null,
+        },
+    },
+}));
+
+vi.mock('cobe', () => ({
+    default: () => {
+        throw new Error('webgl unavailable');
+    },
+}));
+
+vi.mock('../../../components/marketing/MarketingLayout', () => ({
+    MarketingLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../../services/analyticsService', () => ({
+    trackEvent: (...args: unknown[]) => trackEventMock(...args),
+    getAnalyticsDebugAttributes: () => ({}),
+}));
+
+vi.mock('../../../services/navigationPrefetch', () => ({
+    warmRouteAssets: (...args: unknown[]) => warmRouteAssetsMock(...args),
+}));
+
+vi.mock('../../../services/runtimeLocationService', () => ({
+    getRuntimeLocationSnapshot: () => runtimeLocationSnapshot,
+    ensureRuntimeLocationLoaded: vi.fn().mockResolvedValue(runtimeLocationSnapshot),
+    subscribeRuntimeLocation: () => () => undefined,
+}));
+
+const getNestedValue = (key: string): unknown => key.split('.').reduce<unknown>((current, part) => {
+    if (current && typeof current === 'object' && part in (current as Record<string, unknown>)) {
+        return (current as Record<string, unknown>)[part];
+    }
+    return undefined;
+}, featuresLocale as unknown);
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string, options?: { returnObjects?: boolean }) => {
+            const value = getNestedValue(key);
+            if (options?.returnObjects) return value;
+            return typeof value === 'string' ? value : key;
+        },
+        i18n: {
+            language: 'en',
+            resolvedLanguage: 'en',
+        },
+    }),
+}));
+
+import { FeaturesPage } from '../../../pages/FeaturesPage';
+
+describe('pages/FeaturesPage', () => {
+    beforeEach(() => {
+        cleanup();
+        trackEventMock.mockReset();
+        warmRouteAssetsMock.mockReset();
+        HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as typeof HTMLCanvasElement.prototype.getContext;
+    });
+
+    afterEach(() => {
+        cleanup();
+        HTMLCanvasElement.prototype.getContext = originalGetContext;
+    });
+
+    it('renders the new hero CTAs and tracks hero clicks', () => {
+        render(
+            <MemoryRouter initialEntries={['/features']}>
+                <FeaturesPage />
+            </MemoryRouter>
+        );
+
+        const startPlanningCta = screen.getAllByRole('link', { name: featuresLocale.hero.primaryCta })[0];
+        const seeExamplesCta = screen.getByRole('link', { name: featuresLocale.hero.secondaryCta });
+
+        fireEvent.click(startPlanningCta);
+        fireEvent.click(seeExamplesCta);
+
+        expect(trackEventMock).toHaveBeenCalledWith('features__hero_cta--start_planning');
+        expect(trackEventMock).toHaveBeenCalledWith('features__hero_cta--see_examples');
+    });
+
+    it('shows the globe fallback card when interactive globe setup fails', async () => {
+        render(
+            <MemoryRouter initialEntries={['/features']}>
+                <FeaturesPage />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByRole('heading', { name: /ready to go/i })).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(screen.getByText(featuresLocale.globe.fallbackTitle)).toBeInTheDocument();
+        });
+
+        expect(screen.getByText(featuresLocale.globe.fallbackDescription)).toBeInTheDocument();
+    });
+});

--- a/test/browser/marketing/globeProjection.test.ts
+++ b/test/browser/marketing/globeProjection.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getGlobeRotationForLocation,
+    projectGlobeLocation,
+    type GlobeProjectionConfig,
+} from '../../../components/marketing/features/globeProjection';
+
+const projectionConfig: GlobeProjectionConfig = {
+    width: 520,
+    height: 520,
+    phi: -1.42,
+    theta: 0.14,
+    scale: 0.94,
+    offset: [0, 18],
+    markerElevation: 0.1,
+};
+
+describe('projectGlobeLocation', () => {
+    it('starts with Europe-facing markers more visible than East Asia markers', () => {
+        const lisbon = projectGlobeLocation([38.7223, -9.1393], projectionConfig);
+        const tokyo = projectGlobeLocation([35.6762, 139.6503], projectionConfig);
+
+        expect(lisbon.visible).toBe(true);
+        expect(tokyo.visible).toBe(false);
+        expect(lisbon.depth).toBeGreaterThan(tokyo.depth);
+    });
+
+    it('fades a marker out when the globe rotates it behind the sphere', () => {
+        const front = projectGlobeLocation([38.7223, -9.1393], projectionConfig);
+        const back = projectGlobeLocation([38.7223, -9.1393], {
+            ...projectionConfig,
+            phi: Math.PI + projectionConfig.phi,
+        });
+
+        expect(front.visible).toBe(true);
+        expect(back.visible).toBe(false);
+        expect(front.depth).toBeGreaterThan(0);
+        expect(back.depth).toBeLessThan(0);
+    });
+
+    it('computes an initial rotation that centers Europe-facing origins on the globe', () => {
+        const hamburgRotation = getGlobeRotationForLocation([53.5511, 9.9937]);
+        const hamburg = projectGlobeLocation([53.5511, 9.9937], {
+            ...projectionConfig,
+            phi: hamburgRotation.phi,
+            theta: hamburgRotation.theta,
+        });
+        const losAngeles = projectGlobeLocation([34.0522, -118.2437], {
+            ...projectionConfig,
+            phi: hamburgRotation.phi,
+            theta: hamburgRotation.theta,
+        });
+
+        expect(hamburg.visible).toBe(true);
+        expect(hamburg.depth).toBeGreaterThan(0.65);
+        expect(hamburg.depth).toBeGreaterThan(losAngeles.depth);
+        expect(hamburg.x).toBeGreaterThan(210);
+        expect(hamburg.x).toBeLessThan(310);
+    });
+});

--- a/test/browser/runtimeLocationService.browser.test.ts
+++ b/test/browser/runtimeLocationService.browser.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const buildResponse = (payload: unknown) => new Response(JSON.stringify(payload), {
+  status: 200,
+  headers: {
+    'content-type': 'application/json; charset=utf-8',
+  },
+});
+
+describe('services/runtimeLocationService', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    window.sessionStorage.clear();
+  });
+
+  it('fetches and persists the runtime location snapshot once per session', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(buildResponse({
+      available: true,
+      source: 'netlify-context',
+      fetchedAt: '2026-03-19T10:30:00.000Z',
+      location: {
+        city: 'Berlin',
+        countryCode: 'DE',
+        countryName: 'Germany',
+        subdivisionCode: 'BE',
+        subdivisionName: 'Berlin',
+        latitude: 52.52,
+        longitude: 13.405,
+        timezone: 'Europe/Berlin',
+        postalCode: '10115',
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = await import('../../services/runtimeLocationService');
+    const snapshot = await service.ensureRuntimeLocationLoaded();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(snapshot.loading).toBe(false);
+    expect(snapshot.source).toBe('netlify-context');
+    expect(snapshot.location.city).toBe('Berlin');
+    expect(window.sessionStorage.getItem(service.RUNTIME_LOCATION_SESSION_STORAGE_KEY)).toContain('"city":"Berlin"');
+  });
+
+  it('hydrates from session storage without triggering another fetch', async () => {
+    window.sessionStorage.setItem('tf_runtime_location_v1', JSON.stringify({
+      available: true,
+      source: 'netlify-context',
+      fetchedAt: '2026-03-19T10:30:00.000Z',
+      location: {
+        city: 'Lisbon',
+        countryCode: 'PT',
+        countryName: 'Portugal',
+        subdivisionCode: null,
+        subdivisionName: null,
+        latitude: 38.7223,
+        longitude: -9.1393,
+        timezone: 'Europe/Lisbon',
+        postalCode: null,
+      },
+    }));
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = await import('../../services/runtimeLocationService');
+    const snapshot = await service.ensureRuntimeLocationLoaded();
+
+    expect(snapshot.source).toBe('session-cache');
+    expect(snapshot.location.city).toBe('Lisbon');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('refresh replaces cached session data with the latest endpoint payload', async () => {
+    window.sessionStorage.setItem('tf_runtime_location_v1', JSON.stringify({
+      available: true,
+      source: 'netlify-context',
+      fetchedAt: '2026-03-19T10:30:00.000Z',
+      location: {
+        city: 'Munich',
+        countryCode: 'DE',
+        countryName: 'Germany',
+        subdivisionCode: 'BY',
+        subdivisionName: 'Bavaria',
+        latitude: 48.1372,
+        longitude: 11.5761,
+        timezone: 'Europe/Berlin',
+        postalCode: '80331',
+      },
+    }));
+
+    const fetchMock = vi.fn().mockResolvedValue(buildResponse({
+      available: true,
+      source: 'netlify-context',
+      fetchedAt: '2026-03-19T12:00:00.000Z',
+      location: {
+        city: 'Hamburg',
+        countryCode: 'DE',
+        countryName: 'Germany',
+        subdivisionCode: 'HH',
+        subdivisionName: 'Hamburg',
+        latitude: 53.5511,
+        longitude: 9.9937,
+        timezone: 'Europe/Berlin',
+        postalCode: '20095',
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = await import('../../services/runtimeLocationService');
+    const snapshot = await service.refreshRuntimeLocation();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(snapshot.source).toBe('netlify-context');
+    expect(snapshot.location.city).toBe('Hamburg');
+    expect(window.sessionStorage.getItem(service.RUNTIME_LOCATION_SESSION_STORAGE_KEY)).toContain('"city":"Hamburg"');
+  });
+
+  it('notifies subscribers and the window event bridge when the snapshot updates', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(buildResponse({
+      available: false,
+      source: 'unavailable',
+      fetchedAt: '2026-03-19T12:00:00.000Z',
+      location: {
+        city: null,
+        countryCode: null,
+        countryName: null,
+        subdivisionCode: null,
+        subdivisionName: null,
+        latitude: null,
+        longitude: null,
+        timezone: null,
+        postalCode: null,
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = await import('../../services/runtimeLocationService');
+    const snapshots: string[] = [];
+    const events: string[] = [];
+
+    const unsubscribe = service.subscribeRuntimeLocation((snapshot) => {
+      snapshots.push(`${snapshot.source}:${snapshot.loading ? 'loading' : 'idle'}`);
+    });
+    window.addEventListener(service.RUNTIME_LOCATION_EVENT, ((event: Event) => {
+      const detail = (event as CustomEvent<{ source: string }>).detail;
+      events.push(detail.source);
+    }) as EventListener);
+
+    await service.ensureRuntimeLocationLoaded();
+    unsubscribe();
+
+    expect(snapshots).toContain('unavailable:idle');
+    expect(snapshots).toContain('unavailable:loading');
+    expect(events.at(-1)).toBe('unavailable');
+  });
+});

--- a/test/unit/runtimeLocationEdge.test.ts
+++ b/test/unit/runtimeLocationEdge.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import handler from '../../netlify/edge-functions/runtime-location';
+
+describe('runtime location edge', () => {
+  it('normalizes the Netlify geo context into the public payload', async () => {
+    const response = await handler(new Request('https://travelflow.test/api/runtime/location'), {
+      geo: {
+        city: 'Berlin',
+        country: {
+          code: 'DE',
+          name: 'Germany',
+        },
+        subdivision: {
+          code: 'BE',
+          name: 'Berlin',
+        },
+        latitude: '52.5200',
+        longitude: 13.405,
+        timezone: 'Europe/Berlin',
+        postalCode: '10115',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    await expect(response.json()).resolves.toEqual({
+      available: true,
+      source: 'netlify-context',
+      fetchedAt: expect.any(String),
+      location: {
+        city: 'Berlin',
+        countryCode: 'DE',
+        countryName: 'Germany',
+        subdivisionCode: 'BE',
+        subdivisionName: 'Berlin',
+        latitude: 52.52,
+        longitude: 13.405,
+        timezone: 'Europe/Berlin',
+        postalCode: '10115',
+      },
+    });
+  });
+
+  it('returns an unavailable snapshot when geo data is missing', async () => {
+    const response = await handler(new Request('https://travelflow.test/api/runtime/location'), {});
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      available: false,
+      source: 'unavailable',
+      fetchedAt: expect.any(String),
+      location: {
+        city: null,
+        countryCode: null,
+        countryName: null,
+        subdivisionCode: null,
+        subdivisionName: null,
+        latitude: null,
+        longitude: null,
+        timezone: null,
+        postalCode: null,
+      },
+    });
+  });
+
+  it('rejects non-GET requests', async () => {
+    const response = await handler(new Request('https://travelflow.test/api/runtime/location', {
+      method: 'POST',
+    }), {});
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('allow')).toBe('GET');
+  });
+});


### PR DESCRIPTION
## Summary
- rebuild `/features` around a planning-first globe hero with a custom COBE 2 implementation and animated bento grid
- add runtime location support via `/api/runtime/location` so the globe can start from the visitor location and route outward from that origin
- tighten the globe overlays with smaller multilingual chips, a Thailand SEA preview card, route-specific positioning, and regression coverage for the new behavior

## Testing
- `pnpm exec vitest run test/browser/marketing/FeaturesPage.browser.test.tsx test/browser/marketing/globeProjection.test.ts test/browser/runtimeLocationService.browser.test.ts test/unit/runtimeLocationEdge.test.ts`
- `pnpm i18n:validate`
- `pnpm storage:validate`
- `pnpm updates:validate`
- `pnpm dlx react-doctor@latest . --verbose --diff`
- `pnpm test:core`
