### PR TITLE
feat(create-trip): adopt midday spans and worktree env sync

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "${repo_root}" ]; then
+  exit 0
+fi
+
+common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -z "${common_dir}" ]; then
+  exit 0
+fi
+
+case "${common_dir}" in
+  /*) common_dir_abs="${common_dir}" ;;
+  *) common_dir_abs="$(cd "${repo_root}/${common_dir}" 2>/dev/null && pwd)" || exit 0 ;;
+esac
+
+source_root="$(cd "${common_dir_abs}/.." 2>/dev/null && pwd)" || exit 0
+
+for name in .env .env.local; do
+  source_path="${source_root}/${name}"
+  target_path="${repo_root}/${name}"
+
+  if [ ! -f "${source_path}" ]; then
+    continue
+  fi
+
+  if [ "${source_path}" = "${target_path}" ]; then
+    continue
+  fi
+
+  cp -fp "${source_path}" "${target_path}"
+done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This repository uses markdown release files as the source of truth for product u
 - For bug fixes, add a regression test that fails on the pre-fix behavior and passes with the fix.
 - Docs-only, copy-only, and style-only changes are exempt from mandatory new tests.
 - For behavioral changes, run `pnpm test:core` before finalizing whenever feasible.
+- In fresh git worktrees, run `pnpm worktree:sync-env` before starting env-dependent tooling if `.env` or `.env.local` is missing. This repo also installs a `post-checkout` hook to copy those files automatically when worktrees are created.
 - For PRs that add new files under `services/` or `config/`, include a corresponding `tests/**` entry in the PR checklist/description.
 - For TripView/route-loader orchestration work, follow `docs/TESTING_PHASE2_SCOPE.md` when planning component/hook regression coverage.
 - Release-note copy in `content/updates/*.md` is exempt from EN/DE style sign-off prompts; do not request bilingual sign-off for release notes unless the user explicitly asks for it.

--- a/CODEX.md
+++ b/CODEX.md
@@ -2,12 +2,13 @@
 
 ## Startup checklist
 1. Read `docs/UPDATE_FORMAT.md`.
-2. If the task changes product behavior, plan release-note updates alongside code changes.
-3. For any locale, translation, or page-routing change, read `docs/I18N_PAGE_WORKFLOW.md`.
-4. For any user-facing text changes (marketing, CTA, planner), read `docs/UX_COPY_GUIDELINES.md`.
-5. For analytics instrumentation, read `docs/ANALYTICS_CONVENTION.md`.
-6. For localized copy placeholders, always use ICU syntax (`{name}`), never `{{name}}` (project uses `i18next-icu`).
-7. For new locale keys, update all active locales (`en`, `es`, `de`, `fr`, `pt`, `ru`, `it`, `pl`, `ko`) and choose namespace intentionally (`common/pages/legal` vs route namespace).
+2. In fresh git worktrees, run `pnpm worktree:sync-env` before env-dependent commands if `.env` or `.env.local` is missing. A repo `post-checkout` hook should usually do this automatically for new worktrees, including Codex-created ones.
+3. If the task changes product behavior, plan release-note updates alongside code changes.
+4. For any locale, translation, or page-routing change, read `docs/I18N_PAGE_WORKFLOW.md`.
+5. For any user-facing text changes (marketing, CTA, planner), read `docs/UX_COPY_GUIDELINES.md`.
+6. For analytics instrumentation, read `docs/ANALYTICS_CONVENTION.md`.
+7. For localized copy placeholders, always use ICU syntax (`{name}`), never `{{name}}` (project uses `i18next-icu`).
+8. For new locale keys, update all active locales (`en`, `es`, `de`, `fr`, `pt`, `ru`, `it`, `pl`, `ko`) and choose namespace intentionally (`common/pages/legal` vs route namespace).
 
 ## Skill usage policy
 - For React performance or refactor work, consult `vercel-react-best-practices` and apply only the rules that materially affect the task.

--- a/components/PrintLayout.tsx
+++ b/components/PrintLayout.tsx
@@ -1,7 +1,8 @@
 import React, { Suspense, lazy } from 'react';
 import { ITrip, ITimelineItem } from '../types';
-import { addDays, DEFAULT_DISTANCE_UNIT, formatDate, formatDistance, getHexFromColorClass, getTripDistanceKm, getTripDuration } from '../utils';
+import { addDays, DEFAULT_DISTANCE_UNIT, formatDate, formatDistance, getHexFromColorClass, getTripDistanceKm } from '../utils';
 import { MapPin, Calendar, Clock, ArrowRight, Hotel, StickyNote } from 'lucide-react';
+import { getTripSpan, getTripSpanFromOffsets } from '../shared/tripSpan';
 import { ItineraryMap } from './ItineraryMap';
 import { CountryInfo } from './CountryInfo';
 import { TransportModeIcon } from './TransportModeIcon';
@@ -61,8 +62,8 @@ const WEEKDAY_HEADERS = [
 // Helper to generate calendar grids
 const CalendarView: React.FC<{ trip: ITrip; onScrollTo: (id: string) => void }> = ({ trip, onScrollTo }) => {
     const startDate = parseLocalDate(trip.startDate);
-    const duration = getTripDuration(trip.items);
-    const endDate = addDays(startDate, duration);
+    const tripSpan = getTripSpan(trip);
+    const endDate = tripSpan.endDate;
     
     // Determine months spanned
     const months: Date[] = [];
@@ -106,13 +107,11 @@ const CalendarView: React.FC<{ trip: ITrip; onScrollTo: (id: string) => void }> 
                  <h3 className="text-xs font-bold uppercase tracking-widest text-gray-400 mb-3 border-b border-gray-100 pb-2">Trip Legend</h3>
                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-2">
                      {cities.map((city, idx) => {
-                         const start = addDays(startDate, city.startDateOffset);
-                         const end = addDays(startDate, city.startDateOffset + city.duration);
-                         const nights = Number(city.duration.toFixed(1));
-                         const days = Math.ceil(city.duration + (city.duration % 1 === 0 ? 1 : 0)); 
-                         const shorthand = `${days}D/${nights}N`;
-                         
-                         const dateStr = `${formatLegendDate(start)} - ${formatLegendDate(end)}`;
+                         const citySpan = getTripSpanFromOffsets(trip.startDate, {
+                             startOffset: city.startDateOffset,
+                             endOffset: city.startDateOffset + city.duration,
+                         });
+                         const dateStr = `${formatLegendDate(citySpan.startDate)} - ${formatLegendDate(citySpan.endDate)}`;
                          const cityColor = getHexFromColorClass(city.color || '');
 
                          return (
@@ -130,7 +129,7 @@ const CalendarView: React.FC<{ trip: ITrip; onScrollTo: (id: string) => void }> 
                                      <div className="font-bold text-gray-800 truncate">{city.title}</div>
                                      <div className="text-gray-400 flex justify-between">
                                          <span>{dateStr}</span>
-                                         <span className="font-mono">{shorthand}</span>
+                                         <span className="font-mono">{citySpan.compactLabel}</span>
                                      </div>
                                  </div>
                              </button>
@@ -252,6 +251,7 @@ export const PrintLayout: React.FC<PrintLayoutProps> = ({
     onExportAllCalendar,
 }) => {
   const tripStartDate = parseLocalDate(trip.startDate);
+  const tripSpan = getTripSpan(trip);
   const cities = trip.items.filter(i => i.type === 'city').sort((a, b) => a.startDateOffset - b.startDateOffset);
   const totalDistanceKm = getTripDistanceKm(trip.items);
   const distanceLabel = totalDistanceKm > 0
@@ -345,8 +345,8 @@ export const PrintLayout: React.FC<PrintLayoutProps> = ({
                         <div>
                             <h1 className="text-4xl font-extrabold tracking-tight mb-2">{trip.title}</h1>
                             <div className="text-gray-500 font-medium flex gap-4">
-                                <span className="flex items-center gap-1"><Calendar size={16}/> {formatDate(tripStartDate)} - {formatDate(addDays(tripStartDate, getTripDuration(trip.items)))}</span>
-                                <span className="flex items-center gap-1"><Clock size={16}/> {Math.ceil(getTripDuration(trip.items))} Days</span>
+                                <span className="flex items-center gap-1"><Calendar size={16}/> {formatDate(tripSpan.startDate)} - {formatDate(tripSpan.endDate)}</span>
+                                <span className="flex items-center gap-1"><Clock size={16}/> {tripSpan.longLabel}</span>
                                 {distanceLabel && (
                                     <span className="flex items-center gap-1"><MapPin size={16}/> {distanceLabel}</span>
                                 )}
@@ -385,8 +385,12 @@ export const PrintLayout: React.FC<PrintLayoutProps> = ({
                 {/* Detailed Itinerary (Subsequent Pages) */}
                 <div className="space-y-12 pt-8 print:pt-4">
                     {cities.map((city, idx) => {
-                        const cityStart = addDays(tripStartDate, city.startDateOffset);
-                        const cityEnd = addDays(tripStartDate, city.startDateOffset + city.duration);
+                        const citySpan = getTripSpanFromOffsets(trip.startDate, {
+                            startOffset: city.startDateOffset,
+                            endOffset: city.startDateOffset + city.duration,
+                        });
+                        const cityStart = citySpan.startDate;
+                        const cityEnd = citySpan.endDate;
                         
                         // Find travel TO this city
                         const arrivalTransport = trip.items.find(i => 
@@ -428,7 +432,7 @@ export const PrintLayout: React.FC<PrintLayoutProps> = ({
                                             <h2 className="text-2xl font-bold text-gray-900">{city.title}</h2>
                                         </div>
                                         <div className="text-gray-500 font-medium ml-6">
-                                            {formatDate(cityStart)} — {formatDate(cityEnd)} <span className="text-gray-300 mx-2">|</span> {Number(city.duration.toFixed(1))} Nights
+                                            {formatDate(cityStart)} — {formatDate(cityEnd)} <span className="text-gray-300 mx-2">|</span> {citySpan.longLabel}
                                         </div>
                                     </div>
                                     <div className="text-4xl font-black text-gray-100 select-none">

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -16,7 +16,7 @@ import { TransportModeIcon } from './TransportModeIcon';
 import { normalizeTransportMode } from '../shared/transportModes';
 import { getExampleCityLaneViewTransitionName } from '../shared/viewTransitionNames';
 import { buildRenderedTimelineDaySlots, buildRenderedTimelineMonths } from './tripview/timelineRenderedSlots';
-import { getTimelineVisualSpan } from '../utils/timelineVisualLayout';
+import { getTimelineVisualCenter, getTimelineVisualRange, getTimelineVisualSpan } from '../utils/timelineVisualLayout';
 
 interface TimelineProps {
   trip: ITrip;
@@ -151,22 +151,14 @@ export const Timeline: React.FC<TimelineProps> = ({
   const extraTimelineWidth = Math.max(0, renderedTimelineWidth - totalWidth);
 
   const tripDayRange = React.useMemo(() => {
-    let minStart = Number.POSITIVE_INFINITY;
-    let maxEnd = Number.NEGATIVE_INFINITY;
-
-    trip.items.forEach((item) => {
-      if (!Number.isFinite(item.startDateOffset) || !Number.isFinite(item.duration)) return;
-      minStart = Math.min(minStart, item.startDateOffset);
-      maxEnd = Math.max(maxEnd, item.startDateOffset + item.duration);
-    });
-
-    if (!Number.isFinite(minStart) || !Number.isFinite(maxEnd) || maxEnd <= minStart) {
+    const visualRange = getTimelineVisualRange(trip.items);
+    if (!visualRange || visualRange.endOffset <= visualRange.startOffset) {
       return { start: 0, end: 0 };
     }
 
     return {
-      start: Math.floor(minStart),
-      end: Math.ceil(maxEnd),
+      start: Math.floor(visualRange.startOffset),
+      end: Math.ceil(visualRange.endOffset),
     };
   }, [trip.items]);
 
@@ -239,10 +231,10 @@ export const Timeline: React.FC<TimelineProps> = ({
   const transferChipLayoutById = React.useMemo(() => {
       const layout = buildHorizontalTransferLaneLayout(
           travelLinks.map((link) => {
-              const fromEnd = link.fromCity.startDateOffset + link.fromCity.duration;
-              const toStart = link.toCity.startDateOffset;
-              const fromX = (fromEnd - visualStartOffset) * pixelsPerDay;
-              const toX = (toStart - visualStartOffset) * pixelsPerDay;
+              const fromCitySpan = getTimelineVisualSpan(link.fromCity);
+              const toCitySpan = getTimelineVisualSpan(link.toCity);
+              const fromX = (fromCitySpan.endOffset - visualStartOffset) * pixelsPerDay;
+              const toX = (toCitySpan.startOffset - visualStartOffset) * pixelsPerDay;
               const segmentStart = Math.min(fromX, toX);
               const segmentEnd = Math.max(fromX, toX);
               const gapWidth = Math.max(2, segmentEnd - segmentStart);
@@ -697,7 +689,7 @@ export const Timeline: React.FC<TimelineProps> = ({
     if (!targetItem || !containerRef.current) return;
 
     const container = containerRef.current;
-    const targetCenter = ((targetItem.startDateOffset - visualStartOffset + (targetItem.duration / 2)) * pixelsPerDay) + 32;
+    const targetCenter = ((getTimelineVisualCenter(targetItem) - visualStartOffset) * pixelsPerDay) + 32;
     const visibleStart = container.scrollLeft + 80;
     const visibleEnd = container.scrollLeft + container.clientWidth - 80;
 
@@ -932,10 +924,10 @@ export const Timeline: React.FC<TimelineProps> = ({
                         style={{ height: `${transferLaneHeightPx}px` }}
                     >
                         {travelLinks.map(link => {
-                            const fromEnd = link.fromCity.startDateOffset + link.fromCity.duration;
-                            const toStart = link.toCity.startDateOffset;
-                            const fromX = (fromEnd - visualStartOffset) * pixelsPerDay;
-                            const toX = (toStart - visualStartOffset) * pixelsPerDay;
+                            const fromCitySpan = getTimelineVisualSpan(link.fromCity);
+                            const toCitySpan = getTimelineVisualSpan(link.toCity);
+                            const fromX = (fromCitySpan.endOffset - visualStartOffset) * pixelsPerDay;
+                            const toX = (toCitySpan.startOffset - visualStartOffset) * pixelsPerDay;
                             const segmentStart = Math.min(fromX, toX);
                             const segmentEnd = Math.max(fromX, toX);
                             const gapWidth = Math.max(2, segmentEnd - segmentStart);

--- a/components/TimelineBlock.tsx
+++ b/components/TimelineBlock.tsx
@@ -117,9 +117,15 @@ export const TimelineBlock: React.FC<TimelineBlockProps> = ({
   );
   const compactVerticalTitleSize = Math.max(9, Math.min(11, size * 0.28));
   const compactHorizontalTitleSize = Math.max(11, Math.min(12.5, compactHorizontalTitleHeightPx * 0.095));
-  const cityDayCount = isCity ? Math.max(1, Math.ceil(item.duration - 0.01)) : 0;
-  const cityNightCount = isCity ? Math.max(0, cityDayCount - 1) : 0;
-  const cityDurationFullLabel = `${cityDayCount} ${cityDayCount === 1 ? 'Day' : 'Days'} / ${cityNightCount} ${cityNightCount === 1 ? 'Night' : 'Nights'}`;
+  const formatCount = (value: number): string => {
+    const rounded = Math.round(value * 10) / 10;
+    return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1).replace(/\.0$/, '');
+  };
+  const cityDayCount = isCity
+    ? Math.max(1, Math.ceil(visualSpan.endOffset - 0.0001) - Math.floor(visualSpan.startOffset))
+    : 0;
+  const cityNightCount = isCity ? Math.max(0, Math.round(Math.max(0, item.duration) * 10) / 10) : 0;
+  const cityDurationFullLabel = `${formatCount(cityDayCount)} ${cityDayCount === 1 ? 'Day' : 'Days'} / ${formatCount(cityNightCount)} ${cityNightCount === 1 ? 'Night' : 'Nights'}`;
   const fallbackCountryFromLocation = item.location
     ? (() => {
         const parts = item.location.split(',').map(part => part.trim()).filter(Boolean);

--- a/components/TripInfoModal.tsx
+++ b/components/TripInfoModal.tsx
@@ -36,7 +36,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
 
 interface TripMetaSummary {
     dateRange: string;
-    totalDaysLabel: string;
+    days: number;
+    nights: number;
     cityCount: number;
     distanceLabel: string | null;
 }
@@ -490,8 +491,11 @@ export const TripInfoModal: React.FC<TripInfoModalProps> = ({
                             <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                                 <SummaryCard label={t('tripView.infoDialog.general.meta.duration')} value={tripMeta.dateRange} />
                                 <SummaryCard
-                                    label={t('tripView.infoDialog.general.meta.totalDays')}
-                                    value={t('tripView.infoDialog.general.meta.totalDaysValue', { count: tripMeta.totalDaysLabel })}
+                                    label={t('tripView.infoDialog.general.meta.tripSpan')}
+                                    value={t('tripView.infoDialog.general.meta.tripSpanValue', {
+                                        days: tripMeta.days,
+                                        nights: tripMeta.nights,
+                                    })}
                                 />
                                 <SummaryCard label={t('tripView.infoDialog.general.meta.cities')} value={tripMeta.cityCount} />
                                 <SummaryCard label={t('tripView.infoDialog.general.meta.totalDistance')} value={tripMeta.distanceLabel || '—'} />

--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -8,6 +8,7 @@ import { DB_ENABLED } from '../config/db';
 import { GoogleMapsLoader } from './GoogleMapsLoader';
 import { BASE_PIXELS_PER_DAY, DEFAULT_CITY_COLOR_PALETTE_ID, DEFAULT_DISTANCE_UNIT, buildShareUrl, formatDistance, getTimelineBounds, getTripDistanceKm, isInternalMapColorModeControlEnabled, normalizeMapColorMode } from '../utils';
 import { buildTripMapLocationContextQueries } from '../shared/tripMapCityResolution';
+import { getTripSpan } from '../shared/tripSpan';
 import { getExampleMapViewTransitionName, getExampleTitleViewTransitionName } from '../shared/viewTransitionNames';
 import { dbGetTrip, type DbTripAccessMetadata } from '../services/dbApi';
 import {
@@ -322,8 +323,9 @@ const normalizeNegativeOffsetsForTrip = (
 
 interface TripMetaSummary {
     dateRange: string;
-    totalDays: number;
-    totalDaysLabel: string;
+    days: number;
+    nights: number;
+    compactSpanLabel: string;
     cityCount: number;
     distanceLabel: string | null;
     summaryLine: string;
@@ -339,14 +341,11 @@ const buildTripMetaSummary = (trip: ITrip): TripMetaSummary => {
         .filter((item) => item.type === 'city')
         .sort((a, b) => a.startDateOffset - b.startDateOffset);
     const cityCount = cityItems.length;
-    const maxEnd = cityItems.reduce((max, city) => Math.max(max, city.startDateOffset + city.duration), 0);
-    const totalDaysRaw = Math.round(maxEnd * 2) / 2;
-    const totalDays = Number.isFinite(totalDaysRaw) ? totalDaysRaw : 0;
-
-    const startDate = new Date(trip.startDate);
-    const endOffsetDays = Math.max(0, Math.ceil(maxEnd) - 1);
-    const endDate = new Date(startDate);
-    endDate.setDate(startDate.getDate() + endOffsetDays);
+    const tripSpan = getTripSpan(trip);
+    const days = tripSpan.days;
+    const nights = tripSpan.nights;
+    const startDate = tripSpan.startDate;
+    const endDate = tripSpan.endDate;
 
     const formatDate = (value: Date) => value.toLocaleDateString(undefined, {
         month: 'short',
@@ -357,7 +356,6 @@ const buildTripMetaSummary = (trip: ITrip): TripMetaSummary => {
         ? formatDate(startDate)
         : `${formatDate(startDate)} – ${formatDate(endDate)}`;
 
-    const totalDaysLabel = totalDays % 1 === 0 ? totalDays.toFixed(0) : totalDays.toFixed(1);
     const citiesLabel = cityCount === 1 ? '1 city' : `${cityCount} cities`;
     const totalDistanceKm = getTripDistanceKm(trip.items);
     const distanceLabel = totalDistanceKm > 0
@@ -367,11 +365,12 @@ const buildTripMetaSummary = (trip: ITrip): TripMetaSummary => {
 
     return {
         dateRange,
-        totalDays,
-        totalDaysLabel,
+        days,
+        nights,
+        compactSpanLabel: tripSpan.compactLabel,
         cityCount,
         distanceLabel,
-        summaryLine: `${dateRange} • ${totalDaysLabel} days • ${citiesLabel}${distancePart}`,
+        summaryLine: `${dateRange} • ${tripSpan.compactLabel} • ${citiesLabel}${distancePart}`,
     };
 };
 
@@ -613,7 +612,7 @@ interface TripViewModalLayerProps {
     generationProgressMessage: string;
     loadingDestinationSummary: string;
     tripDateRange: string;
-    tripTotalDaysLabel: string;
+    tripSpanCompactLabel: string;
     pendingAuthModalStage: 'hidden' | 'loading' | 'locked';
     onContinuePendingAuth: () => void;
     isPendingAuthContinueDisabled: boolean;
@@ -706,7 +705,7 @@ const TripViewModalLayer: React.FC<TripViewModalLayerProps> = ({
     generationProgressMessage,
     loadingDestinationSummary,
     tripDateRange,
-    tripTotalDaysLabel,
+    tripSpanCompactLabel,
     pendingAuthModalStage,
     onContinuePendingAuth,
     isPendingAuthContinueDisabled,
@@ -857,7 +856,7 @@ const TripViewModalLayer: React.FC<TripViewModalLayerProps> = ({
             generationProgressMessage={generationProgressMessage}
             loadingDestinationSummary={loadingDestinationSummary}
             tripDateRange={tripDateRange}
-            tripTotalDaysLabel={tripTotalDaysLabel}
+            tripSpanCompactLabel={tripSpanCompactLabel}
             pendingAuthModalStage={pendingAuthModalStage}
             onContinuePendingAuth={onContinuePendingAuth}
             isPendingAuthContinueDisabled={isPendingAuthContinueDisabled}
@@ -3382,7 +3381,7 @@ const useTripViewRender = ({
                         generationProgressMessage={generationProgressMessage}
                         loadingDestinationSummary={loadingDestinationSummary}
                         tripDateRange={tripMeta.dateRange}
-                        tripTotalDaysLabel={tripMeta.totalDaysLabel}
+                        tripSpanCompactLabel={tripMeta.compactSpanLabel}
                         pendingAuthModalStage={pendingAuthModalStage}
                         onContinuePendingAuth={() => {
                             void handleResolvePendingAuthGeneration();

--- a/components/VerticalTimeline.tsx
+++ b/components/VerticalTimeline.tsx
@@ -7,6 +7,7 @@ import { TransportModeIcon } from './TransportModeIcon';
 import { normalizeTransportMode } from '../shared/transportModes';
 import { getExampleCityLaneViewTransitionName } from '../shared/viewTransitionNames';
 import { buildRenderedTimelineDaySlots, buildRenderedTimelineMonths } from './tripview/timelineRenderedSlots';
+import { getTimelineVisualCenter, getTimelineVisualRange, getTimelineVisualSpan } from '../utils/timelineVisualLayout';
 
 interface VerticalTimelineProps {
   trip: ITrip;
@@ -130,22 +131,14 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
   const extraTimelineHeight = Math.max(0, renderedTimelineHeightTarget - totalHeight);
 
   const tripDayRange = React.useMemo(() => {
-    let minStart = Number.POSITIVE_INFINITY;
-    let maxEnd = Number.NEGATIVE_INFINITY;
-
-    trip.items.forEach((item) => {
-      if (!Number.isFinite(item.startDateOffset) || !Number.isFinite(item.duration)) return;
-      minStart = Math.min(minStart, item.startDateOffset);
-      maxEnd = Math.max(maxEnd, item.startDateOffset + item.duration);
-    });
-
-    if (!Number.isFinite(minStart) || !Number.isFinite(maxEnd) || maxEnd <= minStart) {
+    const visualRange = getTimelineVisualRange(trip.items);
+    if (!visualRange || visualRange.endOffset <= visualRange.startOffset) {
       return { start: 0, end: 0 };
     }
 
     return {
-      start: Math.floor(minStart),
-      end: Math.ceil(maxEnd),
+      start: Math.floor(visualRange.startOffset),
+      end: Math.ceil(visualRange.endOffset),
     };
   }, [trip.items]);
 
@@ -552,7 +545,7 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
     if (!targetItem || !containerRef.current) return;
 
     const container = containerRef.current;
-    const targetCenter = ((targetItem.startDateOffset - visualStartOffset + (targetItem.duration / 2)) * pixelsPerDay) + 32;
+    const targetCenter = ((getTimelineVisualCenter(targetItem, { vertical: true }) - visualStartOffset) * pixelsPerDay) + 32;
     const visibleStart = container.scrollTop + 80;
     const visibleEnd = container.scrollTop + container.clientHeight - 80;
 
@@ -830,10 +823,10 @@ export const VerticalTimeline: React.FC<VerticalTimelineProps> = ({
 
                     <div className="relative min-h-0 flex-1 overflow-visible" ref={travelLaneRef}>
                          {travelLinks.map(link => {
-                             const fromEnd = link.fromCity.startDateOffset + link.fromCity.duration;
-                             const toStart = link.toCity.startDateOffset;
-                             const rawFromBoundaryY = (fromEnd - visualStartOffset) * pixelsPerDay;
-                             const rawToBoundaryY = (toStart - visualStartOffset) * pixelsPerDay;
+                             const fromCitySpan = getTimelineVisualSpan(link.fromCity, { vertical: true });
+                             const toCitySpan = getTimelineVisualSpan(link.toCity, { vertical: true });
+                             const rawFromBoundaryY = (fromCitySpan.endOffset - visualStartOffset) * pixelsPerDay;
+                             const rawToBoundaryY = (toCitySpan.startOffset - visualStartOffset) * pixelsPerDay;
                              const {
                                  connectorTop,
                                  connectorHeight,

--- a/components/profile/ProfileTripCard.tsx
+++ b/components/profile/ProfileTripCard.tsx
@@ -15,13 +15,13 @@ import { isTripExpiredByTimestamp } from '../../config/productLimits';
 import type { AppLanguage, ITrip } from '../../types';
 import { trackEvent } from '../../services/analyticsService';
 import { buildPath } from '../../config/routes';
+import { getTripSpan } from '../../shared/tripSpan';
 import { Checkbox } from '../ui/checkbox';
 import { getTripGenerationState } from '../../services/tripGenerationDiagnosticsService';
 import {
   buildMiniMapUrl,
   formatTripDateRange,
   formatTripSummaryLine,
-  getTripDurationDays,
   getTripCityItems,
   getTripCityStops,
 } from './tripPreviewUtils';
@@ -150,7 +150,7 @@ export const ProfileTripCard: React.FC<ProfileTripCardProps> = ({
   );
   const summaryLine = React.useMemo(() => formatTripSummaryLine(trip, locale), [trip, locale]);
   const dateRange = React.useMemo(() => formatTripDateRange(trip, locale), [trip, locale]);
-  const durationDays = React.useMemo(() => getTripDurationDays(trip), [trip]);
+  const tripSpan = React.useMemo(() => getTripSpan(trip), [trip]);
   const hasCreatorAttribution = showCreatorAttribution && Boolean(creatorHandle) && Boolean(creatorProfilePath);
   const isPublic = trip.showOnPublicProfile !== false;
   const isExpired = trip.status === 'expired' || isTripExpiredByTimestamp(trip.tripExpiresAt);
@@ -302,7 +302,7 @@ export const ProfileTripCard: React.FC<ProfileTripCardProps> = ({
         <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600">
           <span className="inline-flex items-center gap-1.5">
             <Clock size={15} weight="duotone" className="text-accent-500" />
-            {durationDays}
+            {tripSpan.compactLabel}
           </span>
           <span className="inline-flex items-center gap-1.5">
             <MapPin size={15} weight="duotone" className="text-accent-500" />

--- a/components/profile/tripPreviewUtils.ts
+++ b/components/profile/tripPreviewUtils.ts
@@ -8,11 +8,10 @@ import {
 import { getClientMapRuntimeResolution, getMapboxAccessToken } from '../../services/mapRuntimeService';
 import { MAP_RUNTIME_CACHE_KEY_QUERY_PARAM } from '../../shared/mapRuntime';
 import { getMapboxStyleDescriptor } from '../../services/mapRendererVisualStyleService';
-
-interface TripRangeOffsets {
-  startOffset: number;
-  endOffset: number;
-}
+import {
+  getTripRangeOffsets as getSharedTripRangeOffsets,
+  getTripSpan,
+} from '../../shared/tripSpan';
 
 export interface TripCityStop {
   id: string;
@@ -380,62 +379,20 @@ const resolveTripItemColorHex = (value?: string | null): string | null => {
   return resolvedHex;
 };
 
-const parseLocalDate = (dateStr: string): Date => {
-  if (!dateStr) return new Date();
-  const parts = dateStr.split('-').map(Number);
-  if (parts.length === 3 && parts.every((part) => Number.isFinite(part))) {
-    return new Date(parts[0], parts[1] - 1, parts[2]);
-  }
-  const parsed = new Date(dateStr);
-  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
-};
-
-const addDays = (date: Date, days: number): Date => {
-  const next = new Date(date);
-  next.setDate(next.getDate() + days);
-  return next;
-};
-
 export const getTripCityItems = (trip: ITrip): ITimelineItem[] =>
   trip.items
     .filter((item) => item.type === 'city')
     .sort((a, b) => a.startDateOffset - b.startDateOffset);
 
-export const getTripRangeOffsets = (trip: ITrip): TripRangeOffsets => {
-  const cityItems = getTripCityItems(trip);
-  const source = cityItems.length > 0 ? cityItems : trip.items;
-
-  if (source.length === 0) {
-    return { startOffset: 0, endOffset: 1 };
-  }
-
-  let minStart = Number.POSITIVE_INFINITY;
-  let maxEnd = Number.NEGATIVE_INFINITY;
-
-  source.forEach((item) => {
-    if (!Number.isFinite(item.startDateOffset) || !Number.isFinite(item.duration)) return;
-    minStart = Math.min(minStart, item.startDateOffset);
-    maxEnd = Math.max(maxEnd, item.startDateOffset + item.duration);
-  });
-
-  if (!Number.isFinite(minStart) || !Number.isFinite(maxEnd) || maxEnd <= minStart) {
-    return { startOffset: 0, endOffset: 1 };
-  }
-
-  return { startOffset: minStart, endOffset: maxEnd };
-};
+export const getTripRangeOffsets = (trip: ITrip) => getSharedTripRangeOffsets(trip);
 
 export const getTripDateRange = (trip: ITrip): { start: Date; end: Date } => {
-  const baseStart = parseLocalDate(trip.startDate);
-  const range = getTripRangeOffsets(trip);
-  const start = addDays(baseStart, Math.floor(range.startOffset));
-  const end = addDays(baseStart, Math.ceil(range.endOffset) - 1);
-  return { start, end };
+  const tripSpan = getTripSpan(trip);
+  return { start: tripSpan.startDate, end: tripSpan.endDate };
 };
 
 export const getTripDurationDays = (trip: ITrip): number => {
-  const range = getTripRangeOffsets(trip);
-  return Math.max(1, Math.ceil(range.endOffset - range.startOffset));
+  return getTripSpan(trip).days;
 };
 
 export const formatTripDateRange = (trip: ITrip, locale: AppLanguage): string => {
@@ -486,7 +443,7 @@ const buildDirectStaticMapPreviewUrl = (params: URLSearchParams): string | null 
 };
 
 export const formatTripSummaryLine = (trip: ITrip, locale: AppLanguage = 'en'): string => {
-  const days = getTripDurationDays(trip);
+  const tripSpan = getTripSpan(trip);
   const cityCount = getTripCityItems(trip).length;
   const cityLabel = cityCount === 1 ? 'city' : 'cities';
   const totalDistanceKm = getTripDistanceKm(trip.items);
@@ -494,7 +451,7 @@ export const formatTripSummaryLine = (trip: ITrip, locale: AppLanguage = 'en'): 
     ? formatDistance(totalDistanceKm, DEFAULT_DISTANCE_UNIT, { maximumFractionDigits: 0 })
     : null;
   const distancePart = distanceLabel ? ` • ${distanceLabel}` : '';
-  return `${days} ${days === 1 ? 'day' : 'days'} • ${formatTripMonths(trip, locale)} • ${cityCount} ${cityLabel}${distancePart}`;
+  return `${tripSpan.compactLabel} • ${formatTripMonths(trip, locale)} • ${cityCount} ${cityLabel}${distancePart}`;
 };
 
 export const buildMiniMapUrl = (

--- a/components/tripview/TripViewHudOverlays.tsx
+++ b/components/tripview/TripViewHudOverlays.tsx
@@ -26,7 +26,7 @@ interface TripViewHudOverlaysProps {
     generationProgressMessage: string;
     loadingDestinationSummary: string;
     tripDateRange: string;
-    tripTotalDaysLabel: string;
+    tripSpanCompactLabel: string;
     pendingAuthModalStage?: 'hidden' | 'loading' | 'locked';
     onContinuePendingAuth?: () => void;
     isPendingAuthContinueDisabled?: boolean;
@@ -49,7 +49,7 @@ export const TripViewHudOverlays: React.FC<TripViewHudOverlaysProps> = ({
     generationProgressMessage,
     loadingDestinationSummary,
     tripDateRange,
-    tripTotalDaysLabel,
+    tripSpanCompactLabel,
     pendingAuthModalStage = 'hidden',
     onContinuePendingAuth,
     isPendingAuthContinueDisabled = false,
@@ -226,7 +226,7 @@ export const TripViewHudOverlays: React.FC<TripViewHudOverlaysProps> = ({
                                     </div>
                                 </div>
                                 <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
-                                    {loadingDestinationSummary} • {tripDateRange} • {tripTotalDaysLabel} days
+                                    {loadingDestinationSummary} • {tripDateRange} • {tripSpanCompactLabel}
                                 </div>
                             </div>
                         ) : (
@@ -251,7 +251,7 @@ export const TripViewHudOverlays: React.FC<TripViewHudOverlaysProps> = ({
                                     </p>
 
                                     <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
-                                        {loadingDestinationSummary} • {tripDateRange} • {tripTotalDaysLabel} days
+                                        {loadingDestinationSummary} • {tripDateRange} • {tripSpanCompactLabel}
                                     </div>
 
                                     <button
@@ -310,7 +310,7 @@ export const TripViewHudOverlays: React.FC<TripViewHudOverlaysProps> = ({
                             </div>
                         </div>
                         <div className="mt-3 text-xs text-gray-500">
-                            {loadingDestinationSummary} • {tripDateRange} • {tripTotalDaysLabel} days
+                            {loadingDestinationSummary} • {tripDateRange} • {tripSpanCompactLabel}
                         </div>
                         <div className="mt-3 h-1.5 rounded-full bg-gray-100 overflow-hidden">
                             <div className="h-full w-1/2 bg-gradient-to-r from-accent-500 to-accent-600 animate-pulse rounded-full" />
@@ -350,7 +350,7 @@ export const TripViewHudOverlays: React.FC<TripViewHudOverlaysProps> = ({
                                 </p>
 
                                 <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
-                                    {loadingDestinationSummary} • {tripDateRange} • {tripTotalDaysLabel} days
+                                    {loadingDestinationSummary} • {tripDateRange} • {tripSpanCompactLabel}
                                 </div>
 
                                 <div className="mt-5 flex flex-wrap gap-2">

--- a/content/updates/2026-03-10-create-trip-adaptive-wizard-and-full-preferences.md
+++ b/content/updates/2026-03-10-create-trip-adaptive-wizard-and-full-preferences.md
@@ -13,6 +13,7 @@ summary: "Trip creation now starts from what the traveler already knows, carries
 ## Changes
 - [x] [Improved] 🧭 Trip creation now starts by asking what you already know, then reorders the wizard around destinations, dates, or inspiration instead of forcing one fixed flow.
 - [x] [Improved] 👨‍👩‍👧‍👦 Traveler setup, trip style, transport preferences, route constraints, and flexible timing now actively shape routes, activities, and suitability warnings in generated itineraries.
+- [x] [Improved] 🕛 Exact-date trips now assume midday arrival and departure, so trip spans, loading previews, and real timeline stays use half-day boundaries with more accurate labels like 3 days / 2 nights.
 - [x] [Improved] 🧾 The planner now uses stricter itinerary instructions so trip generation is more likely to return the expected JSON structure without losing practical travel guidance.
 - [x] [Fixed] 🗺️ Trip maps now recover missing city markers more reliably by resolving ambiguous stop names like island localities with destination context instead of dropping the route.
 - [x] [Fixed] 🔁 Returning to a claimed trip setup after switching login methods no longer loops claim errors or spams loading/auth modals and warning toasts.
@@ -21,5 +22,6 @@ summary: "Trip creation now starts from what the traveler already knows, carries
 - [x] [Fixed] ✉️ Correcting your email during anonymous sign-up no longer fails just because you reused the same password while upgrading the guest session.
 - [x] [Improved] 🔔 Trip creation now asks whether you want a browser notification before generation starts and can notify you when the itinerary finishes in a background tab.
 - [x] [Improved] ⚠️ Traveler-fit cautions from itinerary generation are now easier to review in trip information, instead of being buried only inside city descriptions.
+- [ ] [Internal] 🧰 Added worktree bootstrap helpers that copy local `.env` and `.env.local` files into active worktrees before dev startup.
 - [ ] [Internal] 🧪 Added an opt-in Playwright auth sandbox and claim-conflict end-to-end coverage so queued-trip login/register handoffs can be tested without real accounts.
 - [ ] [Internal] 🧪 Added shared create-trip draft payloads, benchmark metadata updates, and regression coverage for prompt building, prefill decoding, and the adaptive wizard flow.

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -426,6 +426,8 @@
           "duration": "Zeitraum",
           "totalDays": "Tage gesamt",
           "totalDaysValue": "{count} Tage",
+          "tripSpan": "Tage & Nächte",
+          "tripSpanValue": "{days} Tage / {nights} Nächte",
           "cities": "Städte",
           "totalDistance": "Gesamtdistanz",
           "owner": "Besitzer",

--- a/locales/de/createTrip.json
+++ b/locales/de/createTrip.json
@@ -23,6 +23,7 @@
       "flex": "Flexibles Zeitfenster"
     },
     "summary": "Entwurf: insgesamt {days} Tage.",
+    "summaryExact": "Entwurf: {days} Tage / {nights} Nächte.",
     "labels": {
       "start": "Start",
       "end": "Ende",
@@ -140,6 +141,7 @@
     "destinations": "Reiseziele",
     "emptyDestinations": "Füge Reiseziele hinzu, um die Route zu sehen.",
     "days": "{days} Tage",
+    "daysNights": "{days} Tage / {nights} Nächte",
     "avgPerStop": "Ø {days} pro Stopp",
     "addDestinations": "Reiseziele hinzufügen, um Werte zu berechnen",
     "previewOnly": "Nur Vorschau",
@@ -175,6 +177,7 @@
   "errors": {
     "destinationRequired": "Füge mindestens ein Reiseziel hinzu, bevor du die Reise erstellst.",
     "genericGenerate": "Die Reise konnte nicht erstellt werden. Bitte versuche es erneut.",
+    "minimumNightStay": "Wähle ein Enddatum, das mindestens eine Nacht nach deinem Startdatum liegt.",
     "offlineCreateDisabled": "Trip creation is unavailable while offline. Reconnect and try again."
   },
   "prefillBadge": "Vorausgefüllt aus: {label}",
@@ -257,7 +260,7 @@
         "shoulder": "Nebensaison",
         "off": "Eher unpassende Saison"
       },
-      "exactLength": "{days} Tage",
+      "exactLength": "{days} Tage / {nights} Nächte",
       "flexLength": "Etwa {weeks} Wochen ({days} Tage)"
     },
     "preferences": {

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -426,6 +426,8 @@
           "duration": "Duration",
           "totalDays": "Total days",
           "totalDaysValue": "{count} days",
+          "tripSpan": "Days & nights",
+          "tripSpanValue": "{days} days / {nights} nights",
           "cities": "Cities",
           "totalDistance": "Total distance",
           "owner": "Owner",

--- a/locales/en/createTrip.json
+++ b/locales/en/createTrip.json
@@ -23,6 +23,7 @@
       "flex": "Flexible window"
     },
     "summary": "Draft timeframe: {days} days total.",
+    "summaryExact": "Draft timeframe: {days} days / {nights} nights.",
     "labels": {
       "start": "Start",
       "end": "End",
@@ -140,6 +141,7 @@
     "destinations": "Destinations",
     "emptyDestinations": "Add destinations to preview your route.",
     "days": "{days} days",
+    "daysNights": "{days} days / {nights} nights",
     "avgPerStop": "Avg {days} per stop",
     "addDestinations": "Add destinations to calculate averages",
     "previewOnly": "Preview only",
@@ -175,6 +177,7 @@
   "errors": {
     "destinationRequired": "Add at least one destination before creating your trip.",
     "genericGenerate": "Trip generation failed. Please try again.",
+    "minimumNightStay": "Choose an end date at least one night after your start date.",
     "offlineCreateDisabled": "Trip creation is unavailable while offline. Reconnect and try again."
   },
   "prefillBadge": "Pre-filled from: {label}",
@@ -257,7 +260,7 @@
         "shoulder": "Shoulder season",
         "off": "Off-season risk"
       },
-      "exactLength": "{days} days",
+      "exactLength": "{days} days / {nights} nights",
       "flexLength": "About {weeks} weeks ({days} days)"
     },
     "preferences": {

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -426,6 +426,8 @@
           "duration": "Duration",
           "totalDays": "Total days",
           "totalDaysValue": "{count} days",
+          "tripSpan": "Días y noches",
+          "tripSpanValue": "{days} días / {nights} noches",
           "cities": "Cities",
           "totalDistance": "Total distance",
           "owner": "Owner",

--- a/locales/es/createTrip.json
+++ b/locales/es/createTrip.json
@@ -23,6 +23,7 @@
       "flex": "Ventana flexible"
     },
     "summary": "Periodo provisional: {days} días en total.",
+    "summaryExact": "Periodo provisional: {days} días / {nights} noches.",
     "labels": {
       "start": "Inicio",
       "end": "Fin",
@@ -140,6 +141,7 @@
     "destinations": "Destinos",
     "emptyDestinations": "Añade destinos para previsualizar tu ruta.",
     "days": "{days} días",
+    "daysNights": "{days} días / {nights} noches",
     "avgPerStop": "Prom. {days} por parada",
     "addDestinations": "Añade destinos para calcular promedios",
     "previewOnly": "Solo vista previa",
@@ -175,6 +177,7 @@
   "errors": {
     "destinationRequired": "Añade al menos un destino antes de crear tu viaje.",
     "genericGenerate": "Falló la generación del viaje. Inténtalo de nuevo.",
+    "minimumNightStay": "Elige una fecha de salida que sea al menos una noche después de la fecha de inicio.",
     "offlineCreateDisabled": "Trip creation is unavailable while offline. Reconnect and try again."
   },
   "prefillBadge": "Precargado desde: {label}",
@@ -257,7 +260,7 @@
         "shoulder": "Shoulder season",
         "off": "Off-season risk"
       },
-      "exactLength": "{days} days",
+      "exactLength": "{days} días / {nights} noches",
       "flexLength": "About {weeks} weeks ({days} days)"
     },
     "preferences": {

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -426,6 +426,8 @@
           "duration": "Duration",
           "totalDays": "Total days",
           "totalDaysValue": "{count} days",
+          "tripSpan": "Jours et nuits",
+          "tripSpanValue": "{days} jours / {nights} nuits",
           "cities": "Cities",
           "totalDistance": "Total distance",
           "owner": "Owner",

--- a/locales/fr/createTrip.json
+++ b/locales/fr/createTrip.json
@@ -23,6 +23,7 @@
       "flex": "Fenêtre flexible"
     },
     "summary": "Période provisoire : {days} jours au total.",
+    "summaryExact": "Période provisoire : {days} jours / {nights} nuits.",
     "labels": {
       "start": "Début",
       "end": "Fin",
@@ -140,6 +141,7 @@
     "destinations": "Destinations",
     "emptyDestinations": "Ajoutez des destinations pour prévisualiser votre itinéraire.",
     "days": "{days} jours",
+    "daysNights": "{days} jours / {nights} nuits",
     "avgPerStop": "Moy. {days} par étape",
     "addDestinations": "Ajoutez des destinations pour calculer les moyennes",
     "previewOnly": "Aperçu uniquement",
@@ -175,6 +177,7 @@
   "errors": {
     "destinationRequired": "Ajoutez au moins une destination avant de créer votre voyage.",
     "genericGenerate": "La génération du voyage a échoué. Veuillez réessayer.",
+    "minimumNightStay": "Choisissez une date de fin au moins une nuit après la date de début.",
     "offlineCreateDisabled": "Trip creation is unavailable while offline. Reconnect and try again."
   },
   "prefillBadge": "Prérempli depuis : {label}",
@@ -257,7 +260,7 @@
         "shoulder": "Shoulder season",
         "off": "Off-season risk"
       },
-      "exactLength": "{days} days",
+      "exactLength": "{days} jours / {nights} nuits",
       "flexLength": "About {weeks} weeks ({days} days)"
     },
     "preferences": {

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -426,6 +426,8 @@
           "duration": "Duration",
           "totalDays": "Total days",
           "totalDaysValue": "{count} days",
+          "tripSpan": "Giorni e notti",
+          "tripSpanValue": "{days} giorni / {nights} notti",
           "cities": "Cities",
           "totalDistance": "Total distance",
           "owner": "Owner",

--- a/locales/it/createTrip.json
+++ b/locales/it/createTrip.json
@@ -23,6 +23,7 @@
       "flex": "Finestra flessibile"
     },
     "summary": "Periodo provvisorio: {days} giorni totali.",
+    "summaryExact": "Periodo provvisorio: {days} giorni / {nights} notti.",
     "labels": {
       "start": "Inizio",
       "end": "Fine",
@@ -140,6 +141,7 @@
     "destinations": "Destinazioni",
     "emptyDestinations": "Aggiungi destinazioni per vedere l'anteprima del percorso.",
     "days": "{days} giorni",
+    "daysNights": "{days} giorni / {nights} notti",
     "avgPerStop": "Media {days} per tappa",
     "addDestinations": "Aggiungi destinazioni per calcolare le medie",
     "previewOnly": "Solo anteprima",
@@ -175,6 +177,7 @@
   "errors": {
     "destinationRequired": "Aggiungi almeno una destinazione prima di creare il tuo viaggio.",
     "genericGenerate": "Generazione viaggio non riuscita. Riprova.",
+    "minimumNightStay": "Scegli una data di fine almeno una notte dopo la data di inizio.",
     "offlineCreateDisabled": "Trip creation is unavailable while offline. Reconnect and try again."
   },
   "prefillBadge": "Precompilato da: {label}",
@@ -257,7 +260,7 @@
         "shoulder": "Shoulder season",
         "off": "Off-season risk"
       },
-      "exactLength": "{days} days",
+      "exactLength": "{days} giorni / {nights} notti",
       "flexLength": "About {weeks} weeks ({days} days)"
     },
     "preferences": {

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -426,6 +426,8 @@
           "duration": "Duration",
           "totalDays": "Total days",
           "totalDaysValue": "{count} days",
+          "tripSpan": "일수와 숙박",
+          "tripSpanValue": "{days}일 / {nights}박",
           "cities": "Cities",
           "totalDistance": "Total distance",
           "owner": "Owner",

--- a/locales/ko/createTrip.json
+++ b/locales/ko/createTrip.json
@@ -23,6 +23,7 @@
       "flex": "유연한 일정"
     },
     "summary": "예상 일정: 총 {days}일",
+    "summaryExact": "예상 일정: {days}일 / {nights}박",
     "labels": {
       "start": "시작",
       "end": "종료",
@@ -140,6 +141,7 @@
     "destinations": "여행지",
     "emptyDestinations": "여행지를 추가하면 경로가 미리보기에 표시됩니다.",
     "days": "{days}일",
+    "daysNights": "{days}일 / {nights}박",
     "avgPerStop": "정류지당 평균 {days}일",
     "addDestinations": "여행지를 추가하면 평균이 계산됩니다",
     "previewOnly": "미리보기 전용",
@@ -175,6 +177,7 @@
   "errors": {
     "destinationRequired": "여행을 만들기 전에 여행지를 하나 이상 추가해 주세요.",
     "genericGenerate": "여행 생성에 실패했습니다. 다시 시도해 주세요.",
+    "minimumNightStay": "종료일은 시작일보다 최소 1박 이후로 선택해 주세요.",
     "offlineCreateDisabled": "Trip creation is unavailable while offline. Reconnect and try again."
   },
   "prefillBadge": "자동 입력 출처: {label}",
@@ -257,7 +260,7 @@
         "shoulder": "Shoulder season",
         "off": "Off-season risk"
       },
-      "exactLength": "{days} days",
+      "exactLength": "{days}일 / {nights}박",
       "flexLength": "About {weeks} weeks ({days} days)"
     },
     "preferences": {

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -424,6 +424,8 @@
           "duration": "Duration",
           "totalDays": "Total days",
           "totalDaysValue": "{count} days",
+          "tripSpan": "Dni i noce",
+          "tripSpanValue": "{days} dni / {nights} nocy",
           "cities": "Cities",
           "totalDistance": "Total distance",
           "owner": "Owner",

--- a/locales/pl/createTrip.json
+++ b/locales/pl/createTrip.json
@@ -23,6 +23,7 @@
       "flex": "Elastyczne okno"
     },
     "summary": "Wstępny zakres: łącznie {days} dni.",
+    "summaryExact": "Wstępny zakres: {days} dni / {nights} nocy.",
     "labels": {
       "start": "Start",
       "end": "Koniec",
@@ -140,6 +141,7 @@
     "destinations": "Kierunki",
     "emptyDestinations": "Dodaj kierunki, aby podejrzeć trasę.",
     "days": "{days} dni",
+    "daysNights": "{days} dni / {nights} nocy",
     "avgPerStop": "Śr. {days} na przystanek",
     "addDestinations": "Dodaj kierunki, aby obliczyć średnie",
     "previewOnly": "Tylko podgląd",
@@ -175,6 +177,7 @@
   "errors": {
     "destinationRequired": "Dodaj co najmniej jeden kierunek przed utworzeniem podróży.",
     "genericGenerate": "Nie udało się wygenerować podróży. Spróbuj ponownie.",
+    "minimumNightStay": "Wybierz datę zakończenia co najmniej jedną noc po dacie rozpoczęcia.",
     "offlineCreateDisabled": "Trip creation is unavailable while offline. Reconnect and try again."
   },
   "prefillBadge": "Wstępnie wypełniono z: {label}",
@@ -257,7 +260,7 @@
         "shoulder": "Shoulder season",
         "off": "Off-season risk"
       },
-      "exactLength": "{days} days",
+      "exactLength": "{days} dni / {nights} nocy",
       "flexLength": "About {weeks} weeks ({days} days)"
     },
     "preferences": {

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -426,6 +426,8 @@
           "duration": "Duration",
           "totalDays": "Total days",
           "totalDaysValue": "{count} days",
+          "tripSpan": "Dias e noites",
+          "tripSpanValue": "{days} dias / {nights} noites",
           "cities": "Cities",
           "totalDistance": "Total distance",
           "owner": "Owner",

--- a/locales/pt/createTrip.json
+++ b/locales/pt/createTrip.json
@@ -23,6 +23,7 @@
       "flex": "Janela flexível"
     },
     "summary": "Período provisório: {days} dias no total.",
+    "summaryExact": "Período provisório: {days} dias / {nights} noites.",
     "labels": {
       "start": "Início",
       "end": "Fim",
@@ -140,6 +141,7 @@
     "destinations": "Destinos",
     "emptyDestinations": "Adiciona destinos para pré-visualizar a tua rota.",
     "days": "{days} dias",
+    "daysNights": "{days} dias / {nights} noites",
     "avgPerStop": "Média de {days} por paragem",
     "addDestinations": "Adiciona destinos para calcular médias",
     "previewOnly": "Apenas pré-visualização",
@@ -175,6 +177,7 @@
   "errors": {
     "destinationRequired": "Adiciona pelo menos um destino antes de criares a tua viagem.",
     "genericGenerate": "A geração da viagem falhou. Tenta novamente.",
+    "minimumNightStay": "Escolha uma data de fim pelo menos uma noite depois da data de início.",
     "offlineCreateDisabled": "Trip creation is unavailable while offline. Reconnect and try again."
   },
   "prefillBadge": "Pré-preenchido de: {label}",
@@ -257,7 +260,7 @@
         "shoulder": "Shoulder season",
         "off": "Off-season risk"
       },
-      "exactLength": "{days} days",
+      "exactLength": "{days} dias / {nights} noites",
       "flexLength": "About {weeks} weeks ({days} days)"
     },
     "preferences": {

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -426,6 +426,8 @@
           "duration": "Duration",
           "totalDays": "Total days",
           "totalDaysValue": "{count} days",
+          "tripSpan": "Дни и ночи",
+          "tripSpanValue": "{days} дней / {nights} ночей",
           "cities": "Cities",
           "totalDistance": "Total distance",
           "owner": "Owner",

--- a/locales/ru/createTrip.json
+++ b/locales/ru/createTrip.json
@@ -23,6 +23,7 @@
       "flex": "Гибкое окно"
     },
     "summary": "Черновой период: всего {days} дней.",
+    "summaryExact": "Черновой период: {days} дней / {nights} ночей.",
     "labels": {
       "start": "Начало",
       "end": "Конец",
@@ -140,6 +141,7 @@
     "destinations": "Направления",
     "emptyDestinations": "Добавьте направления, чтобы увидеть предварительный маршрут.",
     "days": "{days} дней",
+    "daysNights": "{days} дней / {nights} ночей",
     "avgPerStop": "В среднем {days} на остановку",
     "addDestinations": "Добавьте направления, чтобы рассчитать средние значения",
     "previewOnly": "Только предпросмотр",
@@ -175,6 +177,7 @@
   "errors": {
     "destinationRequired": "Добавьте хотя бы одно направление перед созданием поездки.",
     "genericGenerate": "Не удалось сгенерировать поездку. Попробуйте еще раз.",
+    "minimumNightStay": "Выберите дату окончания как минимум на одну ночь позже даты начала.",
     "offlineCreateDisabled": "Trip creation is unavailable while offline. Reconnect and try again."
   },
   "prefillBadge": "Предзаполнено из: {label}",
@@ -257,7 +260,7 @@
         "shoulder": "Shoulder season",
         "off": "Off-season risk"
       },
-      "exactLength": "{days} days",
+      "exactLength": "{days} дней / {nights} ночей",
       "flexLength": "About {weeks} weeks ({days} days)"
     },
     "preferences": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "packageManager": "pnpm@10.18.1",
   "type": "module",
   "scripts": {
-    "dev": "pnpm flags:sync && vite",
-    "dev:netlify": "pnpm dlx netlify dev --port 8888 --target-port 5173",
+    "dev": "pnpm worktree:sync-env && pnpm flags:sync && vite",
+    "dev:netlify": "pnpm worktree:sync-env && pnpm dlx netlify dev --port 8888 --target-port 5173",
+    "worktree:install-hooks": "sh scripts/install-git-hooks.sh",
+    "worktree:sync-env": "tsx scripts/sync-worktree-env.ts",
+    "worktree:new": "tsx scripts/create-worktree.ts",
     "flags:sync": "tsx scripts/sync-flagpack-assets.ts",
     "i18n:validate": "node scripts/validate-i18n.mjs",
     "supabase:validate": "node scripts/validate-supabase-docs.mjs",

--- a/pages/CreateTripClassicLabPage.tsx
+++ b/pages/CreateTripClassicLabPage.tsx
@@ -96,6 +96,7 @@ import {
     getDaysDifference,
     generateTripId,
 } from '../utils';
+import { getEstimatedTripNightsFromTotalDays, getExactTripDateSpan } from '../shared/tripSpan';
 import {
     DESTINATION_OPTIONS,
     getDestinationMetaLabel,
@@ -235,15 +236,15 @@ const buildLoadingTripPreview = (params: {
     destinationLabel: string;
     focusLocations: string[];
     startDate: string;
-    totalDays: number;
+    totalNights: number;
     requestedStops: number;
     roundTrip: boolean;
 }): ITrip => {
     const now = Date.now();
-    const totalDays = Math.max(1, Math.round(params.totalDays));
-    const stops = Math.max(1, Math.min(params.requestedStops, totalDays));
-    const baseDuration = Math.floor(totalDays / stops);
-    const remainder = totalDays % stops;
+    const totalNights = Math.max(1, Math.round(params.totalNights));
+    const stops = Math.max(1, Math.min(params.requestedStops, totalNights));
+    const baseDuration = Math.floor(totalNights / stops);
+    const remainder = totalNights % stops;
 
     let offset = 0;
     const normalizedFocusLocations = Array.from(
@@ -529,16 +530,66 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
         if (dateInputMode === 'flex') return Math.max(7, flexWeeks * 7);
         return getDaysDifference(startDate, endDate);
     }, [dateInputMode, endDate, flexWeeks, startDate]);
+    const exactTripSpan = useMemo(
+        () => (dateInputMode === 'exact' ? getExactTripDateSpan(startDate, endDate) : null),
+        [dateInputMode, endDate, startDate]
+    );
+    const totalNights = useMemo(
+        () => (
+            dateInputMode === 'exact'
+                ? (exactTripSpan?.nights ?? 0)
+                : getEstimatedTripNightsFromTotalDays(dayCount)
+        ),
+        [dateInputMode, dayCount, exactTripSpan]
+    );
+    const exactDateRangeError = useMemo(
+        () => (
+            dateInputMode === 'exact' && startDate && endDate && totalNights < 1
+                ? t('errors.minimumNightStay')
+                : null
+        ),
+        [dateInputMode, endDate, startDate, t, totalNights]
+    );
+    const plannerDurationLabel = useMemo(
+        () => (
+            dateInputMode === 'exact'
+                ? t('dates.summaryExact', {
+                    days: exactTripSpan?.days ?? dayCount,
+                    nights: exactTripSpan?.nights ?? totalNights,
+                })
+                : t('dates.summary', { days: dayCount })
+        ),
+        [dateInputMode, dayCount, exactTripSpan, t, totalNights]
+    );
+    const snapshotDurationLabel = useMemo(
+        () => (
+            dateInputMode === 'exact'
+                ? t('snapshot.daysNights', {
+                    days: exactTripSpan?.days ?? dayCount,
+                    nights: exactTripSpan?.nights ?? totalNights,
+                })
+                : t('snapshot.days', { days: dayCount })
+        ),
+        [dateInputMode, dayCount, exactTripSpan, t, totalNights]
+    );
+    const mobileSnapshotDurationValue = useMemo(
+        () => (
+            dateInputMode === 'exact'
+                ? (exactTripSpan?.compactLabel ?? `${Math.max(1, dayCount)}D/${Math.max(0, totalNights)}N`)
+                : String(dayCount)
+        ),
+        [dateInputMode, dayCount, exactTripSpan, totalNights]
+    );
 
     const mobileDateRangeLabel = useMemo(() => {
         const start = new Date(`${startDate}T00:00:00`);
         const end = new Date(`${endDate}T00:00:00`);
         if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
-            return t('dates.summary', { days: dayCount });
+            return plannerDurationLabel;
         }
         const formatter = new Intl.DateTimeFormat(i18n.language, { month: 'short', day: 'numeric' });
         return `${formatter.format(start)} - ${formatter.format(end)}`;
-    }, [dayCount, endDate, i18n.language, startDate, t]);
+    }, [dayCount, endDate, i18n.language, plannerDurationLabel, startDate]);
 
     const averageDaysPerStop = useMemo(() => {
         if (orderedDestinations.length === 0) return 0;
@@ -560,7 +611,9 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
     );
 
     const destinationComplete = orderedDestinations.length > 0;
-    const datesComplete = Boolean(startDate && endDate);
+    const datesComplete = dateInputMode === 'flex'
+        ? Boolean(startDate && endDate)
+        : Boolean(startDate && endDate && totalNights >= 1);
     const canLockRoute = destinations.length > 1;
     const isGenerationBlockedOffline = !isBrowserOnline;
 
@@ -1539,6 +1592,10 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
             showSubmitError(t('errors.destinationRequired'));
             return;
         }
+        if (dateInputMode === 'exact' && totalNights < 1) {
+            showSubmitError(t('errors.minimumNightStay'));
+            return;
+        }
 
         await maybeRequestTripReadyNotifications();
 
@@ -1618,6 +1675,7 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
             interests: notesInterests.length > 0 ? notesInterests : undefined,
             roundTrip,
             totalDays: dayCount,
+            totalNights: totalNights > 0 ? totalNights : undefined,
             dateInputMode,
             flexWeeks: dateInputMode === 'flex' ? flexWeeks : undefined,
             flexWindow: dateInputMode === 'flex' ? flexWindow : undefined,
@@ -1665,7 +1723,7 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
                     destinationLabel,
                     focusLocations: localizedDestinationLabels,
                     startDate,
-                    totalDays: dayCount,
+                    totalNights: Math.max(1, totalNights),
                     requestedStops: Math.max(orderedDestinations.length, 2),
                     roundTrip,
                 });
@@ -1742,7 +1800,7 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
             destinationLabel,
             focusLocations: localizedDestinationLabels,
             startDate,
-            totalDays: dayCount,
+            totalNights: Math.max(1, totalNights),
             requestedStops: Math.max(orderedDestinations.length, 2),
             roundTrip,
         });
@@ -2153,26 +2211,31 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
                                 </div>
 
                                 {dateInputMode === 'exact' ? (
-                                    <DateRangePicker
-                                        startDate={startDate}
-                                        endDate={endDate}
-                                        onChange={(nextStartDate, nextEndDate) => {
-                                            setStartDate(nextStartDate);
-                                            setEndDate(nextEndDate);
-                                        }}
-                                        showLabel={false}
-                                        monthLabelFormat="long"
-                                        locale={i18n.language}
-                                        labels={{
-                                            start: t('dates.labels.start'),
-                                            end: t('dates.labels.end'),
-                                            selectDate: t('dates.labels.selectDate'),
-                                            selectStartDate: t('dates.labels.selectStartDate'),
-                                            selectEndDate: t('dates.labels.selectEndDate'),
-                                            previousMonth: t('dates.labels.previousMonth'),
-                                            nextMonth: t('dates.labels.nextMonth'),
-                                        }}
-                                    />
+                                    <div className="space-y-3">
+                                        <DateRangePicker
+                                            startDate={startDate}
+                                            endDate={endDate}
+                                            onChange={(nextStartDate, nextEndDate) => {
+                                                setStartDate(nextStartDate);
+                                                setEndDate(nextEndDate);
+                                            }}
+                                            showLabel={false}
+                                            monthLabelFormat="long"
+                                            locale={i18n.language}
+                                            labels={{
+                                                start: t('dates.labels.start'),
+                                                end: t('dates.labels.end'),
+                                                selectDate: t('dates.labels.selectDate'),
+                                                selectStartDate: t('dates.labels.selectStartDate'),
+                                                selectEndDate: t('dates.labels.selectEndDate'),
+                                                previousMonth: t('dates.labels.previousMonth'),
+                                                nextMonth: t('dates.labels.nextMonth'),
+                                            }}
+                                        />
+                                        {exactDateRangeError && (
+                                            <p className="text-sm font-medium text-rose-600">{exactDateRangeError}</p>
+                                        )}
+                                    </div>
                                 ) : (
                                     <div className="grid gap-3 sm:grid-cols-2">
                                         <label className="space-y-1.5 text-sm">
@@ -2234,7 +2297,7 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
                                 )}
 
                                 <div className="mt-3 border-t border-slate-200 pt-2 text-xs text-slate-500">
-                                    {t('dates.summary', { days: dayCount })}
+                                    {plannerDurationLabel}
                                 </div>
                             </section>
 
@@ -2537,7 +2600,7 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
                                     <div className="rounded-xl border border-white/15 bg-white/5 p-3">
                                         <div className="inline-flex items-center gap-2 text-sm font-semibold">
                                             <CalendarBlank size={15} weight="duotone" className="text-indigo-200" />
-                                            {t('snapshot.days', { days: dayCount })}
+                                            {snapshotDurationLabel}
                                         </div>
                                         <div className="mt-1 text-xs text-indigo-100/80">
                                             {orderedDestinations.length > 0
@@ -2654,7 +2717,7 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
                                 <button
                                     type="button"
                                     onClick={handleGenerateTrip}
-                                    disabled={isSubmitting || !destinationComplete || isGenerationBlockedOffline}
+                                        disabled={isSubmitting || !destinationComplete || isGenerationBlockedOffline || (dateInputMode === 'exact' && totalNights < 1)}
                                     className="inline-flex w-full items-center justify-center rounded-xl bg-white px-4 py-3 text-sm font-semibold text-indigo-900 transition-colors hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-60"
                                     {...getAnalyticsDebugAttributes('create_trip__cta--generate', {
                                         destination_count: orderedDestinations.length,
@@ -2773,14 +2836,14 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
                                         {mobileDateRangeLabel}
                                     </span>
                                     <span className="inline-flex items-center rounded-full border border-white/20 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-indigo-100">
-                                        {t('snapshot.days', { days: dayCount })}
+                                        {snapshotDurationLabel}
                                     </span>
                                 </div>
                             </div>
                             <button
                                 type="button"
                                 onClick={handleGenerateTrip}
-                                disabled={isSubmitting || !destinationComplete || isGenerationBlockedOffline}
+                                disabled={isSubmitting || !destinationComplete || isGenerationBlockedOffline || (dateInputMode === 'exact' && totalNights < 1)}
                                 className="rounded-xl bg-white px-3.5 py-2.5 text-sm font-semibold text-indigo-900 shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
                                 {...getAnalyticsDebugAttributes('create_trip__cta--generate', {
                                     destination_count: orderedDestinations.length,
@@ -2805,7 +2868,7 @@ export const CreateTripClassicLabPage: React.FC<CreateTripClassicLabPageProps> =
                             <div className="mt-2.5 grid grid-cols-2 gap-3 rounded-xl border border-white/15 bg-white/5 p-3.5 text-xs text-indigo-100">
                                 <div>
                                     <div className="font-semibold text-indigo-200">{t('mobileSnapshot.days')}</div>
-                                    <div>{dayCount}</div>
+                                    <div>{mobileSnapshotDurationValue}</div>
                                 </div>
                                 <div>
                                     <div className="font-semibold text-indigo-200">{t('mobileSnapshot.traveler')}</div>

--- a/pages/CreateTripV3Page.tsx
+++ b/pages/CreateTripV3Page.tsx
@@ -49,6 +49,7 @@ import {
     getDaysDifference,
     getDefaultTripDates,
 } from '../utils';
+import { getEstimatedTripNightsFromTotalDays, getExactTripDateSpan } from '../shared/tripSpan';
 import {
     getDestinationOptionByName,
     getDestinationPromptLabel,
@@ -285,6 +286,7 @@ const buildPreviewTrip = (params: {
     destination: string;
     startDate: string;
     endDate: string;
+    totalNights: number;
     tripId?: string;
     title?: string;
     stopTitle: (index: number) => string;
@@ -293,10 +295,10 @@ const buildPreviewTrip = (params: {
     titleFallback: string;
 }): ITrip => {
     const now = Date.now();
-    const totalDays = getDaysDifference(params.startDate, params.endDate);
-    const cityCount = Math.max(1, Math.min(4, Math.max(2, Math.round(totalDays / 4))));
-    const baseDuration = Math.floor(totalDays / cityCount);
-    const remainder = totalDays % cityCount;
+    const totalNights = Math.max(1, Math.round(params.totalNights));
+    const cityCount = Math.max(1, Math.min(4, totalNights, Math.max(2, Math.round(totalNights / 4))));
+    const baseDuration = Math.floor(totalNights / cityCount);
+    const remainder = totalNights % cityCount;
     let offset = 0;
     const items: ITimelineItem[] = Array.from({ length: cityCount }).map((_, index) => {
         const duration = baseDuration + (index < remainder ? 1 : 0);
@@ -510,6 +512,26 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
         () => (dateInputMode === 'flex' ? Math.max(7, flexWeeks * 7) : getDaysDifference(startDate, endDate)),
         [dateInputMode, endDate, flexWeeks, startDate]
     );
+    const exactTripSpan = useMemo(
+        () => (dateInputMode === 'exact' ? getExactTripDateSpan(startDate, endDate) : null),
+        [dateInputMode, endDate, startDate]
+    );
+    const totalNights = useMemo(
+        () => (
+            dateInputMode === 'exact'
+                ? (exactTripSpan?.nights ?? 0)
+                : getEstimatedTripNightsFromTotalDays(totalDays)
+        ),
+        [dateInputMode, exactTripSpan, totalDays]
+    );
+    const exactDateRangeError = useMemo(
+        () => (
+            dateInputMode === 'exact' && startDate && endDate && totalNights < 1
+                ? t('errors.minimumNightStay')
+                : null
+        ),
+        [dateInputMode, endDate, startDate, t, totalNights]
+    );
     const destinationRecommendationMonths = useMemo(() => {
         if (dateInputMode === 'flex') {
             return FLEX_WINDOW_MONTHS[flexWindow];
@@ -669,14 +691,16 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
 
     const dateSummary = useMemo(() => {
         if (dateInputMode === 'exact') {
-            return `${new Date(`${startDate}T00:00:00`).toLocaleDateString(i18n.language, { month: 'short', day: 'numeric', year: 'numeric' })} - ${new Date(`${endDate}T00:00:00`).toLocaleDateString(i18n.language, { month: 'short', day: 'numeric', year: 'numeric' })} (${t('snapshot.days', { days: totalDays })})`;
+            const exactDays = exactTripSpan?.days ?? totalDays;
+            const exactNights = exactTripSpan?.nights ?? totalNights;
+            return `${new Date(`${startDate}T00:00:00`).toLocaleDateString(i18n.language, { month: 'short', day: 'numeric', year: 'numeric' })} - ${new Date(`${endDate}T00:00:00`).toLocaleDateString(i18n.language, { month: 'short', day: 'numeric', year: 'numeric' })} (${t('wizard.dates.exactLength', { days: exactDays, nights: exactNights })})`;
         }
         return t('wizard.review.flexDates', {
             weeks: flexWeeks,
             window: t(FLEX_WINDOW_OPTIONS.find((entry) => entry.id === flexWindow)?.labelKey || 'dates.flexWindow.options.shoulder'),
             days: totalDays,
         });
-    }, [dateInputMode, endDate, flexWeeks, flexWindow, i18n.language, startDate, t, totalDays]);
+    }, [dateInputMode, endDate, exactTripSpan, flexWeeks, flexWindow, i18n.language, startDate, t, totalDays, totalNights]);
 
     const draftMeta = useMemo<CreateTripPrefillDraft>(() => ({
         version: 2,
@@ -1137,13 +1161,22 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
     const canContinue = useMemo(() => {
         if (currentStepId === 'intent') return Boolean(wizardBranch);
         if (currentStepId === 'destinations') return selectedCountries.length > 0;
-        if (currentStepId === 'dates') return dateInputMode === 'flex' ? flexWeeks > 0 : Boolean(startDate && endDate);
+        if (currentStepId === 'dates') {
+            return dateInputMode === 'flex'
+                ? flexWeeks > 0
+                : Boolean(startDate && endDate && totalNights >= 1);
+        }
         return true;
-    }, [currentStepId, dateInputMode, endDate, flexWeeks, selectedCountries.length, startDate, wizardBranch]);
+    }, [currentStepId, dateInputMode, endDate, flexWeeks, selectedCountries.length, startDate, totalNights, wizardBranch]);
 
-    const canGenerate = selectedCountries.length > 0 && !isGenerating;
+    const canGenerate = selectedCountries.length > 0 && !isGenerating && (dateInputMode === 'flex' || totalNights >= 1);
 
     const handleGenerate = async () => {
+        if (dateInputMode === 'exact' && totalNights < 1) {
+            setGenerationError(t('errors.minimumNightStay'));
+            return;
+        }
+
         await maybeRequestTripReadyNotifications();
 
         const sessionUserId = await ensureDbSession();
@@ -1168,6 +1201,7 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
             endDate,
             roundTrip: isRoundTrip,
             totalDays,
+            totalNights: totalNights > 0 ? totalNights : undefined,
             budget,
             pace,
             interests: notes.split(',').map((token) => token.trim()).filter(Boolean),
@@ -1229,6 +1263,7 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
                     destination: destinationLabel,
                     startDate,
                     endDate,
+                    totalNights: Math.max(1, totalNights),
                     tripId: generateTripId(),
                     title: destinationLabel,
                     stopTitle: (index) => t('wizard.loading.stopTitle', { index }),
@@ -1295,6 +1330,7 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
             destination: destinationLabel,
             startDate,
             endDate,
+            totalNights: Math.max(1, totalNights),
             title: destinationLabel,
             stopTitle: (index) => t('wizard.loading.stopTitle', { index }),
             stopDescription: t('wizard.loading.stopDescription'),
@@ -1322,6 +1358,7 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
                     destination: destinationLabel,
                     startDate,
                     endDate,
+                    totalNights: Math.max(1, totalNights),
                     tripId,
                     title: destinationLabel,
                     stopTitle: (index) => t('wizard.loading.stopTitle', { index }),
@@ -1724,17 +1761,22 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
                     )}
 
                     {dateInputMode === 'exact' ? (
-                        <DateRangePicker
-                            startDate={startDate}
-                            endDate={endDate}
-                            onChange={(nextStartDate, nextEndDate) => {
-                                setStartDate(nextStartDate);
-                                setEndDate(nextEndDate);
-                            }}
-                            showLabel={false}
-                            monthLabelFormat="long"
-                            locale={i18n.language}
-                        />
+                        <div className="space-y-3">
+                            <DateRangePicker
+                                startDate={startDate}
+                                endDate={endDate}
+                                onChange={(nextStartDate, nextEndDate) => {
+                                    setStartDate(nextStartDate);
+                                    setEndDate(nextEndDate);
+                                }}
+                                showLabel={false}
+                                monthLabelFormat="long"
+                                locale={i18n.language}
+                            />
+                            {exactDateRangeError && (
+                                <p className="text-sm font-medium text-rose-600">{exactDateRangeError}</p>
+                            )}
+                        </div>
                     ) : (
                         <div className="grid gap-4 md:grid-cols-[1fr,1fr]">
                             <NumberStepper
@@ -1763,7 +1805,7 @@ export const CreateTripV3Page: React.FC<CreateTripV3PageProps> = ({ onTripGenera
                     <div className="flex flex-wrap items-center justify-center gap-3 text-sm">
                         <span className="inline-flex items-center rounded-full border border-accent-200 bg-accent-50 px-3 py-1 font-medium text-accent-700">
                             {dateInputMode === 'exact'
-                                ? t('wizard.dates.exactLength', { days: totalDays })
+                                ? t('wizard.dates.exactLength', { days: exactTripSpan?.days ?? totalDays, nights: exactTripSpan?.nights ?? totalNights })
                                 : t('wizard.dates.flexLength', { weeks: flexWeeks, days: totalDays })}
                         </span>
                         {seasonQuality && (

--- a/scripts/create-worktree.ts
+++ b/scripts/create-worktree.ts
@@ -1,0 +1,14 @@
+import {
+  createWorktreeAndSyncEnv,
+  formatWorktreeEnvSyncSummary,
+} from './worktreeEnv.ts';
+
+const main = () => {
+  const result = createWorktreeAndSyncEnv(process.argv.slice(2));
+
+  for (const line of formatWorktreeEnvSyncSummary(result)) {
+    console.log(line);
+  }
+};
+
+void main();

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+common_dir="$(git rev-parse --git-common-dir)"
+case "${common_dir}" in
+  /*) common_dir_abs="${common_dir}" ;;
+  *) common_dir_abs="$(cd "${repo_root}/${common_dir}" && pwd)" ;;
+esac
+
+primary_root="$(cd "${common_dir_abs}/.." && pwd)"
+hooks_dir="${primary_root}/.githooks"
+
+mkdir -p "${hooks_dir}"
+cp -fp "${repo_root}/.githooks/post-checkout" "${hooks_dir}/post-checkout"
+chmod +x "${hooks_dir}/post-checkout"
+
+git config core.hooksPath "${hooks_dir}"
+
+echo "Configured core.hooksPath=${hooks_dir}"

--- a/scripts/sync-worktree-env.ts
+++ b/scripts/sync-worktree-env.ts
@@ -1,0 +1,74 @@
+import { formatWorktreeEnvSyncSummary, runWorktreeEnvSync } from './worktreeEnv.ts';
+
+interface ParsedSyncArgs {
+  sourceRoot?: string;
+  targetRoot?: string;
+  overwrite: boolean;
+  dryRun: boolean;
+}
+
+const parseSyncArgs = (args: string[]): ParsedSyncArgs => {
+  let sourceRoot: string | undefined;
+  let targetRoot: string | undefined;
+  let overwrite = true;
+  let dryRun = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--') continue;
+    if (arg === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    if (arg === '--no-overwrite') {
+      overwrite = false;
+      continue;
+    }
+    if (arg === '--source') {
+      const value = args[index + 1];
+      if (!value) throw new Error('Missing path after --source.');
+      sourceRoot = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--source=')) {
+      sourceRoot = arg.slice('--source='.length);
+      continue;
+    }
+    if (arg === '--target') {
+      const value = args[index + 1];
+      if (!value) throw new Error('Missing path after --target.');
+      targetRoot = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--target=')) {
+      targetRoot = arg.slice('--target='.length);
+      continue;
+    }
+    throw new Error(`Unsupported option: ${arg}`);
+  }
+
+  return {
+    sourceRoot,
+    targetRoot,
+    overwrite,
+    dryRun,
+  };
+};
+
+const main = () => {
+  const parsed = parseSyncArgs(process.argv.slice(2));
+  const result = runWorktreeEnvSync(parsed);
+
+  for (const line of formatWorktreeEnvSyncSummary(result)) {
+    console.log(line);
+  }
+
+  if (parsed.dryRun) {
+    console.log('Dry run only, no files were written.');
+  }
+};
+
+void main();

--- a/scripts/worktreeEnv.ts
+++ b/scripts/worktreeEnv.ts
@@ -1,0 +1,261 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, resolve } from 'node:path';
+
+export const WORKTREE_ENV_FILES = ['.env', '.env.local'] as const;
+
+export type WorktreeEnvFileName = (typeof WORKTREE_ENV_FILES)[number];
+export type WorktreeEnvPlanStatus =
+  | 'pending'
+  | 'copied'
+  | 'missing-source'
+  | 'same-path'
+  | 'existing-target';
+
+export interface WorktreeEnvPlanItem {
+  name: WorktreeEnvFileName;
+  sourcePath: string;
+  targetPath: string;
+  status: WorktreeEnvPlanStatus;
+}
+
+export interface RunWorktreeEnvSyncOptions {
+  cwd?: string;
+  sourceRoot?: string;
+  targetRoot?: string;
+  overwrite?: boolean;
+  dryRun?: boolean;
+}
+
+export interface RunWorktreeEnvSyncResult {
+  sourceRoot: string;
+  targetRoot: string;
+  plan: WorktreeEnvPlanItem[];
+}
+
+const resolveGitOutputPath = (cwd: string, value: string): string => (
+  isAbsolute(value) ? value : resolve(cwd, value)
+);
+
+const trimGitOutput = (value: string): string => value.trim();
+
+export const resolvePrimaryCheckoutRootFromCommonDir = (commonDir: string): string => resolve(commonDir, '..');
+
+export const getActiveWorktreeRoot = (cwd = process.cwd()): string => trimGitOutput(
+  execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd, encoding: 'utf8' }),
+);
+
+export const getGitCommonDir = (cwd = process.cwd()): string => {
+  const output = trimGitOutput(execFileSync('git', ['rev-parse', '--git-common-dir'], { cwd, encoding: 'utf8' }));
+  return resolveGitOutputPath(cwd, output);
+};
+
+export const buildWorktreeEnvCopyPlan = (
+  sourceRoot: string,
+  targetRoot: string,
+  overwrite = true,
+): WorktreeEnvPlanItem[] => WORKTREE_ENV_FILES.map((name) => {
+  const sourcePath = resolve(sourceRoot, name);
+  const targetPath = resolve(targetRoot, name);
+
+  if (!existsSync(sourcePath)) {
+    return { name, sourcePath, targetPath, status: 'missing-source' };
+  }
+
+  if (sourcePath === targetPath) {
+    return { name, sourcePath, targetPath, status: 'same-path' };
+  }
+
+  if (!overwrite && existsSync(targetPath)) {
+    return { name, sourcePath, targetPath, status: 'existing-target' };
+  }
+
+  return { name, sourcePath, targetPath, status: 'pending' };
+});
+
+export const executeWorktreeEnvCopyPlan = (
+  plan: WorktreeEnvPlanItem[],
+  dryRun = false,
+): WorktreeEnvPlanItem[] => plan.map((item) => {
+  if (item.status !== 'pending') return item;
+
+  if (!dryRun) {
+    mkdirSync(dirname(item.targetPath), { recursive: true });
+    copyFileSync(item.sourcePath, item.targetPath);
+    chmodSync(item.targetPath, statSync(item.sourcePath).mode & 0o777);
+  }
+
+  return {
+    ...item,
+    status: 'copied',
+  };
+});
+
+export const runWorktreeEnvSync = ({
+  cwd = process.cwd(),
+  sourceRoot,
+  targetRoot,
+  overwrite = true,
+  dryRun = false,
+}: RunWorktreeEnvSyncOptions = {}): RunWorktreeEnvSyncResult => {
+  const resolvedTargetRoot = targetRoot ? resolve(cwd, targetRoot) : getActiveWorktreeRoot(cwd);
+  const resolvedSourceRoot = sourceRoot
+    ? resolve(cwd, sourceRoot)
+    : resolvePrimaryCheckoutRootFromCommonDir(getGitCommonDir(cwd));
+  const plan = buildWorktreeEnvCopyPlan(resolvedSourceRoot, resolvedTargetRoot, overwrite);
+
+  return {
+    sourceRoot: resolvedSourceRoot,
+    targetRoot: resolvedTargetRoot,
+    plan: executeWorktreeEnvCopyPlan(plan, dryRun),
+  };
+};
+
+export interface ParsedCreateWorktreeArgs {
+  path: string;
+  ref?: string;
+  branch?: string;
+  force: boolean;
+  detach: boolean;
+  noCheckout: boolean;
+}
+
+export const parseCreateWorktreeArgs = (args: string[]): ParsedCreateWorktreeArgs => {
+  const positionals: string[] = [];
+  let branch: string | undefined;
+  let ref: string | undefined;
+  let force = false;
+  let detach = false;
+  let noCheckout = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--') continue;
+    if (arg === '--force' || arg === '-f') {
+      force = true;
+      continue;
+    }
+    if (arg === '--detach') {
+      detach = true;
+      continue;
+    }
+    if (arg === '--no-checkout') {
+      noCheckout = true;
+      continue;
+    }
+    if (arg === '--branch' || arg === '-b') {
+      const value = args[index + 1];
+      if (!value) throw new Error('Missing branch name after --branch.');
+      branch = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--branch=')) {
+      branch = arg.slice('--branch='.length);
+      continue;
+    }
+    if (arg === '--ref') {
+      const value = args[index + 1];
+      if (!value) throw new Error('Missing ref after --ref.');
+      ref = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--ref=')) {
+      ref = arg.slice('--ref='.length);
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new Error(`Unsupported worktree option: ${arg}`);
+    }
+
+    positionals.push(arg);
+  }
+
+  if (positionals.length === 0) {
+    throw new Error('Usage: pnpm worktree:new <path> [ref] [--branch <name>] [--force] [--detach] [--no-checkout]');
+  }
+
+  if (positionals.length > 2) {
+    throw new Error('Too many positional arguments. Expected <path> and optional [ref].');
+  }
+
+  if (!ref && positionals[1]) {
+    ref = positionals[1];
+  }
+
+  if (detach && branch) {
+    throw new Error('Cannot combine --detach with --branch.');
+  }
+
+  return {
+    path: positionals[0],
+    ref,
+    branch,
+    force,
+    detach,
+    noCheckout,
+  };
+};
+
+export const buildGitWorktreeAddArgs = (parsed: ParsedCreateWorktreeArgs): string[] => {
+  const gitArgs = ['worktree', 'add'];
+
+  if (parsed.force) gitArgs.push('--force');
+  if (parsed.detach) gitArgs.push('--detach');
+  if (parsed.noCheckout) gitArgs.push('--no-checkout');
+  if (parsed.branch) gitArgs.push('-b', parsed.branch);
+
+  gitArgs.push(parsed.path);
+
+  if (parsed.ref) gitArgs.push(parsed.ref);
+
+  return gitArgs;
+};
+
+export const formatWorktreeEnvSyncSummary = (result: RunWorktreeEnvSyncResult): string[] => {
+  const lines = [
+    `Source root: ${result.sourceRoot}`,
+    `Target root: ${result.targetRoot}`,
+  ];
+
+  for (const item of result.plan) {
+    if (item.status === 'copied') {
+      lines.push(`Copied ${item.name}`);
+      continue;
+    }
+    if (item.status === 'missing-source') {
+      lines.push(`Skipped ${item.name} (missing in source checkout)`);
+      continue;
+    }
+    if (item.status === 'same-path') {
+      lines.push(`Skipped ${item.name} (already using the primary checkout)`);
+      continue;
+    }
+    if (item.status === 'existing-target') {
+      lines.push(`Skipped ${item.name} (target already exists)`);
+    }
+  }
+
+  return lines;
+};
+
+export const createWorktreeAndSyncEnv = (args: string[], cwd = process.cwd()): RunWorktreeEnvSyncResult => {
+  const parsed = parseCreateWorktreeArgs(args);
+  const gitArgs = buildGitWorktreeAddArgs(parsed);
+  const command = spawnSync('git', gitArgs, {
+    cwd,
+    stdio: 'inherit',
+    shell: false,
+  });
+
+  if (command.status !== 0) {
+    throw new Error(`git ${gitArgs.join(' ')} failed with exit code ${command.status ?? 1}`);
+  }
+
+  return runWorktreeEnvSync({
+    cwd,
+    targetRoot: resolve(cwd, parsed.path),
+  });
+};

--- a/services/aiBenchmarkClassicScenarioService.ts
+++ b/services/aiBenchmarkClassicScenarioService.ts
@@ -1,6 +1,7 @@
 import { buildClassicItineraryPrompt, type GenerateOptions } from './aiService';
 import type { BenchmarkMaskScenario } from './aiBenchmarkPreferencesService';
 import { getDestinationPromptLabel, resolveDestinationName } from './destinationService';
+import { getEstimatedTripNightsFromTotalDays, getExactTripDateSpan } from '../shared/tripSpan';
 
 export interface ClassicBenchmarkScenarioBuildResult {
     prompt: string;
@@ -9,6 +10,7 @@ export interface ClassicBenchmarkScenarioBuildResult {
     destinationPrompt: string;
     selectedDestinations: string[];
     totalDays: number;
+    totalNights: number;
     generationOptions: GenerateOptions;
     input: {
         destinations: string[];
@@ -21,6 +23,7 @@ export interface ClassicBenchmarkScenarioBuildResult {
         specificCities: string;
         numCities: number | null;
         totalDays: number;
+        totalNights: number;
         roundTrip: boolean;
         routeLock: boolean;
         preferenceSignals: {
@@ -50,16 +53,6 @@ const parseBenchmarkDestinations = (value: string): string[] => {
         });
 };
 
-const getScenarioDateSpanDays = (startDate: string | null, endDate: string | null): number | null => {
-    if (!startDate || !endDate) return null;
-
-    const start = new Date(startDate);
-    const end = new Date(endDate);
-    const diffTime = Math.abs(end.getTime() - start.getTime());
-    if (!Number.isFinite(diffTime)) return null;
-    return Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1;
-};
-
 const getFlexTotalDays = (flexWeeks: number): number => {
     if (!Number.isFinite(flexWeeks) || flexWeeks <= 0) return DEFAULT_FLEX_TOTAL_DAYS;
     return Math.max(7, Math.round(flexWeeks) * 7);
@@ -75,9 +68,13 @@ export const buildClassicBenchmarkScenario = (
     }
 
     const destinationPrompt = selectedDestinations.map((entry) => getDestinationPromptLabel(entry)).join(', ');
+    const exactTripSpan = scenario.dateInputMode === 'exact'
+        ? getExactTripDateSpan(scenario.startDate || '', scenario.endDate || '')
+        : null;
     const totalDays = scenario.dateInputMode === 'flex'
         ? getFlexTotalDays(scenario.flexWeeks)
-        : getScenarioDateSpanDays(scenario.startDate, scenario.endDate) || getFlexTotalDays(scenario.flexWeeks);
+        : exactTripSpan?.days || getFlexTotalDays(scenario.flexWeeks);
+    const totalNights = exactTripSpan?.nights ?? getEstimatedTripNightsFromTotalDays(totalDays);
 
     const generationOptions: GenerateOptions = {
         budget: scenario.budget,
@@ -86,6 +83,7 @@ export const buildClassicBenchmarkScenario = (
         specificCities: scenario.specificCities.trim() || undefined,
         roundTrip: scenario.roundTrip,
         totalDays,
+        totalNights,
         numCities: typeof scenario.numCities === 'number' ? scenario.numCities : undefined,
         destinationOrder: selectedDestinations,
         routeLock: scenario.routeLock,
@@ -99,6 +97,7 @@ export const buildClassicBenchmarkScenario = (
         destinationPrompt,
         selectedDestinations,
         totalDays,
+        totalNights,
         generationOptions,
         input: {
             destinations: selectedDestinations,
@@ -111,6 +110,7 @@ export const buildClassicBenchmarkScenario = (
             specificCities: scenario.specificCities,
             numCities: typeof scenario.numCities === 'number' ? scenario.numCities : null,
             totalDays,
+            totalNights,
             roundTrip: scenario.roundTrip,
             routeLock: scenario.routeLock,
             preferenceSignals: {

--- a/services/aiService.ts
+++ b/services/aiService.ts
@@ -128,6 +128,7 @@ const cityNotesSchema = {
 export interface GenerateOptions extends CreateTripPreferenceSignals {
     roundTrip?: boolean;
     totalDays?: number;
+    totalNights?: number;
     numCities?: number;
     budget?: string;
     pace?: string;
@@ -146,6 +147,7 @@ export interface WizardGenerateOptions extends CreateTripPreferenceSignals {
     endDate?: string;
     roundTrip?: boolean;
     totalDays?: number;
+    totalNights?: number;
     budget?: string;
     pace?: string;
     interests?: string[];
@@ -165,6 +167,7 @@ export interface SurpriseGenerateOptions {
     startDate?: string;
     endDate?: string;
     totalDays?: number;
+    totalNights?: number;
     monthLabels?: string[];
     durationWeeks?: number;
     seasonalEvents?: string[];
@@ -300,7 +303,9 @@ const BASE_ITINERARY_RULES_PROMPT = `
       Return a list of consecutive cities/stops.
       Important Rules for complex trips:
       1. Provide accurate Latitude and Longitude for each city/stop.
-      2. Treat multi-day excursions (like treks, cruises, jungle expeditions, or hikes) as separate 'cities/stops' with their own duration (days) and coordinates.
+      2. Treat multi-day excursions (like treks, cruises, jungle expeditions, or hikes) as separate 'cities/stops' with their own duration and coordinates.
+         - In the "cities" array, the "days" field means nights stayed in that stop.
+         - Arrival day and departure day each count as calendar days outside that night count.
       3. For EACH city description, you MUST include these exact markdown sections:
          ### Must See (3-4 items)
          ### Must Try (3-4 local foods)
@@ -330,7 +335,9 @@ const BASE_ITINERARY_RULES_PROMPT_COMPACT = `
       Return a concise list of consecutive cities/stops.
       Important Rules for compact benchmark output:
       1. Provide accurate Latitude and Longitude for each city/stop.
-      2. Treat multi-day excursions (like treks, cruises, jungle expeditions, or hikes) as separate 'cities/stops' with their own duration (days) and coordinates.
+      2. Treat multi-day excursions (like treks, cruises, jungle expeditions, or hikes) as separate 'cities/stops' with their own duration and coordinates.
+         - In the "cities" array, the "days" field means nights stayed in that stop.
+         - Arrival day and departure day each count as calendar days outside that night count.
       3. For EACH city description, you MUST include these exact markdown sections:
          ### Must See
          ### Must Try
@@ -368,6 +375,7 @@ const STRICT_JSON_OBJECT_CONTRACT_PROMPT = `
          - description
          - lat
          - lng
+         - IMPORTANT: "days" means nights stayed in that stop.
       5. "travelSegments" must be an array (can be empty) of objects with:
          - fromCityIndex
          - toCityIndex
@@ -390,9 +398,26 @@ const STRICT_JSON_OBJECT_CONTRACT_PROMPT = `
       12. Before finalizing your answer, run a self-check:
          - Every city.description contains all three headings: "### Must See", "### Must Try", "### Must Do".
          - Only add "### Heads Up" when a practical warning is genuinely needed.
+         - cities[].days is interpreted as nights stayed, not touched calendar days.
          - countryInfo is a single object, languages is an array, and the canonical countryInfo keys are used exactly.
          - Return exactly one JSON object and nothing else.
     `;
+
+const buildStayBudgetPrompt = (options: Pick<GenerateOptions, 'totalDays' | 'totalNights'>): string => {
+    if (typeof options.totalNights === 'number' && Number.isFinite(options.totalNights) && options.totalNights > 0) {
+        const totalNights = Math.round(options.totalNights);
+        const totalDays = typeof options.totalDays === 'number' && Number.isFinite(options.totalDays) && options.totalDays > 0
+            ? Math.round(options.totalDays)
+            : totalNights + 1;
+        return `The full itinerary MUST cover exactly ${totalNights} total nights across all city stays. In the "cities" array, the "days" field means nights stayed. The trip spans ${totalDays} calendar days including the arrival day and departure day. `;
+    }
+
+    if (typeof options.totalDays === 'number' && Number.isFinite(options.totalDays) && options.totalDays > 0) {
+        return `The full itinerary MUST cover exactly ${Math.round(options.totalDays)} total days across all city stays. `;
+    }
+
+    return '';
+};
 
 const BENCHMARK_COMPACT_OUTPUT_PROMPT = `
       Benchmark compact-output mode:
@@ -1359,7 +1384,7 @@ export const buildClassicItineraryPrompt = (prompt: string, options?: GenerateOp
         if (options.roundTrip) {
             detailedPrompt += ` Roundtrip is enabled. The FINAL city in "cities" MUST be the same place as the FIRST city (same city name and coordinates), representing the return to start. `;
         }
-        if (options.totalDays) detailedPrompt += ` The full itinerary MUST cover exactly ${options.totalDays} total days across all city stays. `;
+        detailedPrompt += buildStayBudgetPrompt(options);
         if (options.numCities) detailedPrompt += ` Visit exactly ${options.numCities} distinct cities/stops. `;
         if (options.budget) detailedPrompt += ` Budget level: ${options.budget}. `;
         if (options.pace) detailedPrompt += ` Travel pace: ${options.pace}. `;
@@ -1417,9 +1442,7 @@ export const buildWizardItineraryPrompt = (options: WizardGenerateOptions): stri
     if (options.roundTrip) {
         detailedPrompt += `Roundtrip is enabled. The FINAL city in "cities" MUST be the same place as the FIRST city (same city name and coordinates), representing the return to start. `;
     }
-    if (options.totalDays) {
-        detailedPrompt += `The full itinerary MUST cover exactly ${options.totalDays} total days across all city stays. `;
-    }
+    detailedPrompt += buildStayBudgetPrompt(options);
     if (options.budget) {
         detailedPrompt += `Budget level: ${options.budget}. `;
     }
@@ -1481,9 +1504,7 @@ export const buildSurpriseItineraryPrompt = (options: SurpriseGenerateOptions): 
     detailedPrompt += `This request comes from the "Surprise Me" flow, so the plan should feel exciting, varied, and season-aware while still practical. `;
     detailedPrompt += `${USER_PROMPT_DATA_GUARD_PROMPT} `;
 
-    if (options.totalDays) {
-        detailedPrompt += `The full itinerary MUST cover exactly ${options.totalDays} total days across all city stays. `;
-    }
+    detailedPrompt += buildStayBudgetPrompt(options);
     if (options.monthLabels && options.monthLabels.length > 0) {
         detailedPrompt += `${formatUserPromptDataListBlock('travel window months', options.monthLabels)} `;
     }

--- a/shared/aiTripItinerarySchema.ts
+++ b/shared/aiTripItinerarySchema.ts
@@ -65,7 +65,7 @@ const tripCountryInfoJsonSchema = {
 const tripCityJsonSchema = {
   type: "object",
   additionalProperties: false,
-  properties: {
+    properties: {
     name: { type: "string", minLength: 1 },
     days: { type: "number", minimum: 0 },
     description: {
@@ -165,7 +165,7 @@ export const createGeminiTripItineraryResponseSchema = <TValue extends string | 
         type: Type.OBJECT,
         properties: {
           name: { type: Type.STRING },
-          days: { type: Type.NUMBER, description: "Number of days to stay" },
+          days: { type: Type.NUMBER, description: "Number of nights to stay in this stop" },
           description: { type: Type.STRING, description: "Markdown text that MUST contain 3 sections: '### Must See', '### Must Try', and '### Must Do' with checkbox lists." },
           lat: { type: Type.NUMBER, description: "Latitude of the city center" },
           lng: { type: Type.NUMBER, description: "Longitude of the city center" },

--- a/shared/tripSpan.ts
+++ b/shared/tripSpan.ts
@@ -1,0 +1,148 @@
+import type { ITrip, ITimelineItem } from '../types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface TripRangeOffsets {
+    startOffset: number;
+    endOffset: number;
+}
+
+export interface TripSpanSummary {
+    startDate: Date;
+    endDate: Date;
+    days: number;
+    nights: number;
+    startOffset: number;
+    endOffset: number;
+    compactLabel: string;
+    longLabel: string;
+}
+
+const parseLocalDate = (value: string): Date | null => {
+    if (!value) return null;
+    const parts = value.split('-').map(Number);
+    if (parts.length === 3 && parts.every((part) => Number.isFinite(part))) {
+        const [year, month, day] = parts;
+        return new Date(year, month - 1, day);
+    }
+
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const addDays = (date: Date, days: number): Date => {
+    const next = new Date(date);
+    next.setDate(next.getDate() + days);
+    return next;
+};
+
+const toNoon = (date: Date): Date => {
+    const next = new Date(date);
+    next.setHours(12, 0, 0, 0);
+    return next;
+};
+
+const getCalendarDayDiff = (start: Date, end: Date): number => (
+    Math.round((toNoon(end).getTime() - toNoon(start).getTime()) / DAY_MS)
+);
+
+const formatCompactTripSpan = (days: number, nights: number): string => `${days}D/${nights}N`;
+
+const formatLongTripSpan = (days: number, nights: number): string => (
+    `${days} ${days === 1 ? 'day' : 'days'} / ${nights} ${nights === 1 ? 'night' : 'nights'}`
+);
+
+const createTripSpanSummary = (
+    startDate: Date,
+    endDate: Date,
+    startOffset: number,
+    endOffset: number,
+): TripSpanSummary => {
+    const nights = Math.max(0, getCalendarDayDiff(startDate, endDate));
+    const days = Math.max(1, nights + 1);
+
+    return {
+        startDate,
+        endDate,
+        days,
+        nights,
+        startOffset,
+        endOffset,
+        compactLabel: formatCompactTripSpan(days, nights),
+        longLabel: formatLongTripSpan(days, nights),
+    };
+};
+
+const getSourceItemsForTripRange = (trip: ITrip): ITimelineItem[] => {
+    const cityItems = trip.items.filter((item) => item.type === 'city');
+    return cityItems.length > 0 ? cityItems : trip.items;
+};
+
+export const getTripRangeOffsets = (trip: ITrip): TripRangeOffsets => {
+    const sourceItems = getSourceItemsForTripRange(trip);
+
+    if (sourceItems.length === 0) {
+        return { startOffset: 0, endOffset: 0 };
+    }
+
+    let minStart = Number.POSITIVE_INFINITY;
+    let maxEnd = Number.NEGATIVE_INFINITY;
+
+    sourceItems.forEach((item) => {
+        if (!Number.isFinite(item.startDateOffset) || !Number.isFinite(item.duration)) return;
+        minStart = Math.min(minStart, item.startDateOffset);
+        maxEnd = Math.max(maxEnd, item.startDateOffset + Math.max(item.duration, 0));
+    });
+
+    if (!Number.isFinite(minStart) || !Number.isFinite(maxEnd) || maxEnd < minStart) {
+        return { startOffset: 0, endOffset: 0 };
+    }
+
+    return {
+        startOffset: minStart,
+        endOffset: maxEnd,
+    };
+};
+
+export const getTripSpanFromOffsets = (
+    startDateValue: string,
+    range: TripRangeOffsets,
+): TripSpanSummary => {
+    const baseStartDate = parseLocalDate(startDateValue) || new Date();
+    const startOffset = Number.isFinite(range.startOffset) ? range.startOffset : 0;
+    const endOffset = Number.isFinite(range.endOffset) ? range.endOffset : startOffset;
+    const touchedStartDate = addDays(baseStartDate, Math.floor(startOffset));
+    const touchedEndDate = addDays(baseStartDate, Math.max(Math.floor(startOffset), Math.ceil(endOffset)));
+
+    return createTripSpanSummary(touchedStartDate, touchedEndDate, startOffset, endOffset);
+};
+
+export const getTripSpan = (trip: ITrip): TripSpanSummary => (
+    getTripSpanFromOffsets(trip.startDate, getTripRangeOffsets(trip))
+);
+
+export const getExactTripDateSpan = (startDateValue: string, endDateValue: string): TripSpanSummary | null => {
+    const startDate = parseLocalDate(startDateValue);
+    const endDate = parseLocalDate(endDateValue);
+    if (!startDate || !endDate) return null;
+    if (endDate.getTime() < startDate.getTime()) return null;
+
+    const nights = getCalendarDayDiff(startDate, endDate);
+    const days = Math.max(1, nights + 1);
+
+    return {
+        startDate,
+        endDate,
+        days,
+        nights,
+        startOffset: 0,
+        endOffset: nights,
+        compactLabel: formatCompactTripSpan(days, nights),
+        longLabel: formatLongTripSpan(days, nights),
+    };
+};
+
+export const getEstimatedTripNightsFromTotalDays = (totalDays: number): number => {
+    if (!Number.isFinite(totalDays)) return 0;
+    return Math.max(0, Math.round(totalDays) - 1);
+};

--- a/tests/browser/TimelineBlock.browser.test.ts
+++ b/tests/browser/TimelineBlock.browser.test.ts
@@ -117,4 +117,42 @@ describe('components/TimelineBlock keyboard city navigation', () => {
     expect(regularContent?.className).toContain('justify-start');
     expect(regularTitle?.className).toContain('text-[15px]');
   });
+
+  it('renders city stays on half-day boundaries in horizontal and vertical modes', () => {
+    const horizontal = render(
+      React.createElement(TimelineBlock, {
+        item: buildCityItem(),
+        isSelected: false,
+        isCity: true,
+        pixelsPerDay: 120,
+        onSelect: vi.fn(),
+        onResizeStart: vi.fn(),
+        onMoveStart: vi.fn(),
+      }),
+    );
+
+    const horizontalCityBlock = horizontal.container.querySelector<HTMLElement>('[data-city-id="city-1"]');
+    expect(horizontalCityBlock?.style.left).toBe('61px');
+    expect(horizontalCityBlock?.style.width).toBe('358px');
+    expect(horizontalCityBlock?.getAttribute('data-tooltip')).toBe('Bangkok • 4 Days / 3 Nights');
+
+    horizontal.unmount();
+
+    const vertical = render(
+      React.createElement(TimelineBlock, {
+        item: buildCityItem(),
+        isSelected: false,
+        isCity: true,
+        pixelsPerDay: 120,
+        vertical: true,
+        onSelect: vi.fn(),
+        onResizeStart: vi.fn(),
+        onMoveStart: vi.fn(),
+      }),
+    );
+
+    const verticalCityBlock = vertical.container.querySelector<HTMLElement>('[data-city-id="city-1"]');
+    expect(verticalCityBlock?.style.top).toBe('62px');
+    expect(verticalCityBlock?.style.height).toBe('356px');
+  });
 });

--- a/tests/browser/createTripClassicLabPage.browser.test.ts
+++ b/tests/browser/createTripClassicLabPage.browser.test.ts
@@ -32,7 +32,27 @@ vi.mock('../../components/create-trip/CreateTripWizardCtaBanner', () => ({
 }));
 
 vi.mock('../../components/DateRangePicker', () => ({
-  DateRangePicker: () => React.createElement('div', { 'data-testid': 'date-range-picker' }),
+  DateRangePicker: ({
+    startDate,
+    endDate,
+    onChange,
+  }: {
+    startDate?: string;
+    endDate?: string;
+    onChange: (nextStartDate: string, nextEndDate: string) => void;
+  }) => React.createElement(
+    'div',
+    { 'data-testid': 'date-range-picker' },
+    React.createElement('div', null, `${startDate || 'unset'}:${endDate || 'unset'}`),
+    React.createElement('button', {
+      type: 'button',
+      onClick: () => onChange('2026-04-01', '2026-04-01'),
+    }, 'set-same-day-range'),
+    React.createElement('button', {
+      type: 'button',
+      onClick: () => onChange('2026-04-01', '2026-04-03'),
+    }, 'set-three-day-range'),
+  ),
 }));
 
 vi.mock('../../components/IdealTravelTimeline', () => ({
@@ -144,7 +164,28 @@ vi.mock('../../services/aiService', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (
+        options
+        && typeof options.days === 'number'
+        && typeof options.nights === 'number'
+        && key === 'dates.summaryExact'
+      ) {
+        return `${options.days} days / ${options.nights} nights`;
+      }
+      if (
+        options
+        && typeof options.days === 'number'
+        && typeof options.nights === 'number'
+        && key === 'snapshot.daysNights'
+      ) {
+        return `${options.days} days / ${options.nights} nights`;
+      }
+      if (key === 'errors.minimumNightStay') {
+        return 'Choose an end date at least one night after your start date.';
+      }
+      return key;
+    },
     i18n: {
       language: 'en',
       resolvedLanguage: 'en',
@@ -210,5 +251,20 @@ describe('pages/CreateTripClassicLabPage', () => {
 
     expect(datesHeading.compareDocumentPosition(notesHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(notesHeading.compareDocumentPosition(travelerHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('shows exact-date day/night summaries and blocks same-day ranges', async () => {
+    const user = (await import('@testing-library/user-event')).default.setup();
+    renderPage();
+
+    for (const button of screen.getAllByRole('button', { name: 'set-same-day-range' })) {
+      await user.click(button);
+    }
+    expect(screen.getAllByText('Choose an end date at least one night after your start date.').length).toBeGreaterThan(0);
+
+    for (const button of screen.getAllByRole('button', { name: 'set-three-day-range' })) {
+      await user.click(button);
+    }
+    expect(screen.getAllByText('3 days / 2 nights').length).toBeGreaterThan(0);
   });
 });

--- a/tests/browser/createTripWizard.browser.test.ts
+++ b/tests/browser/createTripWizard.browser.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const mocks = vi.hoisted(() => ({
@@ -48,7 +48,27 @@ vi.mock('../../components/CountrySelect', () => ({
 }));
 
 vi.mock('../../components/DateRangePicker', () => ({
-  DateRangePicker: () => React.createElement('div', { 'data-testid': 'date-range-picker' }, 'date-range-picker'),
+  DateRangePicker: ({
+    startDate,
+    endDate,
+    onChange,
+  }: {
+    startDate?: string;
+    endDate?: string;
+    onChange: (nextStartDate: string, nextEndDate: string) => void;
+  }) => React.createElement(
+    'div',
+    { 'data-testid': 'date-range-picker' },
+    React.createElement('div', null, `${startDate || 'unset'}:${endDate || 'unset'}`),
+    React.createElement('button', {
+      type: 'button',
+      onClick: () => onChange('2026-04-01', '2026-04-01'),
+    }, 'set-same-day-range'),
+    React.createElement('button', {
+      type: 'button',
+      onClick: () => onChange('2026-04-01', '2026-04-03'),
+    }, 'set-three-day-range'),
+  ),
 }));
 
 vi.mock('../../components/MonthSeasonStrip', () => ({
@@ -127,8 +147,13 @@ vi.mock('react-i18next', () => ({
       if (options && typeof options.weeks === 'number' && key === 'wizard.dates.flexLength') {
         return `${options.weeks} weeks`;
       }
-      if (options && typeof options.days === 'number' && key === 'wizard.dates.exactLength') {
-        return `${options.days} days`;
+      if (
+        options
+        && typeof options.days === 'number'
+        && typeof options.nights === 'number'
+        && key === 'wizard.dates.exactLength'
+      ) {
+        return `${options.days} days / ${options.nights} nights`;
       }
       if (options && typeof options.current === 'number' && typeof options.total === 'number' && key === 'wizard.stepBadge') {
         return `Step ${options.current} of ${options.total}`;
@@ -138,6 +163,9 @@ vi.mock('react-i18next', () => ({
       }
       if (options && typeof options.window === 'string' && key === 'wizard.review.flexDates') {
         return `${options.weeks} weeks / ${options.window}`;
+      }
+      if (key === 'errors.minimumNightStay') {
+        return 'Choose an end date at least one night after your start date.';
       }
       return key;
     },
@@ -150,10 +178,33 @@ vi.mock('react-i18next', () => ({
 
 import { CreateTripV3Page } from '../../pages/CreateTripV3Page';
 
-const renderPage = (props?: Partial<React.ComponentProps<typeof CreateTripV3Page>>) => render(
+const encodePrefill = (value: unknown): string => {
+  const json = JSON.stringify(value);
+  const bytes = new TextEncoder().encode(json);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+};
+
+const decodePrefill = (encoded: string): Record<string, unknown> => {
+  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(base64);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
+};
+
+const renderPage = ({
+  initialEntries = ['/create-trip/wizard'],
+  props,
+}: {
+  initialEntries?: string[];
+  props?: Partial<React.ComponentProps<typeof CreateTripV3Page>>;
+} = {}) => render(
   React.createElement(
     MemoryRouter,
-    { initialEntries: ['/create-trip/wizard'] },
+    { initialEntries },
     React.createElement(CreateTripV3Page, {
       onTripGenerated: vi.fn(),
       onOpenManager: vi.fn(),
@@ -162,14 +213,43 @@ const renderPage = (props?: Partial<React.ComponentProps<typeof CreateTripV3Page
   )
 );
 
+const getPrimaryActions = (label: RegExp) => screen.getAllByRole('button', { name: label });
+
 const getPrimaryAction = (label: RegExp) => {
-  const matches = screen.getAllByRole('button', { name: label });
-  return matches[matches.length - 1];
+  const matches = getPrimaryActions(label);
+  return matches.find((button) => !button.hasAttribute('disabled')) ?? matches[matches.length - 1];
 };
 
 const clickPopularPick = async (user: ReturnType<typeof userEvent.setup>, label: string) => {
-  const matches = screen.getAllByText(label);
-  await user.click(matches[0]);
+  const matches = screen.getAllByRole('button', { name: label });
+  await user.click(matches.find((button) => !button.hasAttribute('disabled')) ?? matches[0]);
+};
+
+const continueWizard = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(getPrimaryAction(/wizard\.actions\.continue/i));
+};
+
+const waitForWizardText = async (text: string) => {
+  await waitFor(() => {
+    expect(screen.queryAllByText(text).length).toBeGreaterThan(0);
+  });
+};
+
+const buildPrefilledWizardEntry = (payload: unknown) => `/create-trip/wizard?prefill=${encodePrefill(payload)}`;
+
+const getClassicCardPrefill = () => {
+  const href = screen.getByRole('link', { name: 'labsBanner.links.classicCard' }).getAttribute('href') || '';
+  const url = new URL(href, 'https://travelflow.test');
+  const prefill = url.searchParams.get('prefill');
+  return prefill ? decodePrefill(prefill) : null;
+};
+
+const waitForPrefill = async (assertion: (payload: Record<string, unknown>) => void) => {
+  await waitFor(() => {
+    const payload = getClassicCardPrefill();
+    expect(payload).not.toBeNull();
+    assertion(payload as Record<string, unknown>);
+  });
 };
 
 describe('pages/CreateTripV3Page', () => {
@@ -183,11 +263,15 @@ describe('pages/CreateTripV3Page', () => {
     mocks.authState.isAuthenticated = true;
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it('reorders the first step based on the selected branch', async () => {
     const user = userEvent.setup();
     renderPage();
 
-    await user.click(screen.getByText('wizard.intent.options.known_dates_need_destination.title'));
+    await user.click(screen.getByRole('button', { name: /wizard\.intent\.options\.known_dates_need_destination\.title/i }));
 
     expect(screen.getByText('wizard.dates.title')).toBeInTheDocument();
     expect(screen.queryByText('wizard.destination.title')).not.toBeInTheDocument();
@@ -195,21 +279,52 @@ describe('pages/CreateTripV3Page', () => {
 
   it('submits the adaptive wizard with shared preference signals', async () => {
     const user = userEvent.setup();
-    renderPage();
+    renderPage({
+      initialEntries: [
+        buildPrefilledWizardEntry({
+          countries: ['Japan'],
+          mode: 'wizard',
+          meta: {
+            draft: {
+              version: 2,
+              wizardBranch: 'known_destinations_flexible_dates',
+              dateInputMode: 'flex',
+              flexWeeks: 2,
+              flexWindow: 'shoulder',
+            },
+          },
+        }),
+      ],
+    });
+    await waitForPrefill((payload) => {
+      expect(payload.countries).toEqual(['Japan']);
+      expect(payload.mode).toBe('wizard');
+      expect((payload.meta as { draft?: { wizardBranch?: string; dateInputMode?: string } }).draft?.wizardBranch)
+        .toBe('known_destinations_flexible_dates');
+      expect((payload.meta as { draft?: { wizardBranch?: string; dateInputMode?: string } }).draft?.dateInputMode)
+        .toBe('flex');
+    });
 
-    await user.click(screen.getByText('wizard.intent.options.known_destinations_flexible_dates.title'));
-    await clickPopularPick(user, 'Japan');
-    await user.click(getPrimaryAction(/wizard\.actions\.continue/i));
-    await user.click(getPrimaryAction(/wizard\.actions\.continue/i));
+    await user.click(screen.getByRole('button', { name: /wizard\.intent\.options\.known_destinations_flexible_dates\.title/i }));
+    await waitForWizardText('wizard.destination.title');
+    await waitFor(() => {
+      expect(screen.getByLabelText('country-select')).toHaveValue('Japan');
+    });
+    await continueWizard(user);
+    await waitForWizardText('wizard.dates.title');
+    await continueWizard(user);
+    await waitForWizardText('wizard.preferences.title');
 
-    await user.click(screen.getByText('traveler.options.family'));
-    await user.click(screen.getByText('transport.options.train'));
-    await user.click(getPrimaryAction(/wizard\.actions\.continue/i));
+    await user.click(screen.getByRole('button', { name: 'traveler.options.family' }));
+    await user.click(screen.getByRole('button', { name: 'transport.options.train' }));
+    await continueWizard(user);
+    await waitForWizardText('wizard.details.title');
 
-    await user.click(screen.getByText('wizard.budgetOptions.high'));
-    await user.click(screen.getByText('wizard.paceOptions.fast'));
+    await user.click(screen.getByRole('button', { name: 'wizard.budgetOptions.high' }));
+    await user.click(screen.getByRole('button', { name: 'wizard.paceOptions.fast' }));
     await user.type(screen.getByPlaceholderText('wizard.details.notesPlaceholder'), 'No overnight buses');
-    await user.click(getPrimaryAction(/wizard\.actions\.continue/i));
+    await continueWizard(user);
+    await waitForWizardText('wizard.review.title');
 
     await user.click(getPrimaryAction(/wizard\.actions\.generate/i));
 
@@ -234,17 +349,114 @@ describe('pages/CreateTripV3Page', () => {
     }));
   });
 
+  it('blocks same-day exact ranges and sends totalNights for valid exact trips', async () => {
+    const user = userEvent.setup();
+    renderPage({
+      initialEntries: [
+        buildPrefilledWizardEntry({
+          countries: ['Japan'],
+          startDate: '2026-04-01',
+          endDate: '2026-04-03',
+          mode: 'wizard',
+          meta: {
+            draft: {
+              version: 2,
+              wizardBranch: 'known_dates_need_destination',
+              dateInputMode: 'exact',
+            },
+          },
+        }),
+      ],
+    });
+    await waitForPrefill((payload) => {
+      expect(payload.countries).toEqual(['Japan']);
+      expect(payload.startDate).toBe('2026-04-01');
+      expect(payload.endDate).toBe('2026-04-03');
+      expect((payload.meta as { draft?: { wizardBranch?: string; dateInputMode?: string } }).draft?.wizardBranch)
+        .toBe('known_dates_need_destination');
+      expect((payload.meta as { draft?: { wizardBranch?: string; dateInputMode?: string } }).draft?.dateInputMode)
+        .toBe('exact');
+    });
+
+    await user.click(screen.getByRole('button', { name: /wizard\.intent\.options\.known_dates_need_destination\.title/i }));
+    await waitForWizardText('wizard.dates.title');
+    await waitForWizardText('2026-04-01:2026-04-03');
+
+    await user.click(screen.getAllByRole('button', { name: 'set-same-day-range' })[0]);
+    expect(screen.getByText('Choose an end date at least one night after your start date.')).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole('button', { name: 'set-three-day-range' })[0]);
+    expect(screen.getAllByText('3 days / 2 nights').length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(getPrimaryAction(/wizard\.actions\.continue/i)).toBeEnabled();
+    });
+
+    await continueWizard(user);
+    await waitForWizardText('wizard.destination.title');
+    await continueWizard(user);
+    await waitForWizardText('wizard.preferences.title');
+    await continueWizard(user);
+    await waitForWizardText('wizard.details.title');
+    await continueWizard(user);
+    await waitForWizardText('wizard.review.title');
+    await user.click(getPrimaryAction(/wizard\.actions\.generate/i));
+
+    await waitFor(() => {
+      expect(mocks.startClientAsyncTripGeneration).toHaveBeenCalledTimes(1);
+    });
+
+    const firstCall = mocks.startClientAsyncTripGeneration.mock.calls[0]?.[0];
+    expect(firstCall.inputSnapshot.payload.options).toEqual(expect.objectContaining({
+      countries: ['Japan'],
+      dateInputMode: 'exact',
+      startDate: '2026-04-01',
+      endDate: '2026-04-03',
+      totalDays: 3,
+      totalNights: 2,
+    }));
+  });
+
   it('asks for browser notification permission before generation when permission is undecided', async () => {
     const user = userEvent.setup();
     mocks.confirm.mockResolvedValue(true);
-    renderPage();
+    renderPage({
+      initialEntries: [
+        buildPrefilledWizardEntry({
+          countries: ['Japan'],
+          mode: 'wizard',
+          meta: {
+            draft: {
+              version: 2,
+              wizardBranch: 'known_destinations_flexible_dates',
+              dateInputMode: 'flex',
+              flexWeeks: 2,
+              flexWindow: 'shoulder',
+            },
+          },
+        }),
+      ],
+    });
+    await waitForPrefill((payload) => {
+      expect(payload.countries).toEqual(['Japan']);
+      expect((payload.meta as { draft?: { wizardBranch?: string; dateInputMode?: string } }).draft?.wizardBranch)
+        .toBe('known_destinations_flexible_dates');
+      expect((payload.meta as { draft?: { wizardBranch?: string; dateInputMode?: string } }).draft?.dateInputMode)
+        .toBe('flex');
+    });
 
-    await user.click(screen.getByText('wizard.intent.options.known_destinations_flexible_dates.title'));
-    await clickPopularPick(user, 'Japan');
-    await user.click(getPrimaryAction(/wizard\.actions\.continue/i));
-    await user.click(getPrimaryAction(/wizard\.actions\.continue/i));
-    await user.click(getPrimaryAction(/wizard\.actions\.continue/i));
-    await user.click(getPrimaryAction(/wizard\.actions\.continue/i));
+    await user.click(screen.getByRole('button', { name: /wizard\.intent\.options\.known_destinations_flexible_dates\.title/i }));
+    await waitForWizardText('wizard.destination.title');
+    await waitFor(() => {
+      expect(screen.getByLabelText('country-select')).toHaveValue('Japan');
+    });
+    await continueWizard(user);
+    await waitForWizardText('wizard.dates.title');
+    await continueWizard(user);
+    await waitForWizardText('wizard.preferences.title');
+    await continueWizard(user);
+    await waitForWizardText('wizard.details.title');
+    await continueWizard(user);
+    await waitForWizardText('wizard.review.title');
     await user.click(getPrimaryAction(/wizard\.actions\.generate/i));
 
     await waitFor(() => {

--- a/tests/browser/tripInfoModal.browser.test.ts
+++ b/tests/browser/tripInfoModal.browser.test.ts
@@ -10,7 +10,8 @@ vi.mock('react-i18next', () => ({
       if (key === 'tripView.infoDialog.tabs.debug') return 'Debug';
       if (key === 'tripView.infoDialog.general.meta.owner') return 'Owner';
       if (key === 'tripView.infoDialog.general.meta.access') return 'Access';
-      if (key === 'tripView.infoDialog.general.meta.totalDaysValue') return `${options?.count ?? ''} days`;
+      if (key === 'tripView.infoDialog.general.meta.tripSpan') return 'Days & nights';
+      if (key === 'tripView.infoDialog.general.meta.tripSpanValue') return `${options?.days ?? ''} days / ${options?.nights ?? ''} nights`;
       return key;
     },
   }),
@@ -38,7 +39,8 @@ describe('components/TripInfoModal ownership context', () => {
       isExamplePreview: false,
       tripMeta: {
         dateRange: 'Jan 1, 2026 – Jan 3, 2026',
-        totalDaysLabel: '3',
+        days: 3,
+        nights: 2,
         cityCount: 2,
         distanceLabel: '120 km',
       },
@@ -89,7 +91,8 @@ describe('components/TripInfoModal ownership context', () => {
       isExamplePreview: false,
       tripMeta: {
         dateRange: 'Jan 1, 2026 – Jan 3, 2026',
-        totalDaysLabel: '3',
+        days: 3,
+        nights: 2,
         cityCount: 2,
         distanceLabel: '120 km',
       },

--- a/tests/browser/tripview/TripInfoModal.browser.test.ts
+++ b/tests/browser/tripview/TripInfoModal.browser.test.ts
@@ -26,7 +26,8 @@ vi.mock('react-i18next', () => ({
       if (key === 'tripView.infoDialog.history.pendingSyncOne') return '1 latest change is saved locally and not synced yet.';
       if (key === 'tripView.infoDialog.general.favoriteAdd') return 'Add to favorites';
       if (key === 'tripView.infoDialog.general.favoriteOff') return 'Favorite';
-      if (key === 'tripView.infoDialog.general.meta.totalDaysValue') return `${options?.count ?? ''} days`;
+      if (key === 'tripView.infoDialog.general.meta.tripSpan') return 'Days & nights';
+      if (key === 'tripView.infoDialog.general.meta.tripSpanValue') return `${options?.days ?? ''} days / ${options?.nights ?? ''} nights`;
       return key;
     },
   }),
@@ -64,7 +65,8 @@ const buildProps = (): React.ComponentProps<typeof TripInfoModal> => ({
   isExamplePreview: false,
   tripMeta: {
     dateRange: 'Apr 1, 2026 – Apr 7, 2026',
-    totalDaysLabel: '7',
+    days: 7,
+    nights: 6,
     cityCount: 2,
     distanceLabel: '450 km',
   },

--- a/tests/unit/aiBenchmarkClassicScenarioService.test.ts
+++ b/tests/unit/aiBenchmarkClassicScenarioService.test.ts
@@ -57,9 +57,12 @@ describe('buildClassicBenchmarkScenario', () => {
     const result = buildClassicBenchmarkScenario(scenario);
 
     expect(result.totalDays).toBe(8);
+    expect(result.totalNights).toBe(7);
     expect(result.generationOptions.totalDays).toBe(8);
+    expect(result.generationOptions.totalNights).toBe(7);
     expect(result.generationOptions.specificCities).toBe('Lisbon, Porto');
     expect(result.input.totalDays).toBe(8);
+    expect(result.input.totalNights).toBe(7);
     expect(result.input.specificCities).toBe('Lisbon, Porto');
   });
 });

--- a/tests/unit/aiServicePromptBuilder.test.ts
+++ b/tests/unit/aiServicePromptBuilder.test.ts
@@ -31,6 +31,19 @@ describe('services/aiService buildClassicItineraryPrompt', () => {
     expect(prompt).not.toContain('Benchmark compact-output mode');
   });
 
+  it('uses total nights as the stay budget for exact-date trips', () => {
+    const prompt = buildClassicItineraryPrompt('Japan', {
+      totalDays: 3,
+      totalNights: 2,
+      dateInputMode: 'exact',
+      promptMode: 'default',
+    });
+
+    expect(prompt).toContain('The full itinerary MUST cover exactly 2 total nights across all city stays.');
+    expect(prompt).toContain('the "days" field means nights stayed');
+    expect(prompt).toContain('The trip spans 3 calendar days including the arrival day and departure day.');
+  });
+
   it('includes traveler, route, timing, and transport preference signals', () => {
     const prompt = buildClassicItineraryPrompt('Japan, South Korea', {
       totalDays: 14,

--- a/tests/unit/timelineVisualLayout.test.ts
+++ b/tests/unit/timelineVisualLayout.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
+import { getTimelineBounds } from '../../utils';
 import { getTimelineVisualSpan } from '../../utils/timelineVisualLayout';
 
 describe('getTimelineVisualSpan', () => {
-  it('keeps non-activity items on their original offsets', () => {
+  it('renders city stays from midday to midday', () => {
     expect(
       getTimelineVisualSpan({
         type: 'city',
-        startDateOffset: 2.25,
-        duration: 1.5,
+        startDateOffset: 2,
+        duration: 2,
       }),
     ).toEqual({
-      startOffset: 2.25,
-      endOffset: 3.75,
-      duration: 1.5,
+      startOffset: 2.5,
+      endOffset: 4.5,
+      duration: 2,
     });
   });
 
@@ -57,6 +58,44 @@ describe('getTimelineVisualSpan', () => {
       startOffset: 3.4,
       endOffset: 3.6,
       duration: 0.2,
+    });
+  });
+
+  it('expands timeline bounds to the touched calendar days for city stays', () => {
+    expect(
+      getTimelineBounds([
+        {
+          id: 'city-1',
+          type: 'city',
+          title: 'Tokyo',
+          startDateOffset: 0,
+          duration: 2,
+          color: 'border',
+          description: '',
+        },
+      ]),
+    ).toEqual({
+      startOffset: 0,
+      endOffset: 3,
+      dayCount: 3,
+    });
+
+    expect(
+      getTimelineBounds([
+        {
+          id: 'city-2',
+          type: 'city',
+          title: 'Osaka',
+          startDateOffset: 1,
+          duration: 1.5,
+          color: 'border',
+          description: '',
+        },
+      ]),
+    ).toEqual({
+      startOffset: 1,
+      endOffset: 3,
+      dayCount: 2,
     });
   });
 });

--- a/tests/unit/tripSpan.test.ts
+++ b/tests/unit/tripSpan.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { getExactTripDateSpan, getTripSpan, getTripSpanFromOffsets } from '../../shared/tripSpan';
+
+describe('shared/tripSpan', () => {
+  it('treats exact dates as touched days plus overnight span', () => {
+    const span = getExactTripDateSpan('2026-04-01', '2026-04-03');
+
+    expect(span).not.toBeNull();
+    expect(span).toMatchObject({
+      days: 3,
+      nights: 2,
+      compactLabel: '3D/2N',
+      longLabel: '3 days / 2 nights',
+    });
+  });
+
+  it('keeps same-day exact ranges at one touched day and zero nights', () => {
+    const span = getExactTripDateSpan('2026-04-01', '2026-04-01');
+
+    expect(span).not.toBeNull();
+    expect(span).toMatchObject({
+      days: 1,
+      nights: 0,
+      compactLabel: '1D/0N',
+    });
+  });
+
+  it('maps fractional city stays to the correct touched calendar days', () => {
+    const span = getTripSpan({
+      id: 'trip-1',
+      title: 'Sample Trip',
+      startDate: '2026-04-01',
+      items: [
+        {
+          id: 'city-1',
+          type: 'city',
+          startDateOffset: 1.25,
+          duration: 1.5,
+          title: 'Lisbon',
+          location: 'Lisbon',
+        },
+      ],
+    } as any);
+
+    expect(span).toMatchObject({
+      days: 3,
+      nights: 2,
+      compactLabel: '3D/2N',
+    });
+    expect([span.startDate.getFullYear(), span.startDate.getMonth(), span.startDate.getDate()]).toEqual([2026, 3, 2]);
+    expect([span.endDate.getFullYear(), span.endDate.getMonth(), span.endDate.getDate()]).toEqual([2026, 3, 4]);
+  });
+
+  it('uses floor and ceil offsets when deriving touched days directly', () => {
+    const span = getTripSpanFromOffsets('2026-04-01', {
+      startOffset: 0.5,
+      endOffset: 2,
+    });
+
+    expect(span).toMatchObject({
+      days: 3,
+      nights: 2,
+      compactLabel: '3D/2N',
+    });
+    expect([span.startDate.getFullYear(), span.startDate.getMonth(), span.startDate.getDate()]).toEqual([2026, 3, 1]);
+    expect([span.endDate.getFullYear(), span.endDate.getMonth(), span.endDate.getDate()]).toEqual([2026, 3, 3]);
+  });
+});

--- a/tests/unit/worktreeEnv.test.ts
+++ b/tests/unit/worktreeEnv.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  buildGitWorktreeAddArgs,
+  buildWorktreeEnvCopyPlan,
+  executeWorktreeEnvCopyPlan,
+  parseCreateWorktreeArgs,
+  resolvePrimaryCheckoutRootFromCommonDir,
+} from '../../scripts/worktreeEnv.ts';
+
+const tempDirs: string[] = [];
+
+const makeTempDir = (label: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), `${label}-`));
+  tempDirs.push(dir);
+  return dir;
+};
+
+describe('scripts/worktreeEnv', () => {
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (!dir) continue;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves the primary checkout from the shared git dir', () => {
+    expect(resolvePrimaryCheckoutRootFromCommonDir('/repo/.git')).toBe('/repo');
+  });
+
+  it('copies only env files that exist in the source checkout', () => {
+    const sourceRoot = makeTempDir('worktree-env-source');
+    const targetRoot = makeTempDir('worktree-env-target');
+
+    writeFileSync(join(sourceRoot, '.env.local'), 'API_KEY=test-key\n', 'utf8');
+
+    const plan = buildWorktreeEnvCopyPlan(sourceRoot, targetRoot);
+    const executed = executeWorktreeEnvCopyPlan(plan);
+
+    expect(executed).toEqual([
+      expect.objectContaining({ name: '.env', status: 'missing-source' }),
+      expect.objectContaining({ name: '.env.local', status: 'copied' }),
+    ]);
+    expect(readFileSync(join(targetRoot, '.env.local'), 'utf8')).toBe('API_KEY=test-key\n');
+  });
+
+  it('skips existing target files when overwrite is disabled', () => {
+    const sourceRoot = makeTempDir('worktree-env-source');
+    const targetRoot = makeTempDir('worktree-env-target');
+
+    writeFileSync(join(sourceRoot, '.env.local'), 'API_KEY=source\n', 'utf8');
+    writeFileSync(join(targetRoot, '.env.local'), 'API_KEY=target\n', 'utf8');
+
+    const plan = buildWorktreeEnvCopyPlan(sourceRoot, targetRoot, false);
+    const executed = executeWorktreeEnvCopyPlan(plan);
+
+    expect(executed[1]).toEqual(expect.objectContaining({
+      name: '.env.local',
+      status: 'existing-target',
+    }));
+    expect(readFileSync(join(targetRoot, '.env.local'), 'utf8')).toBe('API_KEY=target\n');
+  });
+
+  it('parses common worktree wrapper arguments and builds git args', () => {
+    const parsed = parseCreateWorktreeArgs([
+      '../travelflow-test',
+      '--branch',
+      'codex/test-branch',
+      '--ref',
+      'main',
+      '--force',
+      '--no-checkout',
+    ]);
+
+    expect(parsed).toEqual({
+      path: '../travelflow-test',
+      ref: 'main',
+      branch: 'codex/test-branch',
+      force: true,
+      detach: false,
+      noCheckout: true,
+    });
+    expect(buildGitWorktreeAddArgs(parsed)).toEqual([
+      'worktree',
+      'add',
+      '--force',
+      '--no-checkout',
+      '-b',
+      'codex/test-branch',
+      '../travelflow-test',
+      'main',
+    ]);
+  });
+
+  it('supports positional refs and rejects invalid argument combinations', () => {
+    expect(parseCreateWorktreeArgs(['../travelflow-test', 'main'])).toEqual({
+      path: '../travelflow-test',
+      ref: 'main',
+      branch: undefined,
+      force: false,
+      detach: false,
+      noCheckout: false,
+    });
+
+    expect(() => parseCreateWorktreeArgs(['../travelflow-test', '--branch', 'codex/test', '--detach']))
+      .toThrow('Cannot combine --detach with --branch.');
+  });
+});

--- a/utils.ts
+++ b/utils.ts
@@ -2,6 +2,7 @@ import LZString from 'lz-string';
 import { ActivityType, AppLanguage, ICoordinates, ITrip, ITimelineItem, IViewSettings, ISharedState, MapColorMode, TransportMode, TripPrefillData } from './types';
 import { normalizeTransportMode } from './shared/transportModes';
 import { DEFAULT_LOCALE, localeToIntlLocale, normalizeLocale } from './config/locales';
+import { getTimelineVisualRange } from './utils/timelineVisualLayout';
 
 export const BASE_PIXELS_PER_DAY = 120; // Width of one day column (Base Zoom 1.0)
 export const PIXELS_PER_DAY = BASE_PIXELS_PER_DAY; // Deprecated: Use prop passed from parent for zooming
@@ -278,16 +279,9 @@ export const getTimelineBounds = (
     options: { minDays?: number } = {}
 ): TimelineBounds => {
     const minDays = Math.max(1, Math.floor(options.minDays ?? 1));
-    let minStart = Number.POSITIVE_INFINITY;
-    let maxEnd = Number.NEGATIVE_INFINITY;
+    const visualRange = getTimelineVisualRange(items);
 
-    items.forEach(item => {
-        if (!Number.isFinite(item.startDateOffset) || !Number.isFinite(item.duration)) return;
-        minStart = Math.min(minStart, item.startDateOffset);
-        maxEnd = Math.max(maxEnd, item.startDateOffset + Math.max(item.duration, 0));
-    });
-
-    if (!Number.isFinite(minStart) || !Number.isFinite(maxEnd)) {
+    if (!visualRange) {
         return {
             startOffset: 0,
             endOffset: minDays,
@@ -295,8 +289,8 @@ export const getTimelineBounds = (
         };
     }
 
-    const startOffset = Math.floor(minStart);
-    const endOffset = Math.max(startOffset + minDays, Math.ceil(maxEnd));
+    const startOffset = Math.floor(visualRange.startOffset);
+    const endOffset = Math.max(startOffset + minDays, Math.ceil(visualRange.endOffset));
 
     return {
         startOffset,

--- a/utils/timelineVisualLayout.ts
+++ b/utils/timelineVisualLayout.ts
@@ -1,11 +1,17 @@
 import type { ITimelineItem } from '../types';
 
 const TIMELINE_DAY_EPSILON = 1e-4;
+const CITY_MIDDAY_OFFSET = 0.5;
 
 export interface TimelineVisualSpan {
   startOffset: number;
   endOffset: number;
   duration: number;
+}
+
+export interface TimelineVisualRange {
+  startOffset: number;
+  endOffset: number;
 }
 
 export function getTimelineVisualSpan(
@@ -14,6 +20,14 @@ export function getTimelineVisualSpan(
 ): TimelineVisualSpan {
   const startOffset = Number.isFinite(item.startDateOffset) ? item.startDateOffset : 0;
   const duration = Number.isFinite(item.duration) ? Math.max(0, item.duration) : 0;
+
+  if (item.type === 'city') {
+    return {
+      startOffset: startOffset + CITY_MIDDAY_OFFSET,
+      endOffset: startOffset + duration + CITY_MIDDAY_OFFSET,
+      duration,
+    };
+  }
 
   if (options?.vertical || item.type !== 'activity') {
     return {
@@ -32,4 +46,36 @@ export function getTimelineVisualSpan(
     endOffset: dayEnd,
     duration: dayEnd - dayStart,
   };
+}
+
+export function getTimelineVisualRange(
+  items: Array<Pick<ITimelineItem, 'type' | 'startDateOffset' | 'duration'>>,
+  options?: { vertical?: boolean },
+): TimelineVisualRange | null {
+  let minStart = Number.POSITIVE_INFINITY;
+  let maxEnd = Number.NEGATIVE_INFINITY;
+
+  items.forEach((item) => {
+    const span = getTimelineVisualSpan(item, options);
+    if (!Number.isFinite(span.startOffset) || !Number.isFinite(span.endOffset)) return;
+    minStart = Math.min(minStart, span.startOffset);
+    maxEnd = Math.max(maxEnd, span.endOffset);
+  });
+
+  if (!Number.isFinite(minStart) || !Number.isFinite(maxEnd) || maxEnd < minStart) {
+    return null;
+  }
+
+  return {
+    startOffset: minStart,
+    endOffset: maxEnd,
+  };
+}
+
+export function getTimelineVisualCenter(
+  item: Pick<ITimelineItem, 'type' | 'startDateOffset' | 'duration'>,
+  options?: { vertical?: boolean },
+): number {
+  const span = getTimelineVisualSpan(item, options);
+  return span.startOffset + (span.duration / 2);
 }


### PR DESCRIPTION
## Summary
- switch exact-date trip creation and timeline rendering to midday arrival/departure spans so stays render as half-day start/end blocks and summarize as days plus nights
- apply the shared span math across create-trip previews, real trip timelines, trip summaries, and AI night budgeting
- add worktree env bootstrap helpers plus Codex-facing git hook/docs so new worktrees copy `.env` and `.env.local`

## Verification
- `pnpm test:core`
- `pnpm dlx dotenv-cli -e .env.local -- pnpm build:netlify`
- `pnpm dlx react-doctor@latest . --verbose --diff`
