### PR TITLE
[codex] Fix AI model family grouping and OpenRouter JSON mode

### DIFF
--- a/config/aiModelCatalog.ts
+++ b/config/aiModelCatalog.ts
@@ -38,6 +38,22 @@ export const CREATE_TRIP_PREFERRED_MODEL_IDS = [
 
 const ESTIMATE_NOTE = 'Estimate for one classic itinerary generation; real cost varies by prompt/output size.';
 
+const MODEL_FAMILY_SORT_ORDER: Record<string, number> = {
+    OpenAI: 0,
+    'Google Gemini': 1,
+    Anthropic: 2,
+    xAI: 3,
+    Perplexity: 4,
+    Qwen: 5,
+    MiniMax: 6,
+    'Moonshot AI': 7,
+    'Z.ai': 8,
+    DeepSeek: 9,
+    NVIDIA: 10,
+    'OpenRouter (Free)': 11,
+    OpenRouter: 12,
+};
+
 type RawAiModelCatalogItem = Omit<AiModelCatalogItem, 'providerLabel' | 'providerShortName'> & {
     providerLabel?: string;
     providerShortName?: string;
@@ -309,7 +325,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:openai/gpt-oss-20b:free',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter (Free)',
+        providerLabel: 'OpenAI',
+        providerShortName: 'OpenAI',
         model: 'openai/gpt-oss-20b:free',
         label: 'GPT-OSS 20B (Free)',
         availability: 'active',
@@ -320,7 +337,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:qwen/qwen3-coder:free',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter (Free)',
+        providerLabel: 'Qwen',
+        providerShortName: 'Qwen',
         model: 'qwen/qwen3-coder:free',
         label: 'Qwen3 Coder (Free)',
         availability: 'active',
@@ -331,7 +349,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:nvidia/nemotron-3-super-120b-a12b:free',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter (Free)',
+        providerLabel: 'NVIDIA',
+        providerShortName: 'NVIDIA',
         model: 'nvidia/nemotron-3-super-120b-a12b:free',
         label: 'Nemotron 3 Super (Free)',
         availability: 'active',
@@ -342,7 +361,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:openai/gpt-5.4-nano',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'OpenAI',
+        providerShortName: 'OpenAI',
         model: 'openai/gpt-5.4-nano',
         label: 'GPT-5.4 Nano',
         availability: 'active',
@@ -353,7 +373,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:openai/gpt-5.4-mini',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'OpenAI',
+        providerShortName: 'OpenAI',
         model: 'openai/gpt-5.4-mini',
         label: 'GPT-5.4 Mini',
         availability: 'active',
@@ -364,7 +385,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:google/gemini-3.5-flash',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'Google Gemini',
+        providerShortName: 'Gemini',
         model: 'google/gemini-3.5-flash',
         label: 'Gemini 3.5 Flash',
         availability: 'active',
@@ -376,7 +398,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:google/gemini-3.1-flash-lite',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'Google Gemini',
+        providerShortName: 'Gemini',
         model: 'google/gemini-3.1-flash-lite',
         label: 'Gemini 3.1 Flash Lite',
         availability: 'active',
@@ -388,7 +411,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:x-ai/grok-4.3',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'xAI',
+        providerShortName: 'xAI',
         model: 'x-ai/grok-4.3',
         label: 'Grok 4.3',
         availability: 'active',
@@ -400,7 +424,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:openai/gpt-5.5',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'OpenAI',
+        providerShortName: 'OpenAI',
         model: 'openai/gpt-5.5',
         label: 'GPT-5.5',
         availability: 'active',
@@ -412,7 +437,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:qwen/qwen3.5-plus-20260420',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'Qwen',
+        providerShortName: 'Qwen',
         model: 'qwen/qwen3.5-plus-20260420',
         label: 'Qwen3.5 Plus 2026-04-20',
         availability: 'active',
@@ -424,7 +450,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:z-ai/glm-5',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'Z.ai',
+        providerShortName: 'Z.ai',
         model: 'z-ai/glm-5',
         label: 'GLM 5',
         availability: 'active',
@@ -436,7 +463,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:deepseek/deepseek-v3.2',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'DeepSeek',
+        providerShortName: 'DeepSeek',
         model: 'deepseek/deepseek-v3.2',
         label: 'DeepSeek V3.2',
         availability: 'active',
@@ -448,7 +476,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:x-ai/grok-4.1-fast',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'xAI',
+        providerShortName: 'xAI',
         model: 'x-ai/grok-4.1-fast',
         label: 'Grok 4.1 Fast',
         availability: 'active',
@@ -460,7 +489,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:x-ai/grok-4.20-beta',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'xAI',
+        providerShortName: 'xAI',
         model: 'x-ai/grok-4.20-beta',
         label: 'Grok 4.20 Beta',
         availability: 'active',
@@ -471,7 +501,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:minimax/minimax-m2.5',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'MiniMax',
+        providerShortName: 'MiniMax',
         model: 'minimax/minimax-m2.5',
         label: 'MiniMax M2.5',
         availability: 'active',
@@ -483,7 +514,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:moonshotai/kimi-k2.5',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'Moonshot AI',
+        providerShortName: 'Moonshot',
         model: 'moonshotai/kimi-k2.5',
         label: 'Kimi K2.5',
         availability: 'active',
@@ -495,7 +527,8 @@ const RAW_AI_MODEL_CATALOG: RawAiModelCatalogItem[] = [
     {
         id: 'openrouter:qwen/qwen3.5-9b',
         provider: 'openrouter',
-        providerLabel: 'OpenRouter',
+        providerLabel: 'Qwen',
+        providerShortName: 'Qwen',
         model: 'qwen/qwen3.5-9b',
         label: 'Qwen3.5-9B',
         availability: 'active',
@@ -519,9 +552,15 @@ const toReleaseTs = (releasedAt: string): number => {
     return Number.isFinite(parsed) ? parsed : 0;
 };
 
+const getModelFamilySortOrder = (item: AiModelCatalogItem): number => {
+    const labelOrder = MODEL_FAMILY_SORT_ORDER[item.providerLabel];
+    if (Number.isFinite(labelOrder)) return labelOrder;
+    return 100 + getAiProviderSortOrder(item.provider);
+};
+
 export const sortAiModels = (items: AiModelCatalogItem[]): AiModelCatalogItem[] => {
     return [...items].sort((left, right) => {
-        const providerDelta = getAiProviderSortOrder(left.provider) - getAiProviderSortOrder(right.provider);
+        const providerDelta = getModelFamilySortOrder(left) - getModelFamilySortOrder(right);
         if (providerDelta !== 0) return providerDelta;
 
         const releaseDelta = toReleaseTs(right.releasedAt) - toReleaseTs(left.releasedAt);

--- a/content/updates/2026-05-21-ai-model-family-routing-and-openrouter-json.md
+++ b/content/updates/2026-05-21-ai-model-family-routing-and-openrouter-json.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-05-21-ai-model-family-routing-and-openrouter-json
+version: v0.112.0
+title: "Clearer AI model families and stronger JSON generation"
+date: 2026-05-21
+published_at: 2026-05-21T06:51:29Z
+status: published
+notify_in_app: false
+in_app_hours: 24
+summary: "Grouped AI choices by model family and made OpenRouter itinerary output more reliable."
+---
+
+## Changes
+- [x] [Improved] 🧭 AI model selectors now group choices by model family instead of routing gateway.
+- [x] [Fixed] 🧩 OpenRouter trip generation now requests stricter JSON output for more reliable Gemini results.
+- [ ] [Internal] 🏷️ Benchmark model targets now mark the frontend current model.

--- a/netlify/edge-lib/ai-provider-runtime.ts
+++ b/netlify/edge-lib/ai-provider-runtime.ts
@@ -1337,8 +1337,8 @@ const generateWithOpenRouter = async (
           body: JSON.stringify({
             model,
             max_tokens: maxOutputTokens,
-            temperature: 0.2,
-            response_format: { type: "text" },
+            temperature: 0,
+            response_format: { type: "json_object" },
             messages: [
               {
                 role: "system",

--- a/pages/AdminAiBenchmarkPage.tsx
+++ b/pages/AdminAiBenchmarkPage.tsx
@@ -272,15 +272,21 @@ const ProviderLabel: React.FC<{
     logoSize = 14,
 }) => {
     const metadata = getAiProviderMetadata(provider);
+    const catalogModel = model
+        ? AI_MODEL_CATALOG.find((item) => item.provider === provider && item.model === model)
+        : null;
+    const providerLabel = catalogModel?.providerLabel || metadata.label;
+    const providerShortName = catalogModel?.providerShortName || metadata.shortName;
+    const modelLabel = catalogModel?.label || model;
     return (
         <span className="inline-flex min-w-0 items-center gap-1.5">
             <AiProviderLogo provider={provider} model={model} size={logoSize} />
-            <span className={providerClassName || 'font-semibold text-slate-800'} title={`${metadata.label} (${provider})`}>
-                {metadata.shortName}
+            <span className={providerClassName || 'font-semibold text-slate-800'} title={`${providerLabel} (${provider})`}>
+                {providerShortName}
             </span>
-            {model && showModel ? (
+            {modelLabel && showModel ? (
                 <span className={modelClassName || 'truncate text-slate-600'}>
-                    / {model}
+                    / {modelLabel}
                 </span>
             ) : null}
         </span>
@@ -2327,6 +2333,11 @@ export const AdminAiBenchmarkPage: React.FC = () => {
                                                 logoSize={12}
                                             />
                                             <span className={`font-semibold ${isActive ? '' : 'line-through'}`}>{model.label}</span>
+                                            {model.isCurrentRuntime && (
+                                                <span className="rounded-full border border-indigo-200 bg-indigo-50 px-1.5 py-0.5 text-[10px] font-semibold text-indigo-700">
+                                                    Frontend current
+                                                </span>
+                                            )}
                                             <button
                                                 type="button"
                                                 onClick={() => toggleModelTargetActive(model.id)}
@@ -2798,13 +2809,8 @@ export const AdminAiBenchmarkPage: React.FC = () => {
                             {Object.entries(groupedModels).map(([providerLabel, models]) => (
                                 <div key={providerLabel} className="space-y-1">
                                     <div className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                                        <AiProviderLogo provider={models[0]?.provider || providerLabel} size={12} />
+                                        <AiProviderLogo provider={models[0]?.provider || providerLabel} model={models[0]?.model} size={12} />
                                         <span>{providerLabel}</span>
-                                        {models[0]?.provider ? (
-                                            <span className="rounded-full border border-slate-300 bg-white px-1.5 py-0 text-[10px] text-slate-500 normal-case">
-                                                {getAiProviderMetadata(models[0].provider).shortName}
-                                            </span>
-                                        ) : null}
                                     </div>
                                     <div className="space-y-1">
                                         {models.map((model) => {
@@ -2825,9 +2831,14 @@ export const AdminAiBenchmarkPage: React.FC = () => {
                                                     ].join(' ')}
                                                 >
                                                     <span className="inline-flex min-w-0 items-center gap-1.5">
-                                        <AiProviderLogo provider={model.provider} model={model.model} size={12} />
-                                        <span className="min-w-0 truncate font-semibold">{model.label}</span>
-                                    </span>
+                                                        <AiProviderLogo provider={model.provider} model={model.model} size={12} />
+                                                        <span className="min-w-0 truncate font-semibold">{model.label}</span>
+                                                        {model.isCurrentRuntime && (
+                                                            <span className="shrink-0 rounded-full border border-indigo-200 bg-indigo-50 px-1.5 py-0.5 text-[10px] font-semibold text-indigo-700">
+                                                                Frontend current
+                                                            </span>
+                                                        )}
+                                                    </span>
                                                     <span className="ml-2 shrink-0 text-[10px] text-slate-500">{model.estimatedCostPerQueryLabel}</span>
                                                 </button>
                                             );

--- a/tests/unit/aiModelCatalog.test.ts
+++ b/tests/unit/aiModelCatalog.test.ts
@@ -52,27 +52,36 @@ describe('config/aiModelCatalog', () => {
     expect(defaultModel.isCurrentRuntime).toBe(true);
   });
 
-  it('sorts openrouter after direct providers and new provider families', () => {
+  it('sorts model families with OpenAI first even when a model is served through OpenRouter', () => {
     const sorted = sortAiModels(AI_MODEL_CATALOG);
-    const providerOrder = sorted.map((item) => item.provider);
+    const providerLabelOrder = sorted.map((item) => item.providerLabel);
 
-    const firstOpenRouterIndex = providerOrder.indexOf('openrouter');
-    const lastQwenIndex = providerOrder.lastIndexOf('qwen');
+    expect(providerLabelOrder[0]).toBe('OpenAI');
+    expect(sorted.find((item) => item.id === 'openrouter:openai/gpt-5.5')?.providerLabel).toBe('OpenAI');
+    expect(sorted.find((item) => item.id === 'openrouter:google/gemini-3.5-flash')?.providerLabel).toBe('Google Gemini');
+    expect(sorted.find((item) => item.id === 'openrouter:x-ai/grok-4.3')?.providerLabel).toBe('xAI');
+    expect(sorted.find((item) => item.id === 'openrouter:qwen/qwen3.5-plus-20260420')?.providerLabel).toBe('Qwen');
 
-    expect(firstOpenRouterIndex).toBeGreaterThan(-1);
-    expect(lastQwenIndex).toBeGreaterThan(-1);
-    expect(firstOpenRouterIndex).toBeGreaterThan(lastQwenIndex);
+    expect(providerLabelOrder.indexOf('OpenAI')).toBeLessThan(providerLabelOrder.indexOf('Google Gemini'));
   });
 
-  it('groups entries by provider label', () => {
+  it('groups entries by model family label instead of routing gateway label', () => {
     const grouped = groupAiModelsByProvider(AI_MODEL_CATALOG);
     expect(grouped['Google Gemini']?.length).toBeGreaterThan(0);
     expect(grouped.OpenAI?.length).toBeGreaterThan(0);
     expect(grouped.Anthropic?.length).toBeGreaterThan(0);
     expect(grouped.Perplexity?.length).toBeGreaterThan(0);
     expect(grouped.Qwen?.length).toBeGreaterThan(0);
-    expect(grouped.OpenRouter?.length).toBeGreaterThan(0);
+    expect(grouped.xAI?.map((item) => item.id)).toContain('openrouter:x-ai/grok-4.3');
     expect(grouped['OpenRouter (Free)']?.length).toBeGreaterThan(0);
+    expect(grouped['OpenRouter (Free)']?.map((item) => item.id)).toEqual(['openrouter:openrouter/free']);
+    expect(grouped.OpenAI?.map((item) => item.id)).toContain('openrouter:openai/gpt-5.5');
+    expect(grouped['Google Gemini']?.map((item) => item.id)).toEqual(expect.arrayContaining([
+      'openrouter:google/gemini-3.5-flash',
+      'openrouter:google/gemini-3.1-flash-lite',
+    ]));
+    expect(grouped.Qwen?.map((item) => item.id)).toContain('openrouter:qwen/qwen3.5-plus-20260420');
+    expect(grouped.OpenRouter).toBeUndefined();
   });
 
   it('prioritizes create-trip preferred models and keeps full active coverage', () => {

--- a/tests/unit/aiProviderRuntime.test.ts
+++ b/tests/unit/aiProviderRuntime.test.ts
@@ -755,11 +755,12 @@ describe('netlify/edge-lib/ai-provider-runtime', () => {
     const perplexityRequest = (fetchMock.mock.calls[0] as [string, RequestInit])[1];
     const perplexityBody = JSON.parse(String(perplexityRequest.body));
     expect(perplexityBody.model).toBe('perplexity/sonar');
-    expect(perplexityBody.response_format?.type).toBe('text');
+    expect(perplexityBody.response_format?.type).toBe('json_object');
     const qwenRequest = (fetchMock.mock.calls[1] as [string, RequestInit])[1];
     const qwenBody = JSON.parse(String(qwenRequest.body));
     expect(qwenBody.model).toBe('qwen/qwen3.5-plus-02-15');
-    expect(qwenBody.response_format?.type).toBe('text');
+    expect(qwenBody.response_format?.type).toBe('json_object');
+    expect(qwenBody.temperature).toBe(0);
 
     expect(perplexityResult.ok).toBe(true);
     if (perplexityResult.ok) {
@@ -772,6 +773,35 @@ describe('netlify/edge-lib/ai-provider-runtime', () => {
       expect(qwenResult.value.meta.provider).toBe('qwen');
       expect(qwenResult.value.meta.model).toBe('qwen/qwen3.5-plus-02-15');
     }
+  });
+
+  it('requests OpenRouter Gemini models in JSON mode for itinerary payloads', async () => {
+    stubDenoEnv({
+      OPENROUTER_API_KEY: 'test-key',
+    });
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        model: 'google/gemini-3.5-flash',
+        choices: [{ message: { content: '{"title":"Gemini json mode"}' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+      }),
+    );
+
+    const result = await generateProviderItinerary({
+      prompt: '{"request":"gemini-openrouter"}',
+      provider: 'openrouter',
+      model: 'google/gemini-3.5-flash',
+      timeoutMs: 30_000,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = (fetchMock.mock.calls[0] as [string, RequestInit])[1];
+    const body = JSON.parse(String(init.body));
+    expect(body.model).toBe('google/gemini-3.5-flash');
+    expect(body.response_format).toEqual({ type: 'json_object' });
+    expect(body.temperature).toBe(0);
+    expect(result.ok).toBe(true);
   });
 
   it('passes maxOutputTokens override through to provider requests', async () => {


### PR DESCRIPTION
## Summary
- Group OpenRouter-routed models by their actual model family in selectors instead of by the routing gateway.
- Mark the frontend current model in the admin benchmark target picker and target chips.
- Request deterministic JSON mode for OpenRouter itinerary generation to reduce Gemini 3.5 parse failures.
- Publish v0.112.0 release notes for the selector and JSON-mode fixes.

## Validation
- `volta run --node 22 node node_modules/vitest/vitest.mjs run tests/unit/aiModelCatalog.test.ts tests/unit/aiProviderRuntime.test.ts --reporter=default`
- `node scripts/validate-updates.mjs`
- `volta run --node 22 pnpm edge:validate`
- `volta run --node 22 pnpm test:core`
- `volta run --node 22 pnpm build:netlify`
