### PR TITLE
Fix features globe origin pulse layering

### DIFF
--- a/components/marketing/features/FeaturesGlobe.tsx
+++ b/components/marketing/features/FeaturesGlobe.tsx
@@ -497,7 +497,7 @@ export const FeaturesGlobe: React.FC = () => {
             onPointerCancel={handlePointerUp}
             style={{ touchAction: 'none' }}
         >
-            <div className="pointer-events-none absolute inset-0 z-0">
+            <div className="pointer-events-none absolute inset-0 z-20">
                 <div
                     ref={(node) => {
                         if (node) overlayRefs.current.set('origin-marker', node);

--- a/content/updates/2026-03-19-features-page-globe-redesign.md
+++ b/content/updates/2026-03-19-features-page-globe-redesign.md
@@ -17,4 +17,5 @@ summary: "Rebuilds the features page around a custom interactive globe hero, sha
 - [x] [Improved] 🧩 A new animated bento grid now shows how AI itineraries, route editing, crew sharing, and inspiration work together instead of listing features in isolation.
 - [ ] [Internal] 🧪 Added browser coverage for the new hero CTA analytics and the globe fallback path.
 - [ ] [Internal] 📱 Tightened the globe hero on small screens, tuned the native COBE arc profile, and removed the laggy origin-marker behavior so the route lines feel cleaner without custom path hacks.
+- [ ] [Internal] 📍 Restored the animated origin pulse above the globe so the runtime starting point stays visible after the mobile polish pass.
 - [ ] [Internal] 🛠️ Fixed a duplicate runtime-location registry entry that blocked the merged release from reaching production.

--- a/test/browser/marketing/FeaturesPage.browser.test.tsx
+++ b/test/browser/marketing/FeaturesPage.browser.test.tsx
@@ -136,4 +136,18 @@ describe('pages/FeaturesPage', () => {
         expect(globe.className).not.toContain('aspect-[1.02/0.98]');
         expect(globe.className).not.toContain('min-h-[480px]');
     });
+
+    it('keeps the origin marker above the globe canvas', () => {
+        render(
+            <MemoryRouter initialEntries={['/features']}>
+                <FeaturesPage />
+            </MemoryRouter>
+        );
+
+        const globe = screen.getByRole('img', { name: featuresLocale.globe.accessibility });
+        const originMarkerLayer = globe.firstElementChild;
+
+        expect(originMarkerLayer).not.toBeNull();
+        expect(originMarkerLayer).toHaveClass('z-20');
+    });
 });


### PR DESCRIPTION
## Summary
- restore the features globe origin pulse above the canvas so the runtime starting point stays visible
- add a browser regression test covering the pulse layer stacking
- record the follow-up in the existing feature release note

## Validation
- pnpm test -- test/browser/marketing/FeaturesPage.browser.test.tsx
- pnpm updates:validate
