### PR TITLE
Correct v0.113 release timestamp

### DIFF
--- a/content/updates/2026-05-21-openrouter-truncation-recovery.md
+++ b/content/updates/2026-05-21-openrouter-truncation-recovery.md
@@ -3,7 +3,7 @@ id: rel-2026-05-21-openrouter-truncation-recovery
 version: v0.113.0
 title: "More reliable OpenRouter trip generation"
 date: 2026-05-21
-published_at: 2026-05-21T11:55:25Z
+published_at: 2026-05-21T12:10:20Z
 status: published
 notify_in_app: false
 in_app_hours: 24


### PR DESCRIPTION
## Summary
- Corrects the v0.113.0 release note `published_at` value to the production Netlify publish timestamp for PR #360.

## Validation
- `node scripts/validate-updates.mjs` (passes with existing canonical-gap warnings)
- `git diff --check`
