### PR TITLE
[codex] Fix AI model selector visibility

### DIFF
--- a/config/aiModelCatalog.ts
+++ b/config/aiModelCatalog.ts
@@ -27,6 +27,11 @@ export const DEFAULT_CREATE_TRIP_MODEL_ID = `${'openai'}:${CURRENT_RUNTIME_MODEL
 
 export const CREATE_TRIP_PREFERRED_MODEL_IDS = [
     DEFAULT_CREATE_TRIP_MODEL_ID,
+    'openrouter:openai/gpt-5.5',
+    'openrouter:google/gemini-3.5-flash',
+    'openrouter:google/gemini-3.1-flash-lite',
+    'openrouter:x-ai/grok-4.3',
+    'openrouter:qwen/qwen3.5-plus-20260420',
     'openrouter:minimax/minimax-m2.5',
     'perplexity:perplexity/sonar-pro',
 ] as const;

--- a/content/updates/2026-05-20-ai-model-selector-visibility.md
+++ b/content/updates/2026-05-20-ai-model-selector-visibility.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-05-20-ai-model-selector-visibility
+version: v0.111.0
+title: "Improved visibility for new AI model choices"
+date: 2026-05-20
+published_at: 2026-05-20T15:25:00Z
+status: published
+notify_in_app: false
+in_app_hours: 24
+summary: "Made the newest AI model choices easier to find in trip creation and benchmark setup."
+---
+
+## Changes
+- [x] [Fixed] 🔎 New AI model choices now appear more prominently in trip creation and existing benchmark setups.
+- [ ] [Internal] 🧪 Existing default benchmark preferences are migrated to the latest target set without overriding custom model selections.

--- a/netlify/edge-functions/ai-benchmark.ts
+++ b/netlify/edge-functions/ai-benchmark.ts
@@ -1625,7 +1625,7 @@ const handleTelemetry = async (
 
 const normalizeBenchmarkPreferencesForStorage = (
   value: unknown,
-  options: { defaultStartDate: string; defaultEndDate: string },
+  options: { defaultStartDate: string; defaultEndDate: string; mergeFallbackModelIds?: boolean },
 ): BenchmarkPreferencesPayload => {
   const fallbackPresets = createSystemBenchmarkPresets(options.defaultStartDate, options.defaultEndDate);
   return normalizeBenchmarkPreferencesPayload(value, {
@@ -1634,6 +1634,7 @@ const normalizeBenchmarkPreferencesForStorage = (
     defaultStartDate: options.defaultStartDate,
     defaultEndDate: options.defaultEndDate,
     allowedModelIds: ACTIVE_BENCHMARK_MODEL_ID_SET,
+    mergeFallbackModelIds: options.mergeFallbackModelIds,
   });
 };
 
@@ -1792,6 +1793,7 @@ const handlePreferences = async (
     }, {
       defaultStartDate: startDate,
       defaultEndDate: endDate,
+      mergeFallbackModelIds: true,
     });
 
     // Ensure first access has a persisted row in DB instead of local storage only.

--- a/pages/AdminAiBenchmarkPage.tsx
+++ b/pages/AdminAiBenchmarkPage.tsx
@@ -909,13 +909,17 @@ export const AdminAiBenchmarkPage: React.FC = () => {
         setMessage(`Custom JSON applied to benchmark mask (${customScenarioDraftParse.flow}).`);
     }, [applyMaskScenario, customScenarioDraftParse.error, customScenarioDraftParse.flow, customScenarioDraftParse.scenario]);
 
-    const normalizePreferencesForClient = useCallback((value: unknown): BenchmarkPreferencesPayload => {
+    const normalizePreferencesForClient = useCallback((
+        value: unknown,
+        options?: { mergeFallbackModelIds?: boolean },
+    ): BenchmarkPreferencesPayload => {
         return normalizeBenchmarkPreferencesPayload(value, {
             fallbackPresets: defaultPresets,
             defaultStartDate: defaultDates.startDate,
             defaultEndDate: defaultDates.endDate,
             fallbackModelIds: defaultModelTargetIds,
             allowedModelIds: activeModelIdSet,
+            mergeFallbackModelIds: options?.mergeFallbackModelIds,
         });
     }, [activeModelIdSet, defaultDates.endDate, defaultDates.startDate, defaultModelTargetIds, defaultPresets]);
 
@@ -1070,7 +1074,9 @@ export const AdminAiBenchmarkPage: React.FC = () => {
                 method: 'GET',
             }) as BenchmarkPreferencesApiResponse;
 
-            const normalized = normalizePreferencesForClient(payload.preferences || {});
+            const normalized = normalizePreferencesForClient(payload.preferences || {}, {
+                mergeFallbackModelIds: true,
+            });
             setModelTargetIds(normalized.modelTargets);
             setPresetConfigs(normalized.presets);
             setSelectedPresetId(normalized.selectedPresetId);

--- a/pages/CreateTripClassicLabPage.tsx
+++ b/pages/CreateTripClassicLabPage.tsx
@@ -110,6 +110,7 @@ import {
 import { decodeTripPrefill } from '../services/tripPrefillDecoder';
 import {
     AI_MODEL_CATALOG,
+    CREATE_TRIP_PREFERRED_MODEL_IDS,
     DEFAULT_CREATE_TRIP_MODEL_ID,
     getAiModelById,
     getCreateTripModelOptions,
@@ -213,7 +214,7 @@ const MODEL_PREFERENCE_NOTE_KEY_BY_ID: Record<string, string> = {
     'perplexity:perplexity/sonar-pro': 'modelPicker.badges.veryFast',
     [DEFAULT_CREATE_TRIP_MODEL_ID]: 'modelPicker.badges.default',
 };
-const CREATE_TRIP_PREFERRED_MODEL_ID_SET = new Set(Object.keys(MODEL_PREFERENCE_NOTE_KEY_BY_ID));
+const CREATE_TRIP_PREFERRED_MODEL_ID_SET = new Set<string>(CREATE_TRIP_PREFERRED_MODEL_IDS);
 const CREATE_TRIP_MODELS = getCreateTripModelOptions(AI_MODEL_CATALOG);
 const IS_DEV = Boolean((import.meta as any)?.env?.DEV);
 

--- a/services/aiBenchmarkPreferencesService.ts
+++ b/services/aiBenchmarkPreferencesService.ts
@@ -53,6 +53,16 @@ export const BENCHMARK_DEFAULT_MODEL_IDS = [
     'qwen:qwen/qwen3.5-plus-02-15',
 ];
 
+const BENCHMARK_PREVIOUS_DEFAULT_MODEL_IDS = [
+    'openai:gpt-5.4',
+    'gemini:gemini-3.1-pro-preview',
+    'gemini:gemini-3-pro-preview',
+    'openai:gpt-5.2-pro',
+    'anthropic:claude-sonnet-4.6',
+    'perplexity:perplexity/sonar',
+    'qwen:qwen/qwen3.5-plus-02-15',
+];
+
 export const DEFAULT_BENCHMARK_MASK_SCENARIO: BenchmarkMaskScenario = {
     destinations: 'Japan',
     dateInputMode: 'exact',
@@ -208,6 +218,7 @@ export const normalizeModelTargetIds = (
     options?: {
         allowedModelIds?: Set<string>;
         fallbackModelIds?: string[];
+        mergeFallbackModelIds?: boolean;
     },
 ): string[] => {
     const list = Array.isArray(value) ? value : [];
@@ -220,10 +231,29 @@ export const normalizeModelTargetIds = (
         ? deduped.filter((entry) => options.allowedModelIds?.has(entry))
         : deduped;
 
-    if (filtered.length > 0) return filtered;
     const fallback = options?.fallbackModelIds?.filter(Boolean) || BENCHMARK_DEFAULT_MODEL_IDS;
+    const allowedFallback = options?.allowedModelIds
+        ? fallback.filter((entry) => options.allowedModelIds?.has(entry))
+        : fallback;
+
+    if (filtered.length > 0) {
+        if (!options?.mergeFallbackModelIds) return filtered;
+
+        const legacyDefaults = options?.allowedModelIds
+            ? BENCHMARK_PREVIOUS_DEFAULT_MODEL_IDS.filter((entry) => options.allowedModelIds?.has(entry))
+            : BENCHMARK_PREVIOUS_DEFAULT_MODEL_IDS;
+        const isLegacyDefaultSelection = (
+            legacyDefaults.length > 0
+            && filtered.length === legacyDefaults.length
+            && legacyDefaults.every((entry, index) => filtered[index] === entry)
+        );
+
+        if (!isLegacyDefaultSelection) return filtered;
+
+        return allowedFallback.length > 0 ? allowedFallback : filtered;
+    }
+
     if (options?.allowedModelIds) {
-        const allowedFallback = fallback.filter((entry) => options.allowedModelIds?.has(entry));
         if (allowedFallback.length > 0) return allowedFallback;
     }
     return fallback.length > 0 ? fallback : [...BENCHMARK_DEFAULT_MODEL_IDS];
@@ -304,6 +334,7 @@ export const normalizeBenchmarkPreferencesPayload = (
         defaultStartDate?: string | null;
         defaultEndDate?: string | null;
         allowedModelIds?: Set<string>;
+        mergeFallbackModelIds?: boolean;
     },
 ): BenchmarkPreferencesPayload => {
     const typed = isRecord(value) ? value : {};
@@ -317,6 +348,7 @@ export const normalizeBenchmarkPreferencesPayload = (
     const modelTargets = normalizeModelTargetIds(typed.modelTargets, {
         allowedModelIds: options?.allowedModelIds,
         fallbackModelIds,
+        mergeFallbackModelIds: options?.mergeFallbackModelIds,
     });
     const selectedPresetIdRaw = normalizeText(typed.selectedPresetId);
     const selectedPresetId = presets.some((preset) => preset.id === selectedPresetIdRaw)

--- a/tests/unit/aiBenchmarkPreferencesService.test.ts
+++ b/tests/unit/aiBenchmarkPreferencesService.test.ts
@@ -117,4 +117,33 @@ describe('services/aiBenchmarkPreferencesService', () => {
     expect(payload.selectedPresetId).toBe(fallbackPresets[0]?.id);
     expect(payload.presets).toEqual(fallbackPresets);
   });
+
+  it('can merge newly added default targets into an existing saved default preference payload', () => {
+    const fallbackPresets = createSystemBenchmarkPresets('2026-05-10', '2026-05-24');
+    const newDefaultTargets = [
+      'openrouter:openai/gpt-5.5',
+      'openrouter:google/gemini-3.5-flash',
+      'openrouter:google/gemini-3.1-flash-lite',
+      'openrouter:x-ai/grok-4.3',
+      'openrouter:qwen/qwen3.5-plus-20260420',
+    ];
+    const legacyDefaultTargets = BENCHMARK_DEFAULT_MODEL_IDS.filter((modelId) => !newDefaultTargets.includes(modelId));
+    const allowed = new Set(BENCHMARK_DEFAULT_MODEL_IDS);
+
+    const payload = normalizeBenchmarkPreferencesPayload(
+      {
+        modelTargets: legacyDefaultTargets,
+        presets: fallbackPresets,
+        selectedPresetId: fallbackPresets[0]?.id,
+      },
+      {
+        fallbackPresets,
+        fallbackModelIds: BENCHMARK_DEFAULT_MODEL_IDS,
+        allowedModelIds: allowed,
+        mergeFallbackModelIds: true,
+      },
+    );
+
+    expect(payload.modelTargets).toEqual(BENCHMARK_DEFAULT_MODEL_IDS);
+  });
 });

--- a/tests/unit/aiModelCatalog.test.ts
+++ b/tests/unit/aiModelCatalog.test.ts
@@ -85,6 +85,13 @@ describe('config/aiModelCatalog', () => {
     expect(options.slice(0, CREATE_TRIP_PREFERRED_MODEL_IDS.length).map((item) => item.id)).toEqual(
       [...CREATE_TRIP_PREFERRED_MODEL_IDS]
     );
+    expect([...CREATE_TRIP_PREFERRED_MODEL_IDS]).toEqual(expect.arrayContaining([
+      'openrouter:openai/gpt-5.5',
+      'openrouter:google/gemini-3.5-flash',
+      'openrouter:google/gemini-3.1-flash-lite',
+      'openrouter:x-ai/grok-4.3',
+      'openrouter:qwen/qwen3.5-plus-20260420',
+    ]));
     expect(new Set(options.map((item) => item.id))).toEqual(uniqueActiveIds);
     expect(options).toHaveLength(uniqueActiveIds.size);
   });


### PR DESCRIPTION
## Summary
- Promote the new OpenRouter model additions into the Create Trip top-picks list so admins see them immediately in the selector.
- Migrate existing saved benchmark preferences that still match the old default model set to the new default model target list.
- Publish v0.111.0 release metadata for the selector visibility fix.

## Validation
- `volta run --node 22 pnpm install --frozen-lockfile`
- `volta run --node 22 node node_modules/vitest/vitest.mjs run tests/unit/aiModelCatalog.test.ts tests/unit/aiProviderRuntime.test.ts tests/unit/aiBenchmarkPreferencesService.test.ts --reporter=default`
- `volta run --node 22 pnpm edge:validate`
- `volta run --node 22 pnpm test:core`
- `volta run --node 22 pnpm build:netlify`
- `git diff --check`
