### PR TITLE
Fix the main Netlify deploy and publish the features update

### DIFF
--- a/content/updates/2026-03-19-features-page-globe-redesign.md
+++ b/content/updates/2026-03-19-features-page-globe-redesign.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-03-19-features-page-globe-redesign
-version: v0.0.0
+version: v0.103.0
 title: "Features page now opens with a richer globe-led story"
-date: 2026-03-19
-published_at: 2026-03-19T16:20:00Z
-status: draft
+date: 2026-03-20
+published_at: 2026-03-20T10:33:14Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Rebuilds the features page around a custom interactive globe hero, sharper planning-first copy, and a more polished visual product story."
@@ -16,3 +16,4 @@ summary: "Rebuilds the features page around a custom interactive globe hero, sha
 - [x] [Improved] 📍 The globe now uses the session runtime location to highlight your starting point, draw routes out from it, and keep the travel chips smaller, shorter, and easier to read across all supported languages.
 - [x] [Improved] 🧩 A new animated bento grid now shows how AI itineraries, route editing, crew sharing, and inspiration work together instead of listing features in isolation.
 - [ ] [Internal] 🧪 Added browser coverage for the new hero CTA analytics and the globe fallback path.
+- [ ] [Internal] 🛠️ Fixed a duplicate runtime-location registry entry that blocked the merged release from reaching production.

--- a/lib/legal/cookies.config.ts
+++ b/lib/legal/cookies.config.ts
@@ -568,14 +568,6 @@ export const COOKIE_REGISTRY: CookieRegistry = {
       notes: 'Dynamic key suffix is module-specific.',
     },
     {
-      name: 'tf_runtime_location_v1',
-      purpose: 'Stores the current session runtime location snapshot for geo-aware defaults and debugger diagnostics.',
-      duration: 'Session',
-      provider: 'TravelFlow',
-      storage: 'sessionStorage',
-      notes: 'Approximate Netlify-derived location only; no raw IP is stored.',
-    },
-    {
       name: 'tf_connectivity_banner_dismissed_state_v1',
       purpose: 'Stores per-session dismissal state for outage/connectivity planner banner.',
       duration: 'Session',

--- a/tests/unit/legalCookies.test.ts
+++ b/tests/unit/legalCookies.test.ts
@@ -16,6 +16,14 @@ describe('lib/legal cookie registry', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('registers the runtime location session key exactly once', () => {
+    const runtimeLocationEntries = getAllCookies().filter(
+      (cookie) => cookie.name === 'tf_runtime_location_v1',
+    );
+
+    expect(runtimeLocationEntries).toHaveLength(1);
+  });
+
   it('resolves cookie helpers consistently', () => {
     expect(isCookieRegistered('tf_cookie_consent_choice_v1')).toBe(true);
     expect(getCookieByName('tf_cookie_consent_choice_v1')).toBeDefined();


### PR DESCRIPTION
## Summary
- remove the duplicate `tf_runtime_location_v1` cookie registry entry that breaks the production `pnpm build`
- add a focused regression assertion so the runtime-location key cannot be registered twice again
- publish the globe/features release note so it appears on `/updates` once the fixed deploy reaches production

## Validation
- `pnpm exec vitest run tests/unit/legalCookies.test.ts --reporter=verbose`
- `pnpm storage:validate`
- `pnpm updates:validate`
- `pnpm build:netlify`
