### PR TITLE
Correct v0.114 release timestamp

### DIFF
--- a/content/updates/2026-05-21-gemini-openrouter-benchmark-budget.md
+++ b/content/updates/2026-05-21-gemini-openrouter-benchmark-budget.md
@@ -3,7 +3,7 @@ id: rel-2026-05-21-gemini-openrouter-benchmark-budget
 version: v0.114.0
 title: "Gemini benchmark recovery tuning"
 date: 2026-05-21
-published_at: 2026-05-21T12:34:26Z
+published_at: 2026-05-21T12:50:34Z
 status: published
 notify_in_app: false
 in_app_hours: 24


### PR DESCRIPTION
## Summary
- update v0.114.0 `published_at` to the actual Netlify production deploy time for PR #362

## Tests
- `node scripts/validate-updates.mjs`
- `git diff --check`
