### PR TITLE
Correct v0.112 release timestamp

### DIFF
--- a/content/updates/2026-05-21-ai-model-family-routing-and-openrouter-json.md
+++ b/content/updates/2026-05-21-ai-model-family-routing-and-openrouter-json.md
@@ -3,7 +3,7 @@ id: rel-2026-05-21-ai-model-family-routing-and-openrouter-json
 version: v0.112.0
 title: "Clearer AI model families and stronger JSON generation"
 date: 2026-05-21
-published_at: 2026-05-21T06:51:29Z
+published_at: 2026-05-21T07:09:31Z
 status: published
 notify_in_app: false
 in_app_hours: 24


### PR DESCRIPTION
## Summary
- Corrects the v0.112.0 release note `published_at` value to the production Netlify publish timestamp.

## Validation
- `node scripts/validate-updates.mjs` (passes with existing canonical-gap warnings)
- `git diff --check`
