### PR TITLE
[codex] Correct v0.110.0 release timestamp

### DIFF
--- a/content/updates/2026-05-20-ai-provider-model-options.md
+++ b/content/updates/2026-05-20-ai-provider-model-options.md
@@ -3,7 +3,7 @@ id: rel-2026-05-20-ai-provider-model-options
 version: v0.110.0
 title: "Expanded AI model options for planning and benchmark runs"
 date: 2026-05-20
-published_at: 2026-05-20T14:07:19Z
+published_at: 2026-05-20T14:27:20Z
 status: published
 notify_in_app: false
 in_app_hours: 24


### PR DESCRIPTION
## Summary
- Corrects the v0.110.0 release note `published_at` to the actual Netlify production deploy timestamp.

## Test Plan
- [x] `node scripts/validate-updates.mjs` (passes with existing canonical-version warnings)
- [x] `git diff --check`
