### PR TITLE
Tune OpenRouter Gemini benchmark recovery

### DIFF
--- a/content/updates/2026-05-21-gemini-openrouter-benchmark-budget.md
+++ b/content/updates/2026-05-21-gemini-openrouter-benchmark-budget.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-05-21-gemini-openrouter-benchmark-budget
+version: v0.114.0
+title: "Gemini benchmark recovery tuning"
+date: 2026-05-21
+published_at: 2026-05-21T12:34:26Z
+status: published
+notify_in_app: false
+in_app_hours: 24
+summary: "Improved Gemini 3.5 Flash reliability in benchmark trip generation."
+---
+
+## Changes
+- [x] [Fixed] 🧩 Gemini 3.5 Flash benchmark runs now get more room to finish complete itinerary JSON.
+- [ ] [Internal] 🧪 Tightened truncation recovery prompts and added benchmark token-budget coverage.

--- a/netlify/edge-functions/ai-benchmark.ts
+++ b/netlify/edge-functions/ai-benchmark.ts
@@ -154,6 +154,7 @@ const BENCHMARK_PROVIDER_TIMEOUT_MS = resolveTimeoutMs(
   BENCHMARK_PROVIDER_TIMEOUT_MAX_MS,
 );
 const BENCHMARK_TIMEOUT_60S_MAX_OUTPUT_TOKENS = 3_072;
+const BENCHMARK_OPENROUTER_GEMINI_35_MAX_OUTPUT_TOKENS = 8_192;
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SATISFACTION_RATINGS = new Set(["good", "medium", "bad"]);
 const TELEMETRY_COMMENT_QUERY_LIMIT = 2000;
@@ -200,6 +201,20 @@ const ACTIVE_BENCHMARK_MODEL_ID_SET = new Set(
     .filter((model) => model.availability === "active")
     .map((model) => model.id),
 );
+
+export const resolveBenchmarkMaxOutputTokens = (
+  provider: string,
+  model: string,
+  providerTimeoutMs: number,
+): number | undefined => {
+  if (providerTimeoutMs > 60_000) return undefined;
+  const normalizedProvider = provider.trim().toLowerCase();
+  const normalizedModel = model.trim().toLowerCase();
+  if (normalizedProvider === "openrouter" && normalizedModel === "google/gemini-3.5-flash") {
+    return BENCHMARK_OPENROUTER_GEMINI_35_MAX_OUTPUT_TOKENS;
+  }
+  return BENCHMARK_TIMEOUT_60S_MAX_OUTPUT_TOKENS;
+};
 
 const readEnv = (name: string): string => {
   try {
@@ -999,7 +1014,7 @@ const runGeneration = async (
       provider: run.provider,
       model: run.model,
       timeoutMs: providerTimeoutMs,
-      maxOutputTokens: providerTimeoutMs <= 60_000 ? BENCHMARK_TIMEOUT_60S_MAX_OUTPUT_TOKENS : undefined,
+      maxOutputTokens: resolveBenchmarkMaxOutputTokens(run.provider, run.model, providerTimeoutMs),
       jsonSchema: TRIP_ITINERARY_STRUCTURED_OUTPUT_SCHEMA,
     });
     const latencyMs = Date.now() - startedMs;

--- a/netlify/edge-lib/ai-provider-runtime.ts
+++ b/netlify/edge-lib/ai-provider-runtime.ts
@@ -207,7 +207,8 @@ const SYSTEM_STRICT_MINIFIED_JSON_ONLY_PLANNER_PROMPT =
 const ULTRA_COMPACT_RETRY_INSTRUCTION = `
 TRUNCATION RECOVERY MODE:
 - Keep the JSON intentionally short to avoid token truncation.
-- Use at most 8 cities and at most 16 activities.
+- Use at most 6 cities.
+- Use at most 1 activity per city.
 - Prefer short practical text over narrative prose.
 `.trim();
 
@@ -490,6 +491,14 @@ const extractOpenAiResponsesDetails = (payload: unknown): {
 };
 
 const buildOpenAiResponsesRetryPrompt = (prompt: string, ultraCompact: boolean): string => (
+  [
+    STRICT_JSON_RETRY_INSTRUCTION,
+    ultraCompact ? ULTRA_COMPACT_RETRY_INSTRUCTION : "",
+    prompt,
+  ].filter(Boolean).join("\n\n")
+);
+
+const buildProviderRetryPrompt = (prompt: string, ultraCompact: boolean): string => (
   [
     STRICT_JSON_RETRY_INSTRUCTION,
     ultraCompact ? ULTRA_COMPACT_RETRY_INSTRUCTION : "",
@@ -1329,11 +1338,8 @@ const generateWithOpenRouter = async (
       };
     }
 
-    const retryInstructions = forceUltraCompactJson
-      ? `${STRICT_JSON_RETRY_INSTRUCTION}\n${ULTRA_COMPACT_RETRY_INSTRUCTION}`
-      : STRICT_JSON_RETRY_INSTRUCTION;
     const promptBody = forceStrictJson
-      ? `${prompt}\n\n${retryInstructions}`
+      ? buildProviderRetryPrompt(prompt, forceUltraCompactJson)
       : prompt;
 
     let responseResult:

--- a/tests/unit/aiBenchmarkProviderBudget.test.ts
+++ b/tests/unit/aiBenchmarkProviderBudget.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBenchmarkMaxOutputTokens } from '../../netlify/edge-functions/ai-benchmark.ts';
+
+describe('ai-benchmark provider output budgets', () => {
+  it('does not force the 60s compact cap onto OpenRouter Gemini 3.5 Flash', () => {
+    expect(resolveBenchmarkMaxOutputTokens('openrouter', 'google/gemini-3.5-flash', 60_000)).toBe(8192);
+  });
+
+  it('keeps the compact cap for other 60s benchmark providers', () => {
+    expect(resolveBenchmarkMaxOutputTokens('openrouter', 'openai/gpt-5.5', 60_000)).toBe(3072);
+    expect(resolveBenchmarkMaxOutputTokens('gemini', 'gemini-3.1-flash-lite-preview', 60_000)).toBe(3072);
+  });
+
+  it('leaves longer benchmark timeouts on the provider default budget', () => {
+    expect(resolveBenchmarkMaxOutputTokens('openrouter', 'google/gemini-3.5-flash', 90_000)).toBeUndefined();
+  });
+});

--- a/tests/unit/aiProviderRuntime.test.ts
+++ b/tests/unit/aiProviderRuntime.test.ts
@@ -188,7 +188,8 @@ describe('netlify/edge-lib/ai-provider-runtime', () => {
     const retryInit = (fetchMock.mock.calls[1] as [string, RequestInit])[1];
     const retryBody = JSON.parse(String(retryInit.body));
     expect(retryBody.contents?.[0]?.parts?.[0]?.text).toContain('TRUNCATION RECOVERY MODE');
-    expect(retryBody.contents?.[0]?.parts?.[0]?.text).toContain('Use at most 8 cities and at most 16 activities');
+    expect(retryBody.contents?.[0]?.parts?.[0]?.text).toContain('Use at most 6 cities');
+    expect(retryBody.contents?.[0]?.parts?.[0]?.text).toContain('Use at most 1 activity per city');
 
     expect(result.ok).toBe(false);
     if (!('status' in result)) return;
@@ -984,8 +985,10 @@ describe('netlify/edge-lib/ai-provider-runtime', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
     const thirdBody = JSON.parse(String((fetchMock.mock.calls[2] as [string, RequestInit])[1].body));
     expect(thirdBody.messages[0].content).toContain('Return exactly one minified JSON object');
+    expect(thirdBody.messages[1].content).toMatch(/^IMPORTANT RETRY INSTRUCTIONS:/);
     expect(thirdBody.messages[1].content).toContain('TRUNCATION RECOVERY MODE');
-    expect(thirdBody.messages[1].content).toContain('Use at most 8 cities');
+    expect(thirdBody.messages[1].content).toContain('Use at most 6 cities');
+    expect(thirdBody.messages[1].content).toContain('Use at most 1 activity per city');
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.data.tripTitle).toBe('Recovered compact JSON');


### PR DESCRIPTION
## Summary
- give OpenRouter Gemini 3.5 Flash benchmark runs an 8192-token output budget instead of the shared 60s 3072-token cap
- place strict JSON retry and truncation recovery instructions before the original OpenRouter retry prompt
- tighten truncation recovery to at most 6 cities and 1 activity per city, then cover the budget and retry behavior with Vitest
- publish release note v0.114.0 for the Gemini benchmark reliability fix

## Root cause
Gemini 3.5 Flash was still failing benchmark runs with `finish_reason=length` because the benchmark runner forced all 60-second provider runs through a 3072-token max output budget. The OpenRouter retry path also appended recovery instructions after the original long prompt, so the model still saw the large prompt before the compact constraints.

## Tests
- `volta run --node 22 node node_modules/vitest/vitest.mjs run tests/unit/aiBenchmarkProviderBudget.test.ts --reporter=default`
- `volta run --node 22 node node_modules/vitest/vitest.mjs run tests/unit/aiProviderRuntime.test.ts --reporter=default -t "escalates openrouter parse retries"`
- `volta run --node 22 node node_modules/vitest/vitest.mjs run tests/unit/aiProviderRuntime.test.ts tests/unit/aiBenchmarkProviderBudget.test.ts --reporter=default`
- `volta run --node 22 pnpm edge:validate`
- `node scripts/validate-updates.mjs`
- `volta run --node 22 pnpm test:core`
- `volta run --node 22 pnpm build:netlify`
