### PR TITLE
Recover truncated OpenRouter JSON responses

### DIFF
--- a/content/updates/2026-05-21-openrouter-truncation-recovery.md
+++ b/content/updates/2026-05-21-openrouter-truncation-recovery.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-05-21-openrouter-truncation-recovery
+version: v0.113.0
+title: "More reliable OpenRouter trip generation"
+date: 2026-05-21
+published_at: 2026-05-21T11:55:25Z
+status: published
+notify_in_app: false
+in_app_hours: 24
+summary: "Improved recovery when OpenRouter models return incomplete itinerary JSON."
+---
+
+## Changes
+- [x] [Fixed] 🧩 OpenRouter trip generation now retries incomplete itinerary responses with a shorter JSON recovery pass.
+- [ ] [Internal] 🧪 Added regression coverage for truncated Gemini responses through the OpenRouter path.

--- a/netlify/edge-lib/ai-provider-runtime.ts
+++ b/netlify/edge-lib/ai-provider-runtime.ts
@@ -132,7 +132,7 @@ const GEMINI_PRICING_PER_MILLION: Record<string, { input: number; output: number
 };
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
-const OPENROUTER_MAX_ATTEMPTS = 2;
+const OPENROUTER_MAX_ATTEMPTS = 3;
 const OPENROUTER_RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
 const PROVIDER_PARSE_RETRY_MAX_ATTEMPTS = 2;
 
@@ -214,6 +214,14 @@ TRUNCATION RECOVERY MODE:
 const isTokenLimitSignal = (value: unknown): boolean => {
   if (typeof value !== "string") return false;
   return /max[_\s-]?token|length/i.test(value);
+};
+
+const looksLikeTruncatedJsonObject = (raw: string): boolean => {
+  const trimmed = raw.trim();
+  const firstBrace = trimmed.indexOf("{");
+  if (firstBrace === -1) return false;
+  const lastBrace = trimmed.lastIndexOf("}");
+  return lastBrace <= firstBrace;
 };
 
 const resolveOutputTokenBudget = (
@@ -1304,6 +1312,7 @@ const generateWithOpenRouter = async (
 
   let lastError: ProviderGenerationResult | null = null;
   let forceStrictJson = false;
+  let forceUltraCompactJson = false;
   const requestStartedAt = Date.now();
 
   for (let attempt = 1; attempt <= OPENROUTER_MAX_ATTEMPTS; attempt += 1) {
@@ -1319,6 +1328,13 @@ const generateWithOpenRouter = async (
         },
       };
     }
+
+    const retryInstructions = forceUltraCompactJson
+      ? `${STRICT_JSON_RETRY_INSTRUCTION}\n${ULTRA_COMPACT_RETRY_INSTRUCTION}`
+      : STRICT_JSON_RETRY_INSTRUCTION;
+    const promptBody = forceStrictJson
+      ? `${prompt}\n\n${retryInstructions}`
+      : prompt;
 
     let responseResult:
       | { ok: true; payload: unknown }
@@ -1348,7 +1364,7 @@ const generateWithOpenRouter = async (
               },
               {
                 role: "user",
-                content: prompt,
+                content: promptBody,
               },
             ],
           }),
@@ -1404,24 +1420,35 @@ const generateWithOpenRouter = async (
     }
 
     const payload = responseResult.payload as Record<string, unknown>;
-    const rawText = extractOpenAiText(payload?.choices?.[0]?.message?.content);
+    const firstChoice = (payload?.choices as Array<Record<string, unknown>> | undefined)?.[0];
+    const finishReason = typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "";
+    const rawText = extractOpenAiText((firstChoice?.message as Record<string, unknown> | undefined)?.content);
 
     let parsed: Record<string, unknown>;
     try {
       parsed = extractJsonObject(rawText);
     } catch (error) {
+      const parseDetails = error instanceof Error ? error.message : "Unknown parsing error";
+      const detailsWithReason = finishReason
+        ? `${parseDetails} OpenRouter finish_reason=${finishReason}.`
+        : parseDetails;
       lastError = {
         ok: false,
         status: 502,
         value: {
           error: "OpenRouter response could not be parsed as JSON itinerary payload.",
           code: "OPENROUTER_PARSE_FAILED",
-          details: error instanceof Error ? error.message : "Unknown parsing error",
+          details: forceUltraCompactJson
+            ? `${detailsWithReason} Likely truncated output; compact retry constraints were applied.`
+            : detailsWithReason,
           sample: rawText.slice(0, 800),
         },
       };
-      if (attempt < OPENROUTER_MAX_ATTEMPTS) {
+      const shouldUseUltraCompact = isTokenLimitSignal(finishReason) || looksLikeTruncatedJsonObject(rawText);
+      const shouldRetryParseFailure = attempt < PROVIDER_PARSE_RETRY_MAX_ATTEMPTS || shouldUseUltraCompact;
+      if (attempt < OPENROUTER_MAX_ATTEMPTS && shouldRetryParseFailure) {
         forceStrictJson = true;
+        forceUltraCompactJson = forceUltraCompactJson || shouldUseUltraCompact;
         continue;
       }
       return lastError;

--- a/tests/unit/aiProviderRuntime.test.ts
+++ b/tests/unit/aiProviderRuntime.test.ts
@@ -939,6 +939,58 @@ describe('netlify/edge-lib/ai-provider-runtime', () => {
     expect(result.value.data.title).toBe('Recovered after parse retry');
   });
 
+  it('escalates openrouter parse retries to ultra-compact JSON after truncated content', async () => {
+    stubDenoEnv({
+      OPENROUTER_API_KEY: 'test-key',
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          model: 'google/gemini-3.5-flash',
+          choices: [{ message: { content: 'not-json' } }],
+          usage: {},
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          model: 'google/gemini-3.5-flash',
+          choices: [
+            {
+              finish_reason: 'length',
+              message: {
+                content: '{"tripTitle":"Indochina Explorer","countryInfo":{"visaInfoUrl":"https://www.auswaertiges-amt.de/de/service/laender/thailand-node/thailandsicherheit',
+              },
+            },
+          ],
+          usage: { prompt_tokens: 30, completion_tokens: 8192, total_tokens: 8222 },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          model: 'google/gemini-3.5-flash',
+          choices: [{ message: { content: '{"tripTitle":"Recovered compact JSON"}' } }],
+          usage: { prompt_tokens: 31, completion_tokens: 40, total_tokens: 71 },
+        }),
+      );
+
+    const result = await generateProviderItinerary({
+      prompt: '{"request":"gemini-openrouter"}',
+      provider: 'openrouter',
+      model: 'google/gemini-3.5-flash',
+      timeoutMs: 60_000,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const thirdBody = JSON.parse(String((fetchMock.mock.calls[2] as [string, RequestInit])[1].body));
+    expect(thirdBody.messages[0].content).toContain('Return exactly one minified JSON object');
+    expect(thirdBody.messages[1].content).toContain('TRUNCATION RECOVERY MODE');
+    expect(thirdBody.messages[1].content).toContain('Use at most 8 cities');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.data.tripTitle).toBe('Recovered compact JSON');
+  });
+
   it('returns parse failure when openrouter content is not valid json object', async () => {
     stubDenoEnv({
       OPENROUTER_API_KEY: 'test-key',


### PR DESCRIPTION
## Summary
- Adds truncation-aware OpenRouter parse recovery for incomplete JSON objects, including Gemini 3.5 Flash through OpenRouter.
- Escalates from the normal strict JSON retry to an ultra-compact JSON retry when OpenRouter returns a token-limit finish reason or an object that starts but never closes.
- Adds regression coverage for the malformed Indochina-style truncated JSON response shape.
- Publishes release note `v0.113.0`.

## Validation
- `volta run --node 22 node node_modules/vitest/vitest.mjs run tests/unit/aiProviderRuntime.test.ts --reporter=default -t "escalates openrouter parse retries"` (red before fix, green after fix)
- `volta run --node 22 node node_modules/vitest/vitest.mjs run tests/unit/aiProviderRuntime.test.ts --reporter=default`
- `volta run --node 22 pnpm edge:validate`
- `node scripts/validate-updates.mjs` (passes with existing canonical-gap warnings)
- `git diff --check`
- `volta run --node 22 pnpm test:core`
- `volta run --node 22 pnpm build:netlify`
