### PR TITLE
[codex] Fix mobile navigation and profile quick actions

### DIFF
--- a/components/navigation/MobileMenu.tsx
+++ b/components/navigation/MobileMenu.tsx
@@ -6,7 +6,7 @@ import { NAV_ITEMS } from '../../config/navigation';
 import { LanguageSelect } from './LanguageSelect';
 import { useHasSavedTrips } from '../../hooks/useHasSavedTrips';
 import { getAnalyticsDebugAttributes, trackEvent } from '../../services/analyticsService';
-import { buildLocalizedCreateTripPath, buildLocalizedMarketingPath, buildPath, extractLocaleFromPath, getNamespacesForMarketingPath, getNamespacesForToolPath, isToolRoute } from '../../config/routes';
+import { buildLocalizedCreateTripPath, buildLocalizedMarketingPath, extractLocaleFromPath, getNamespacesForMarketingPath, getNamespacesForToolPath, isToolRoute } from '../../config/routes';
 import { AppLanguage } from '../../types';
 import { applyDocumentLocale, DEFAULT_LOCALE, normalizeLocale } from '../../config/locales';
 import { buildLocalizedLocation } from '../../services/localeRoutingService';
@@ -46,7 +46,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTri
     const { t, i18n } = useTranslation('common');
     const location = useLocation();
     const navigate = useNavigate();
-    const { isAuthenticated, isAdmin, logout, isLoading, profile } = useAuth();
+    const { isAuthenticated, isAdmin, logout, isLoading } = useAuth();
     const { openLoginModal } = useLoginModal();
     const panelRef = useRef<HTMLDivElement | null>(null);
     const closeButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -96,13 +96,6 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTri
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, [isOpen, onClose]);
-
-    const publicProfilePath = useMemo(() => {
-        if (!isAuthenticated) return null;
-        const normalizedUsername = profile?.username?.trim().toLowerCase();
-        if (!normalizedUsername) return null;
-        return buildPath('publicProfile', { username: normalizedUsername });
-    }, [isAuthenticated, profile?.username]);
 
     const handleNavClick = (target: string) => {
         trackEvent(`mobile_nav__${target}`);
@@ -194,20 +187,14 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTri
         return [
             { id: 'profile', path: '/profile', label: 'Profile' },
             { id: 'profile_recent', path: '/profile?tab=recent', label: 'Recent trips' },
-            { id: 'stamps', path: '/profile/stamps', label: 'Stamps' },
             { id: 'settings', path: '/profile/settings', label: 'Settings' },
-            {
-                id: publicProfilePath ? 'public_profile' : 'public_profile_setup',
-                path: publicProfilePath || '/profile/settings',
-                label: 'View public profile',
-            },
         ];
-    }, [isAuthenticated, publicProfilePath]);
+    }, [isAuthenticated]);
 
     return (
         <>
             <div
-                className={`fixed inset-0 z-50 bg-slate-900/50 backdrop-blur-sm transition-opacity duration-300 ${
+                className={`fixed inset-0 z-[1700] bg-slate-900/50 backdrop-blur-sm transition-opacity duration-300 ${
                     isOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
                 }`}
                 aria-hidden="true"
@@ -222,7 +209,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTri
 
             <div
                 ref={panelRef}
-                className={`fixed inset-y-0 right-0 z-50 w-[85vw] max-w-sm bg-white shadow-2xl transition-transform duration-300 ease-out ${
+                className={`fixed inset-y-0 right-0 z-[1700] w-[85vw] max-w-sm bg-white shadow-2xl transition-transform duration-300 ease-out ${
                     isOpen ? 'translate-x-0' : 'translate-x-full'
                 }`}
                 role="dialog"
@@ -248,116 +235,118 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, onMyTri
                             ariaLabel={t('language.label')}
                             value={selectedLocale}
                             onChange={handleLocaleChange}
-                            triggerClassName="h-10 w-full rounded-xl border-slate-200 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 shadow-sm focus:border-accent-400 focus:ring-2 focus:ring-accent-200"
+                            triggerClassName="h-10 w-full rounded-xl border-slate-200 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 shadow-sm"
                             contentAlign="start"
                         />
                     </div>
 
                     <nav className="flex-1 overflow-y-auto border-t border-slate-100 px-4 py-4">
-                        <div className="space-y-2">
-                        {onMyTripsClick && hasTrips ? (
-                            <button
-                                onClick={() => {
-                                    handleNavClick('my_trips');
-                                    onMyTripsClick();
-                                }}
-                                onMouseEnter={onMyTripsIntent}
-                                onFocus={onMyTripsIntent}
-                                onTouchStart={onMyTripsIntent}
-                                className="block w-full rounded-xl bg-accent-600 px-4 py-3 text-center text-base font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
-                                {...mobileNavDebugAttributes('my_trips')}
-                            >
-                                {t('nav.myTrips')}
-                            </button>
-                        ) : (
-                            <NavLink
-                                to={buildLocalizedCreateTripPath(activeLocale)}
-                                onClick={() => handleNavClick('create_trip')}
-                                className="block w-full rounded-xl bg-accent-600 px-4 py-3 text-center text-base font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
-                                {...mobileNavDebugAttributes('create_trip')}
-                            >
-                                {t('nav.createTrip')}
-                            </NavLink>
-                        )}
-                        {accountItems.map((item) => (
-                            <NavLink
-                                key={item.id}
-                                to={item.path}
-                                onClick={() => handleNavClick(item.id)}
-                                className="block w-full rounded-xl border border-slate-200 px-4 py-3 text-center text-base font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900"
-                                {...mobileNavDebugAttributes(item.id)}
-                            >
-                                {item.label}
-                            </NavLink>
-                        ))}
-                        {visibleItems.map((item) => (
-                            <NavLink
-                                key={item.id}
-                                to={buildLocalizedMarketingPath(item.routeKey, activeLocale)}
-                                className={navLinkClass}
-                                onClick={() => handleNavClick(item.id)}
-                                {...mobileNavDebugAttributes(item.id)}
-                            >
-                                {t(item.labelKey)}
-                            </NavLink>
-                        ))}
-                        {isAdmin && (
-                            <NavLink
-                                to="/admin"
-                                onClick={() => handleNavClick('admin_dashboard')}
-                                className="block w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-center text-base font-medium text-slate-700 transition-colors hover:border-slate-300 hover:text-slate-900"
-                                {...mobileNavDebugAttributes('admin_dashboard')}
-                            >
-                                Admin dashboard
-                            </NavLink>
-                        )}
-                        {isAuthenticated ? (
-                            <button
-                                type="button"
-                                onClick={() => {
-                                    void handleLogout();
-                                }}
-                                className="block w-full rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-center text-base font-semibold text-rose-700 transition-colors hover:bg-rose-100"
-                                {...mobileNavDebugAttributes('logout')}
-                            >
-                                Logout
-                            </button>
-                        ) : isLoading ? (
-                            <button
-                                type="button"
-                                disabled
-                                className="inline-flex w-full cursor-wait items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-3 text-center text-base font-medium text-slate-500 opacity-80"
-                                aria-disabled="true"
-                                aria-live="polite"
-                            >
-                                <Loader2 size={16} className="animate-spin" />
-                                {t('nav.login')}
-                            </button>
-                        ) : (
-                            <NavLink
-                                to={buildLocalizedMarketingPath('login', activeLocale)}
-                                onClick={handleLoginClick}
-                                className="block w-full rounded-xl border border-slate-200 px-4 py-3 text-center text-base font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900"
-                                {...mobileNavDebugAttributes('login')}
-                            >
-                                {t('nav.login')}
-                            </NavLink>
-                        )}
-                        <div className="pt-2">
-                            <div className="grid grid-cols-2 gap-2">
-                                {legalNavItems.map((item) => (
+                        <div className="flex min-h-full flex-col">
+                            <div className="space-y-2">
+                                {onMyTripsClick && hasTrips ? (
+                                    <button
+                                        onClick={() => {
+                                            handleNavClick('my_trips');
+                                            onMyTripsClick();
+                                        }}
+                                        onMouseEnter={onMyTripsIntent}
+                                        onFocus={onMyTripsIntent}
+                                        onTouchStart={onMyTripsIntent}
+                                        className="block w-full rounded-xl bg-accent-600 px-4 py-3 text-center text-base font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
+                                        {...mobileNavDebugAttributes('my_trips')}
+                                    >
+                                        {t('nav.myTrips')}
+                                    </button>
+                                ) : (
                                     <NavLink
-                                        key={`mobile-legal-${item.id}`}
-                                        to={buildLocalizedMarketingPath(item.id, activeLocale)}
+                                        to={buildLocalizedCreateTripPath(activeLocale)}
+                                        onClick={() => handleNavClick('create_trip')}
+                                        className="block w-full rounded-xl bg-accent-600 px-4 py-3 text-center text-base font-semibold text-white shadow-sm transition-colors hover:bg-accent-700"
+                                        {...mobileNavDebugAttributes('create_trip')}
+                                    >
+                                        {t('nav.createTrip')}
+                                    </NavLink>
+                                )}
+                                {accountItems.map((item) => (
+                                    <NavLink
+                                        key={item.id}
+                                        to={item.path}
                                         onClick={() => handleNavClick(item.id)}
-                                        className="block rounded-xl border border-slate-200 px-3 py-2 text-center text-sm font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900"
+                                        className="block w-full rounded-xl border border-slate-200 px-4 py-3 text-center text-base font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900"
                                         {...mobileNavDebugAttributes(item.id)}
                                     >
                                         {item.label}
                                     </NavLink>
                                 ))}
+                                {visibleItems.map((item) => (
+                                    <NavLink
+                                        key={item.id}
+                                        to={buildLocalizedMarketingPath(item.routeKey, activeLocale)}
+                                        className={navLinkClass}
+                                        onClick={() => handleNavClick(item.id)}
+                                        {...mobileNavDebugAttributes(item.id)}
+                                    >
+                                        {t(item.labelKey)}
+                                    </NavLink>
+                                ))}
                             </div>
-                        </div>
+                            <div className="mt-auto space-y-3 border-t border-slate-100 pt-4">
+                                {isAdmin && (
+                                    <NavLink
+                                        to="/admin"
+                                        onClick={() => handleNavClick('admin_dashboard')}
+                                        className="block w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-center text-base font-medium text-slate-700 transition-colors hover:border-slate-300 hover:text-slate-900"
+                                        {...mobileNavDebugAttributes('admin_dashboard')}
+                                    >
+                                        Admin dashboard
+                                    </NavLink>
+                                )}
+                                {isAuthenticated ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            void handleLogout();
+                                        }}
+                                        className="block w-full rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-center text-base font-semibold text-rose-700 transition-colors hover:bg-rose-100"
+                                        {...mobileNavDebugAttributes('logout')}
+                                    >
+                                        Logout
+                                    </button>
+                                ) : isLoading ? (
+                                    <button
+                                        type="button"
+                                        disabled
+                                        className="inline-flex w-full cursor-wait items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-3 text-center text-base font-medium text-slate-500 opacity-80"
+                                        aria-disabled="true"
+                                        aria-live="polite"
+                                    >
+                                        <Loader2 size={16} className="animate-spin" />
+                                        {t('nav.login')}
+                                    </button>
+                                ) : (
+                                    <NavLink
+                                        to={buildLocalizedMarketingPath('login', activeLocale)}
+                                        onClick={handleLoginClick}
+                                        className="block w-full rounded-xl border border-slate-200 px-4 py-3 text-center text-base font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900"
+                                        {...mobileNavDebugAttributes('login')}
+                                    >
+                                        {t('nav.login')}
+                                    </NavLink>
+                                )}
+                                <div className="grid grid-cols-2 gap-2">
+                                    {legalNavItems.map((item) => (
+                                        <NavLink
+                                            key={`mobile-legal-${item.id}`}
+                                            to={buildLocalizedMarketingPath(item.id, activeLocale)}
+                                            onClick={() => handleNavClick(item.id)}
+                                            className="block rounded-xl border border-slate-200 px-3 py-2 text-center text-sm font-medium text-slate-600 transition-colors hover:border-slate-300 hover:text-slate-900"
+                                            {...mobileNavDebugAttributes(item.id)}
+                                        >
+                                            {item.label}
+                                        </NavLink>
+                                    ))}
+                                </div>
+                            </div>
                         </div>
                     </nav>
                 </div>

--- a/components/navigation/SiteHeader.tsx
+++ b/components/navigation/SiteHeader.tsx
@@ -189,7 +189,7 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
                                 ariaLabel={t('language.label')}
                                 value={selectedLocale}
                                 onChange={handleLocaleChange}
-                                triggerClassName="h-9 rounded-lg border-slate-200 bg-white py-2 pl-3 pr-3 text-sm font-semibold text-slate-700 shadow-sm transition-colors hover:border-slate-300 focus:border-accent-400 focus:ring-2 focus:ring-accent-200"
+                                triggerClassName="h-9 rounded-lg border-slate-200 bg-white py-2 pl-3 pr-3 text-sm font-semibold text-slate-700 shadow-sm transition-colors hover:border-slate-300"
                             />
                         </div>
                         {isAuthenticated ? (

--- a/components/profile/ProfileTripCard.tsx
+++ b/components/profile/ProfileTripCard.tsx
@@ -159,6 +159,10 @@ export const ProfileTripCard: React.FC<ProfileTripCardProps> = ({
     [trip]
   );
   const displayTitle = trip.title;
+  const tripDetailPath = React.useMemo(
+    () => buildPath('tripDetail', { tripId: trip.id }),
+    [trip.id]
+  );
 
   const cityLanes = React.useMemo(() => (
     cityItems.map((item, index) => ({
@@ -199,6 +203,40 @@ export const ProfileTripCard: React.FC<ProfileTripCardProps> = ({
       style={{ contentVisibility: 'auto', containIntrinsicSize: '420px' }}
     >
       <div className={`relative aspect-[16/9] overflow-hidden ${isGenerationFailed ? 'bg-rose-50' : (isExpired ? 'bg-amber-50' : 'bg-slate-100')}`}>
+        <Link
+          to={tripDetailPath}
+          onClick={() => onOpen(trip)}
+          aria-label={`${labels.open}: ${displayTitle}`}
+          className="absolute inset-0 block cursor-pointer overflow-hidden"
+          {...(analyticsAttrs ? analyticsAttrs('open') : {})}
+        >
+          {!isNearViewport ? (
+            <div className="absolute inset-0 flex items-center justify-center bg-slate-100 text-xs font-medium text-slate-500">
+              {labels.mapLoading}
+            </div>
+          ) : mapUrl && !mapError ? (
+            <>
+              {!mapLoaded && (
+                <div className="absolute inset-0 flex items-center justify-center bg-slate-100 text-xs font-medium text-slate-500">
+                  {labels.mapLoading}
+                </div>
+              )}
+              <img
+                src={mapUrl}
+                alt={`Map preview for ${trip.title}`}
+                className={`h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.01] ${isExpired ? 'opacity-70 grayscale-[0.28]' : ''}`}
+                loading="lazy"
+                onLoad={() => setMapLoaded(true)}
+                onError={() => setMapError(true)}
+              />
+            </>
+          ) : (
+            <div className="flex h-full items-center justify-center px-3 text-center text-xs font-medium text-slate-500">
+              {labels.mapUnavailable}
+            </div>
+          )}
+        </Link>
+
         {isSelectable && onSelectionChange && (
           <div
             className={[
@@ -214,32 +252,6 @@ export const ProfileTripCard: React.FC<ProfileTripCardProps> = ({
               className="h-6 w-6 cursor-pointer rounded-md border border-white/90 bg-white/95 shadow-sm"
               {...(analyticsAttrs ? analyticsAttrs('select') : {})}
             />
-          </div>
-        )}
-
-        {!isNearViewport ? (
-          <div className="absolute inset-0 flex items-center justify-center bg-slate-100 text-xs font-medium text-slate-500">
-            {labels.mapLoading}
-          </div>
-        ) : mapUrl && !mapError ? (
-          <>
-            {!mapLoaded && (
-              <div className="absolute inset-0 flex items-center justify-center bg-slate-100 text-xs font-medium text-slate-500">
-                {labels.mapLoading}
-              </div>
-            )}
-            <img
-              src={mapUrl}
-              alt={`Map preview for ${trip.title}`}
-              className={`h-full w-full object-cover ${isExpired ? 'opacity-70 grayscale-[0.28]' : ''}`}
-              loading="lazy"
-              onLoad={() => setMapLoaded(true)}
-              onError={() => setMapError(true)}
-            />
-          </>
-        ) : (
-          <div className="flex h-full items-center justify-center px-3 text-center text-xs font-medium text-slate-500">
-            {labels.mapUnavailable}
           </div>
         )}
 
@@ -276,7 +288,16 @@ export const ProfileTripCard: React.FC<ProfileTripCardProps> = ({
       )}
 
       <div className="space-y-3 p-4">
-        <h3 className="line-clamp-2 text-2xl font-black leading-tight tracking-tight text-slate-900">{displayTitle}</h3>
+        <h3 className="line-clamp-2 text-2xl font-black leading-tight tracking-tight text-slate-900">
+          <Link
+            to={tripDetailPath}
+            onClick={() => onOpen(trip)}
+            className="inline cursor-pointer transition-colors hover:text-accent-700"
+            {...(analyticsAttrs ? analyticsAttrs('open') : {})}
+          >
+            {displayTitle}
+          </Link>
+        </h3>
 
         <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600">
           <span className="inline-flex items-center gap-1.5">
@@ -377,7 +398,7 @@ export const ProfileTripCard: React.FC<ProfileTripCardProps> = ({
 
       <div className={`${cityLanes.length > 0 || hasCreatorAttribution ? '' : 'border-t border-slate-100'} flex items-center justify-between gap-2 px-4 py-3`}>
         <Link
-          to={buildPath('tripDetail', { tripId: trip.id })}
+          to={tripDetailPath}
           onClick={() => onOpen(trip)}
           title={labels.openTooltip || 'Open trip'}
           aria-label={labels.openTooltip || labels.open}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -13,8 +13,8 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={[
-      'flex h-10 w-full items-center justify-between rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900',
-      'outline-none ring-offset-white placeholder:text-slate-500 focus:ring-2 focus:ring-accent-500 focus:ring-offset-0',
+      'flex h-10 w-full cursor-pointer items-center justify-between rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900',
+      'outline-none ring-offset-white placeholder:text-slate-500 focus-visible:border-accent-400',
       'disabled:cursor-not-allowed disabled:opacity-50',
       className || '',
     ].join(' ')}
@@ -35,7 +35,7 @@ const SelectScrollUpButton = React.forwardRef<
   <SelectPrimitive.ScrollUpButton
     ref={ref}
     className={[
-      'flex cursor-default items-center justify-center py-1 text-slate-600',
+      'flex cursor-pointer items-center justify-center py-1 text-slate-600',
       className || '',
     ].join(' ')}
     {...props}
@@ -52,7 +52,7 @@ const SelectScrollDownButton = React.forwardRef<
   <SelectPrimitive.ScrollDownButton
     ref={ref}
     className={[
-      'flex cursor-default items-center justify-center py-1 text-slate-600',
+      'flex cursor-pointer items-center justify-center py-1 text-slate-600',
       className || '',
     ].join(' ')}
     {...props}
@@ -123,7 +123,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={[
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-2 text-sm text-slate-800 outline-none',
+      'relative flex w-full cursor-pointer select-none items-center rounded-sm py-2 text-sm text-slate-800 outline-none',
       indicatorPosition === 'right' ? 'pl-2 pr-8' : 'pl-8 pr-2',
       'data-[highlighted]:bg-accent-50 data-[highlighted]:text-accent-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className || '',

--- a/content/updates/2026-04-02-mobile-menu-and-profile-preview-interactions.md
+++ b/content/updates/2026-04-02-mobile-menu-and-profile-preview-interactions.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-04-02-mobile-menu-and-profile-preview-interactions
+version: v0.108.0
+title: "Mobile menu and profile preview interactions feel reliable again"
+date: 2026-04-02
+published_at: 2026-04-02T15:59:18Z
+status: published
+notify_in_app: false
+in_app_hours: 24
+summary: "Fixes the mobile navigation drawer, sharpens button affordances with clearer pointer and focus feedback, and makes profile trip previews easier to open."
+---
+
+## Changes
+- [x] [Fixed] 📱 The mobile menu now closes reliably again, keeps admin/logout/footer actions anchored to the bottom, temporarily removes stamps and public-profile shortcuts from the drawer, and restores the translated Create Trip quick action on profile.
+- [x] [Improved] 🧭 Profile trip previews now open directly from the map snapshot and trip title, with clearer hover feedback on clickable headlines.
+- [x] [Improved] 🎯 Buttons and dropdown actions now consistently show a pointer cursor and a larger accent-colored focus treatment across the app shell.
+- [ ] [Internal] 🧪 Added browser regression coverage for the mobile drawer close flow and the new profile preview click targets.

--- a/index.css
+++ b/index.css
@@ -348,6 +348,76 @@ html[lang^="ur-"] {
   }
 }
 
+@layer base {
+  :where(
+    button,
+    [role="button"],
+    [role="menuitem"],
+    [role="option"],
+    [role="checkbox"],
+    [role="radio"],
+    [role="switch"],
+    summary
+  ):not(:disabled):not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+
+  :where(
+    button,
+    [role="button"],
+    [role="menuitem"],
+    [role="option"],
+    [role="checkbox"],
+    [role="radio"],
+    [role="switch"],
+    summary
+  ):is(:disabled, [aria-disabled="true"]) {
+    cursor: not-allowed;
+  }
+
+  :where(
+    a[href],
+    button,
+    input:not([type="hidden"]),
+    textarea,
+    select,
+    summary,
+    [role="button"],
+    [role="menuitem"],
+    [role="option"],
+    [role="checkbox"],
+    [role="radio"],
+    [role="switch"]
+  ) {
+    transition:
+      outline-color 160ms ease,
+      outline-offset 160ms ease,
+      box-shadow 160ms ease,
+      border-color 160ms ease,
+      background-color 160ms ease,
+      color 160ms ease;
+  }
+
+  :where(
+    a[href],
+    button,
+    input:not([type="hidden"]),
+    textarea,
+    select,
+    summary,
+    [role="button"],
+    [role="menuitem"],
+    [role="option"],
+    [role="checkbox"],
+    [role="radio"],
+    [role="switch"]
+  ):focus-visible {
+    outline: 2px solid rgb(var(--tf-accent-rgb) / 0.82);
+    outline-offset: 3px;
+    box-shadow: 0 0 0 5px rgb(var(--tf-accent-rgb) / 0.14);
+  }
+}
+
 input[type="checkbox"] {
   accent-color: var(--tf-accent-500);
 }

--- a/pages/ProfilePage.tsx
+++ b/pages/ProfilePage.tsx
@@ -982,7 +982,7 @@ export const ProfilePage: React.FC = () => {
                             {...getAnalyticsDebugAttributes('profile__shortcut--planner')}
                         >
                             <IdentificationCard size={16} />
-                            {t('common:createTrip')}
+                            {t('nav.createTrip')}
                         </NavLink>
                         <button
                             type="button"

--- a/tests/browser/navigation/mobileMenu.browser.test.ts
+++ b/tests/browser/navigation/mobileMenu.browser.test.ts
@@ -2,6 +2,7 @@
 import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 
 const mocks = vi.hoisted(() => ({
@@ -115,5 +116,51 @@ describe('components/navigation/MobileMenu legal links', () => {
     expect(screen.queryByRole('link', { name: 'Users' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Trips' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'AI Telemetry' })).toBeNull();
+  });
+
+  it('keeps the mobile menu close controls interactive above the sticky header layer', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      React.createElement(
+        MemoryRouter,
+        { initialEntries: ['/trip/example'] },
+        React.createElement(MobileMenu, {
+          isOpen: true,
+          onClose,
+        })
+      )
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Navigation menu' })).toHaveClass('z-[1700]');
+
+    await user.click(screen.getByRole('button', { name: 'Close menu' }));
+    await user.click(screen.getByRole('button', { name: 'Close navigation menu', hidden: true }));
+
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('hides stamps and public-profile shortcuts from the authenticated mobile account section', () => {
+    mocks.isAuthenticated = true;
+    mocks.isAdmin = false;
+    mocks.profile = { username: 'owner' };
+
+    render(
+      React.createElement(
+        MemoryRouter,
+        { initialEntries: ['/profile'] },
+        React.createElement(MobileMenu, {
+          isOpen: true,
+          onClose: vi.fn(),
+        })
+      )
+    );
+
+    expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute('href', '/profile');
+    expect(screen.getByRole('link', { name: 'Recent trips' })).toHaveAttribute('href', '/profile?tab=recent');
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/profile/settings');
+    expect(screen.queryByRole('link', { name: 'Stamps' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'View public profile' })).toBeNull();
   });
 });

--- a/tests/browser/profilePage.browser.test.ts
+++ b/tests/browser/profilePage.browser.test.ts
@@ -86,6 +86,9 @@ vi.mock('react-i18next', () => ({
       if (key === 'sections.highlightsCount') {
         return `${options?.count ?? 0}/3 pinned`;
       }
+      if (key === 'nav.createTrip') {
+        return 'Create Trip';
+      }
       return key;
     },
     i18n: {
@@ -272,7 +275,7 @@ describe('pages/ProfilePage query-driven tabs and sort', () => {
     renderProfilePage('/profile');
 
     await waitFor(() => {
-      expect(screen.getAllByRole('link', { name: /common:createTrip/i }).length).toBeGreaterThan(0);
+      expect(screen.getByRole('link', { name: /create trip/i })).toBeInTheDocument();
     });
   });
 

--- a/tests/browser/profileTripCard.browser.test.ts
+++ b/tests/browser/profileTripCard.browser.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ProfileTripCard } from '../../components/profile/ProfileTripCard';
+import { makeTrip } from '../helpers/tripFixtures';
+
+describe('components/profile/ProfileTripCard', () => {
+  it('opens the trip from both the map preview and the headline link', async () => {
+    const user = userEvent.setup();
+    const trip = makeTrip({
+      id: 'trip-42',
+      title: 'Weekend in Lisbon',
+    });
+    const onOpen = vi.fn();
+
+    render(
+      React.createElement(
+        MemoryRouter,
+        null,
+        React.createElement(ProfileTripCard, {
+          trip,
+          locale: 'en',
+          sourceLabel: 'Saved trip',
+          labels: {
+            open: 'Open trip',
+            favorite: 'Favorite',
+            unfavorite: 'Unfavorite',
+            pin: 'Pin',
+            unpin: 'Unpin',
+            pinnedTag: 'Pinned',
+            mapUnavailable: 'Map unavailable',
+            mapLoading: 'Loading map',
+          },
+          onOpen,
+        })
+      )
+    );
+
+    const mapPreviewLink = screen.getByRole('link', { name: 'Open trip: Weekend in Lisbon' });
+    const titleLink = screen.getByRole('link', { name: 'Weekend in Lisbon' });
+
+    expect(mapPreviewLink).toHaveAttribute('href', '/trip/trip-42');
+    expect(mapPreviewLink).toHaveClass('cursor-pointer');
+    expect(titleLink).toHaveAttribute('href', '/trip/trip-42');
+    expect(titleLink).toHaveClass('hover:text-accent-700');
+
+    await user.click(mapPreviewLink);
+    await user.click(titleLink);
+
+    expect(onOpen).toHaveBeenNthCalledWith(1, trip);
+    expect(onOpen).toHaveBeenNthCalledWith(2, trip);
+  });
+});


### PR DESCRIPTION
## Summary
- fix the mobile menu so close controls stay interactive above the sticky header, keep admin/logout/footer actions pinned to the bottom, and temporarily hide the stamps and public-profile shortcuts
- make profile trip preview cards open from both the map image and the headline, with clearer hover affordance on the title
- restore the translated `Create Trip` quick action on the profile page and standardize pointer/focus treatment for buttons and dropdown actions

## Root cause
- the mobile drawer was rendering beneath a higher z-index header layer, some profile preview affordances were visually styled like links without being fully clickable, and one profile quick action was rendering the raw translation key instead of the intended nav label

## Validation
- `pnpm test:core`
- `pnpm updates:validate`
- `pnpm dlx react-doctor@latest . --verbose --diff`

## Notes
- `pnpm exec tsc --noEmit` still reports an existing repo-wide TypeScript backlog unrelated to this change set
