### PR TITLE
[codex] Correct v0.111.0 release timestamp

### DIFF
--- a/content/updates/2026-05-20-ai-model-selector-visibility.md
+++ b/content/updates/2026-05-20-ai-model-selector-visibility.md
@@ -3,7 +3,7 @@ id: rel-2026-05-20-ai-model-selector-visibility
 version: v0.111.0
 title: "Improved visibility for new AI model choices"
 date: 2026-05-20
-published_at: 2026-05-20T15:25:00Z
+published_at: 2026-05-20T15:44:51Z
 status: published
 notify_in_app: false
 in_app_hours: 24


### PR DESCRIPTION
## Summary
- Corrects the v0.111.0 release note `published_at` to the actual production deploy time.
- Keeps the release version unchanged.

## Validation
- `node scripts/validate-updates.mjs`
