### PR TITLE
Fix airport admin lookup retry loop

### DIFF
--- a/content/updates/2026-03-21-airport-reference-nearby-airports-foundation.md
+++ b/content/updates/2026-03-21-airport-reference-nearby-airports-foundation.md
@@ -17,6 +17,7 @@ summary: "Adds a generated commercial-airport reference snapshot, nearby-airport
 - [ ] [Internal] 🗺️ Added a Google city search + map-based airport tester in admin so nearby-airport lookups can be checked visually against manual coordinates or runtime location.
 - [ ] [Internal] 🎛️ Upgraded the admin airport tester with country scoping, same-country lookup mode, and softer map framing so current location plus nearby airports stay easier to inspect together.
 - [ ] [Internal] 🔁 Fixed the admin nearby-airport tester so same-country filtering now refreshes the result list, map, and fake-ticket context together instead of leaving stale cross-country rows behind.
+- [ ] [Internal] 🐞 Fixed the admin nearby-airport tester so failed auto-restored lookups stop retrying in a loop and clear stale nearby-airport results until someone retries manually.
 - [ ] [Internal] 🔗 Added URL-backed filter state for the airport admin workspace so catalog filters and nearby-airport tester settings survive refreshes and can auto-restore a prior lookup.
 - [ ] [Internal] 📌 Defaulted the nearby-airport tester to the user’s runtime location and major commercial hubs so refreshes reopen the same visible search context instead of an empty or broader fallback state.
 - [ ] [Internal] 🧾 Added a fake digital boarding-pass lab in admin so the nearest commercial airport can be previewed as a realistic ticket artifact for future travel surfaces.

--- a/pages/AdminAirportsPage.tsx
+++ b/pages/AdminAirportsPage.tsx
@@ -204,6 +204,10 @@ const buildAirportTesterFilterSignature = (filters: AdminAirportTesterFilters): 
     `${filters.limitInput.trim()}|${filters.minimumServiceTier}|${filters.countryFilter}|${filters.sameCountryOnly ? '1' : '0'}`
 );
 
+const buildAirportTesterLookupAttemptSignature = (filters: AdminAirportTesterFilters): string => (
+    `${filters.latitudeInput.trim()}|${filters.longitudeInput.trim()}|${buildAirportTesterFilterSignature(filters)}`
+);
+
 const areTesterOriginsEqual = (left: TesterOrigin | null, right: TesterOrigin | null): boolean => {
     if (!left && !right) return true;
     if (!left || !right) return false;
@@ -626,8 +630,13 @@ const AdminAirportTester: React.FC<{
     const [lookupError, setLookupError] = useState<string | null>(null);
     const [lookupResult, setLookupResult] = useState<NearbyAirportsResponse | null>(null);
     const [lastLookupFilterSignature, setLastLookupFilterSignature] = useState('');
+    const [lastLookupAttemptSignature, setLastLookupAttemptSignature] = useState('');
     const filterSignature = useMemo(
         () => buildAirportTesterFilterSignature(filters),
+        [filters],
+    );
+    const lookupAttemptSignature = useMemo(
+        () => buildAirportTesterLookupAttemptSignature(filters),
         [filters],
     );
     const effectiveDisplayCountryCode = filters.sameCountryOnly
@@ -756,16 +765,20 @@ const AdminAirportTester: React.FC<{
         setSuggestions([]);
     }, [filters.cityQuery, selectOrigin]);
 
-    const handleLookup = useCallback(async () => {
+    const handleLookup = useCallback(async (options?: { force?: boolean }) => {
         const lat = Number(filters.latitudeInput);
         const lng = Number(filters.longitudeInput);
         if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
             setLookupError('Valid latitude and longitude are required.');
             return;
         }
+        if (!options?.force && lastLookupAttemptSignature === lookupAttemptSignature) {
+            return;
+        }
 
         setLookupLoading(true);
         setLookupError(null);
+        setLastLookupAttemptSignature(lookupAttemptSignature);
         try {
             let effectiveCountryCode = filters.sameCountryOnly ? (origin?.countryCode || null) : (filters.countryFilter || null);
             let nextOrigin = origin || {
@@ -800,26 +813,29 @@ const AdminAirportTester: React.FC<{
             setOrigin(nextOrigin);
             setLastLookupFilterSignature(filterSignature);
         } catch (error) {
+            setLookupResult(null);
             setLookupError(error instanceof Error ? error.message : 'Airport lookup failed.');
         } finally {
             setLookupLoading(false);
             manualLookupInFlightRef.current = false;
         }
-    }, [filterSignature, filters, origin]);
+    }, [filterSignature, filters, lastLookupAttemptSignature, lookupAttemptSignature, origin]);
 
     useEffect(() => {
         const lat = Number(filters.latitudeInput);
         const lng = Number(filters.longitudeInput);
         if (manualLookupInFlightRef.current || !filters.lookupActive || lookupLoading || lookupResult) return;
+        if (lastLookupAttemptSignature === lookupAttemptSignature) return;
         if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
         void handleLookup();
-    }, [filters.latitudeInput, filters.longitudeInput, filters.lookupActive, handleLookup, lookupLoading, lookupResult]);
+    }, [filters.latitudeInput, filters.longitudeInput, filters.lookupActive, handleLookup, lastLookupAttemptSignature, lookupAttemptSignature, lookupLoading, lookupResult]);
 
     useEffect(() => {
         if (!filters.lookupActive || lookupLoading || !lookupResult) return;
         if (lastLookupFilterSignature === filterSignature) return;
+        if (lastLookupAttemptSignature === lookupAttemptSignature) return;
         void handleLookup();
-    }, [filterSignature, filters.lookupActive, handleLookup, lastLookupFilterSignature, lookupLoading, lookupResult]);
+    }, [filterSignature, filters.lookupActive, handleLookup, lastLookupAttemptSignature, lastLookupFilterSignature, lookupAttemptSignature, lookupLoading, lookupResult]);
 
     return (
         <AdminSurfaceCard className="space-y-4">
@@ -1005,7 +1021,7 @@ const AdminAirportTester: React.FC<{
                                     onFiltersChange({ lookupActive: true });
                                 }
                                 manualLookupInFlightRef.current = true;
-                                void handleLookup();
+                                void handleLookup({ force: true });
                             }}
                             disabled={lookupLoading}
                             className="inline-flex h-10 items-center gap-2 rounded-lg bg-accent-600 px-3 text-sm font-semibold text-white transition-colors hover:bg-accent-700 disabled:cursor-not-allowed disabled:opacity-70"

--- a/tests/browser/admin/adminAirportsPage.browser.test.ts
+++ b/tests/browser/admin/adminAirportsPage.browser.test.ts
@@ -494,6 +494,37 @@ describe('AdminAirportsPage', () => {
     });
   });
 
+  it('does not auto-retry a failed restored nearby-airport lookup until the user retries manually', async () => {
+    const user = userEvent.setup();
+    mocks.fetchNearbyAirports
+      .mockRejectedValueOnce(new Error('Nearby airports request failed with 500.'))
+      .mockResolvedValueOnce({
+        origin: { lat: 52.52, lng: 13.405 },
+        dataVersion: '2026-03-21-4086',
+        airports: [
+          {
+            airport: buildAirport(),
+            airDistanceKm: 18.9,
+            rank: 1,
+          },
+        ],
+      });
+
+    renderAdminAirportsPage();
+
+    expect(await screen.findByText('Nearby airports request failed with 500.')).toBeInTheDocument();
+    await new Promise((resolve) => window.setTimeout(resolve, 50));
+    expect(mocks.fetchNearbyAirports).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Nearest airports')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Lookup nearby airports' }));
+
+    await waitFor(() => {
+      expect(mocks.fetchNearbyAirports).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText('Nearest airports')).toBeInTheDocument();
+  });
+
   it('persists airport filters in the URL and restores nearby lookups on refresh', async () => {
     renderAdminAirportsPage([
       '/admin/airports?country=DE&catalogTier=major&nearbyCity=Berlin%2C%20Germany&nearbyLat=52.52&nearbyLng=13.405&nearbyLimit=3&nearbySameCountry=1&nearbyLookup=1',


### PR DESCRIPTION
## Summary
- stop the admin airport tester from auto-retrying the same restored lookup after a failed request
- clear stale nearby-airport results on lookup failure while still allowing an explicit manual retry
- add a browser regression test and note the fix in the existing airport admin release note

## Validation
- `pnpm test -- tests/browser/admin/adminAirportsPage.browser.test.ts` (current script runs the full Vitest suite)
- `pnpm test:core`
- `pnpm dlx react-doctor@latest . --verbose --diff` (warning-only; existing repo-wide findings)
- `pnpm updates:validate` (warning-only canonical version ordering findings)
