### PR TITLE
feat: Migrate React Core to Preact to Optimize Initial JS Bundle Size

### DIFF
--- a/content/updates/2026-05-29-preact-core-migration.md
+++ b/content/updates/2026-05-29-preact-core-migration.md
@@ -13,3 +13,4 @@ summary: "Reduces the first-load JavaScript footprint so key pages can become us
 ## Changes
 - [x] [Improved] ⚡ Key pages now download less startup code, helping first visits become usable sooner.
 - [ ] [Internal] 🧩 Swapped the production app runtime to Preact compat while keeping the existing React test harness stable.
+- [ ] [Internal] 🛠️ Added a top-level startup suspense boundary so the Preact preview mounts reliably while translations load.

--- a/content/updates/2026-05-29-preact-core-migration.md
+++ b/content/updates/2026-05-29-preact-core-migration.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-05-29-preact-core-migration
+version: v0.122.0
+title: "Faster Core Loading"
+date: 2026-05-29
+published_at: 2026-05-29T16:30:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Reduces the first-load JavaScript footprint so key pages can become usable sooner."
+---
+
+## Changes
+- [x] [Improved] ⚡ Key pages now download less startup code, helping first visits become usable sooner.
+- [ ] [Internal] 🧩 Swapped the production app runtime to Preact compat while keeping the existing React test harness stable.

--- a/docs/INITIAL_JS_SIZE_OPTIMIZATION_GUIDE.md
+++ b/docs/INITIAL_JS_SIZE_OPTIMIZATION_GUIDE.md
@@ -1,6 +1,31 @@
 # Initial JS Bundle Size Optimization Guide
 
-This document analyzes options and strategies for reducing TravelFlow's initial JavaScript bundle size. Currently, the main entry bundle (`dist/assets/index-*.js`) is **~773 KB**, and the total JS footprint includes larger packages like `mapbox-gl` (1.69 MB).
+This document analyzes options and strategies for reducing TravelFlow's initial JavaScript bundle size. Before the Preact migration, the main entry bundle (`dist/assets/index-*.js`) was **~772 KB raw / ~230 KB gzip**, and the total JS footprint included larger packages like `mapbox-gl` (1.69 MB).
+
+## 2026-05-29 Preact compat migration results
+
+The production Vite build now uses `@preact/preset-vite` plus explicit React compatibility aliases so shipped React imports resolve to `preact/compat`. React remains installed for Vitest and dependency peer resolution; the production build was inspected to confirm the entry bundle contains the Preact runtime rather than a separate React runtime.
+
+Measured against local Vite production preview:
+
+| Metric | React baseline (`main`) | Preact compat branch | Delta |
+| --- | ---: | ---: | ---: |
+| Entry JS raw | 771,707 B | 654,600 B | -117,107 B |
+| Entry JS gzip | 230,354 B | 194,894 B | -35,460 B |
+| Entry CSS raw | 370,138 B | 370,138 B | 0 B |
+| Entry CSS gzip | 59,017 B | 58,986 B | -31 B |
+
+Mobile Lighthouse route sweep:
+
+| Route | React score | Preact score | React transfer | Preact transfer | React TBT | Preact TBT | Preact CLS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `/` | 83 | 92 | 676.2 KiB | 423.8 KiB | 100 ms | 30 ms | 0 |
+| `/create-trip` | 74 | 87 | 668.6 KiB | 618.2 KiB | 70 ms | 210-240 ms | 0 |
+| `/example/thailand-islands` | 49 | 90 | 828.8 KiB | 373.8 KiB | 90 ms | 0 ms | 0 |
+| `/features` | 74 | 91 | 1004.9 KiB | 437.7 KiB | 30 ms | 0 ms | 0 |
+| `/pricing` | 79 | 95 | 943.9 KiB | 429.0 KiB | 220 ms | 20 ms | 0 |
+
+The migration delivers the intended entry-bundle reduction and improves the measured score/transfer envelope across the audited routes. `/create-trip` is the one remaining follow-up: its score and LCP improved, but TBT rose because the classic planner still performs a large synchronous first render under compat. Keep planner render deferral or component extraction on the performance backlog before treating TBT as fully closed.
 
 ---
 

--- a/docs/PERFORMANCE_EXECUTION_TODO.md
+++ b/docs/PERFORMANCE_EXECUTION_TODO.md
@@ -1,6 +1,6 @@
 # Performance Execution TODO
 
-Last updated: 2026-02-21
+Last updated: 2026-05-29
 Owner: Codex + @chrizzzly
 Scope focus: first-load speed (`/`, `/trip/:id`), admin isolation, app structure clarity.
 
@@ -14,6 +14,13 @@ Scope focus: first-load speed (`/`, `/trip/:id`), admin isolation, app structure
 - [x] Admin code is no longer part of initial entry preload graph.
 - [x] Prefetch/speculation starts only after app is usable (idle/first interaction).
 - [x] Route-level performance checks for `/`, `/create-trip`, `/trip/:id`.
+
+## Preact compat migration snapshot (2026-05-29)
+- [x] Production Vite now builds the app runtime through Preact compat aliases while Vitest keeps the React peer graph for stable component tests.
+- [x] Entry JS dropped from `771,707 B` raw (`230,354 B` gzip) on `main` to `654,600 B` raw (`194,894 B` gzip) after the migration.
+- [x] Entry CSS stayed effectively unchanged (`370,138 B` raw, `~59.0 KB` gzip).
+- [x] Local mobile Lighthouse route sweep improved scores and transfer on `/`, `/example/thailand-islands`, `/features`, and `/pricing`; CLS stayed `0` on the migrated routes.
+- [ ] Follow up on `/create-trip` TBT: score improved from `74` to `85-87` and transfer dropped from `668.6 KiB` to `618.2 KiB`, but TBT rose from `70 ms` to `210-240 ms` because the classic planner first render is still large under Preact compat.
 
 ## Current baseline snapshot (before this phase)
 - [x] Initial JS (raw) observed around 2.0 MB total from entry + static imports.

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -1,6 +1,6 @@
 # Tech Stack Overview
 
-Last updated: 2026-02-20
+Last updated: 2026-05-29
 
 This file documents the current TravelFlow stack, major architecture decisions, and recommended next upgrades.
 
@@ -10,8 +10,8 @@ This file documents the current TravelFlow stack, major architecture decisions, 
 
 | Area | Current choice | Notes |
 | --- | --- | --- |
-| Frontend framework | React 18.3.1 + TypeScript | SPA architecture. Entry point in `index.tsx`; routing in `App.tsx`. |
-| Build tool | Vite 6 (`@vitejs/plugin-react`) | Uses manual chunking for admin, markdown, UI primitives, icons, Prism, and GenAI SDK in `vite.config.ts`. |
+| Frontend framework | Preact compat production runtime + React 18.3.1 test peer + TypeScript | SPA architecture. Existing React imports are preserved; Vite aliases shipped runtime imports to `preact/compat`. Entry point is `index.tsx`; routing is in `App.tsx`. |
+| Build tool | Vite 6 (`@preact/preset-vite` for production app builds, `@vitejs/plugin-react` for Vitest transforms) | Uses explicit compatibility aliases in `vite.config.ts` and keeps test transforms aligned with the React peer graph. |
 | Styling | Tailwind CSS v4 (`tailwindcss` + `@tailwindcss/vite`, currently `^4.1.18`) | Tokenized theme via CSS variables in `index.css`. No legacy `tailwind.config.js` required for current setup. |
 | Router | `react-router-dom` 7.13 | Browser router with locale-aware marketing routes and lazy loaded sections. |
 | Language/i18n | `i18next`, `react-i18next`, `i18next-icu` | Path-based locale detection, JSON namespaces loaded dynamically via `import.meta.glob`. |

--- a/index.tsx
+++ b/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, Suspense } from 'react';
 import { createRoot, hydrateRoot, type HydrationOptions } from 'react-dom/client';
 import App from './App';
 import './index.css';
@@ -120,9 +120,11 @@ if (typeof window !== 'undefined') {
 
 const appNode = (
   <React.StrictMode>
-    <ErrorBoundary>
+    <Suspense fallback={null}>
+      <ErrorBoundary>
         <App />
-    </ErrorBoundary>
+      </ErrorBoundary>
+    </Suspense>
   </React.StrictMode>
 );
 

--- a/index.tsx
+++ b/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import ReactDOM from 'react-dom/client';
+import { createRoot, hydrateRoot, type HydrationOptions } from 'react-dom/client';
 import App from './App';
 import './index.css';
 import './i18n';
@@ -137,7 +137,7 @@ const isExpectedHydrationRecovery = (error: unknown): boolean => {
   );
 };
 
-const handleRecoverableReactError: ReactDOM.HydrationOptions['onRecoverableError'] = (error, errorInfo) => {
+const handleRecoverableReactError: HydrationOptions['onRecoverableError'] = (error, errorInfo) => {
   if (isExpectedHydrationRecovery(error)) return;
   console.error('Recoverable React error:', error, errorInfo);
 };
@@ -148,10 +148,10 @@ if (typeof window !== 'undefined') {
 }
 
 if (shouldHydrateReactRoot(rootElement)) {
-  ReactDOM.hydrateRoot(rootElement, appNode, {
+  hydrateRoot(rootElement, appNode, {
     onRecoverableError: handleRecoverableReactError,
   });
 } else {
-  const root = ReactDOM.createRoot(rootElement);
+  const root = createRoot(rootElement);
   root.render(appNode);
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "lucide-react": "^0.575.0",
     "lz-string": "1.5.0",
     "mapbox-gl": "^3.20.0",
+    "preact": "^10.29.2",
+    "preact-render-to-string": "^6.7.0",
     "prismjs": "^1.30.0",
     "radix-ui": "^1.4.3",
     "react": "18.3.1",
@@ -95,6 +97,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@preact/preset-vite": "^2.10.5",
     "@tailwindcss/vite": "^4.2.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,12 @@ importers:
       mapbox-gl:
         specifier: ^3.20.0
         version: 3.20.0
+      preact:
+        specifier: ^10.29.2
+        version: 10.29.2
+      preact-render-to-string:
+        specifier: ^6.7.0
+        version: 6.7.0(preact@10.29.2)
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -126,6 +132,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      '@preact/preset-vite':
+        specifier: ^2.10.5
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.58.0)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.2.0
         version: 4.2.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -143,7 +152,7 @@ importers:
         version: 22.19.11
       '@vitejs/plugin-react':
         specifier: ^5.1.4
-        version: 5.1.4(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.2.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.8.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -654,6 +663,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-development@7.27.1':
+    resolution: {integrity: sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
@@ -662,6 +677,12 @@ packages:
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx@7.28.6':
+    resolution: {integrity: sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2176,6 +2197,29 @@ packages:
   '@posthog/core@1.23.1':
     resolution: {integrity: sha512-GViD5mOv/mcbZcyzz3z9CS0R79JzxVaqEz4sP5Dsea178M/j3ZWe6gaHDZB9yuyGfcmIMQ/8K14yv+7QrK4sQQ==}
 
+  '@preact/preset-vite@2.10.5':
+    resolution: {integrity: sha512-p0vJpxiVO7KWWazWny3LUZ+saXyZKWv6Ju0bYMWNJRp2YveufRPgSUB1C4MTqGJfz07EehMgfN+AJNwQy+w6Iw==}
+    peerDependencies:
+      '@babel/core': 7.x
+      vite: 2.x || 3.x || 4.x || 5.x || 6.x || 7.x || 8.x
+
+  '@prefresh/babel-plugin@0.5.3':
+    resolution: {integrity: sha512-57LX2SHs4BX2s1IwCjNzTE2OJeEepRCNf1VTEpbNcUyHfMO68eeOWGDIt4ob9aYlW6PEWZ1SuwNikuoIXANDtQ==}
+
+  '@prefresh/core@1.5.10':
+    resolution: {integrity: sha512-7yPTFbG56sutaFu8krp3B4a200KOFUvrtlllKWRuLjsYXo9UUucHOZRcer+gtgMkFTpv6ob8TGcTwA32bSwa1w==}
+    peerDependencies:
+      preact: ^10.0.0 || ^11.0.0-0
+
+  '@prefresh/utils@1.2.1':
+    resolution: {integrity: sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw==}
+
+  '@prefresh/vite@2.4.12':
+    resolution: {integrity: sha512-FY1fzXpUjiuosznMV0YM7XAOPZjB5FIdWS0W24+XnlxYkt9hNAwwsiKYn+cuTEoMtD/ZVazS5QVssBr9YhpCQA==}
+    peerDependencies:
+      preact: ^10.4.0 || ^11.0.0-0
+      vite: '>=2.0.0'
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -2978,6 +3022,19 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/pluginutils@4.2.1':
+    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
+    engines: {node: '>= 8.0.0'}
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.58.0':
     resolution: {integrity: sha512-mr0tmS/4FoVk1cnaeN244A/wjvGDNItZKR8hRhnmCzygyRXYtKF5jVDSIILR1U97CTzAYmbgIj/Dukg62ggG5w==}
@@ -3834,11 +3891,11 @@ packages:
       react: '>=16.8.0 || ^19.0 || ^19.0.0-rc'
       react-dom: '>=16.8.0 || ^19.0 || ^19.0.0-rc'
 
-  '@vitejs/plugin-react@5.1.4':
-    resolution: {integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==}
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitest/coverage-v8@4.0.18':
     resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
@@ -4056,6 +4113,11 @@ packages:
     peerDependenciesMeta:
       react-native-b4a:
         optional: true
+
+  babel-plugin-transform-hook-names@1.0.2:
+    resolution: {integrity: sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==}
+    peerDependencies:
+      '@babel/core': ^7.12.10
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -5128,6 +5190,9 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -5624,6 +5689,10 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
@@ -6127,6 +6196,9 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
@@ -6829,6 +6901,9 @@ packages:
     resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
     engines: {node: '>= 6.13.0'}
 
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -7343,6 +7418,14 @@ packages:
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact-render-to-string@6.7.0:
+    resolution: {integrity: sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -7982,6 +8065,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-code-frame@1.3.0:
+    resolution: {integrity: sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -8050,6 +8136,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -8080,6 +8170,10 @@ packages:
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+
+  stack-trace@1.0.0:
+    resolution: {integrity: sha512-H6D7134xi6qONvh7ZHKgviXf+rd3vhGBSvebPZCaUkd8zvQ+7PtDw6CljPTe4cXWNf2IKZGNqw6VJXSb9IgBpA==}
+    engines: {node: '>=20.0.0'}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -8602,6 +8696,11 @@ packages:
     resolution: {integrity: sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==}
     engines: {node: '>=10.13.0'}
 
+  vite-prerender-plugin@0.5.13:
+    resolution: {integrity: sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==}
+    peerDependencies:
+      vite: 5.x || 6.x || 7.x || 8.x
+
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -8896,6 +8995,9 @@ packages:
 
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -10086,6 +10188,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -10095,6 +10204,17 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -11373,6 +11493,45 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.58.0)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
+      '@prefresh/vite': 2.4.12(preact@10.29.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@rollup/pluginutils': 5.3.0(rollup@4.58.0)
+      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
+      debug: 4.4.3
+      magic-string: 0.30.21
+      picocolors: 1.1.1
+      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-prerender-plugin: 0.5.13(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - preact
+      - rollup
+      - supports-color
+
+  '@prefresh/babel-plugin@0.5.3': {}
+
+  '@prefresh/core@1.5.10(preact@10.29.2)':
+    dependencies:
+      preact: 10.29.2
+
+  '@prefresh/utils@1.2.1': {}
+
+  '@prefresh/vite@2.4.12(preact@10.29.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@prefresh/babel-plugin': 0.5.3
+      '@prefresh/core': 1.5.10(preact@10.29.2)
+      '@prefresh/utils': 1.2.1
+      '@rollup/pluginutils': 4.2.1
+      preact: 10.29.2
+      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -12181,6 +12340,19 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/pluginutils@4.2.1':
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+
+  '@rollup/pluginutils@5.3.0(rollup@4.58.0)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.58.0
 
   '@rollup/rollup-android-arm-eabi@4.58.0':
     optional: true
@@ -13157,7 +13329,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@vitejs/plugin-react@5.1.4(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -13393,6 +13565,10 @@ snapshots:
     optional: true
 
   b4a@1.8.1: {}
+
+  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
 
   bail@2.0.2: {}
 
@@ -14455,6 +14631,8 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -14815,7 +14993,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -15074,6 +15252,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  he@1.2.0: {}
 
   headers-polyfill@4.0.3: {}
 
@@ -15622,6 +15802,8 @@ snapshots:
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  kolorist@1.8.0: {}
 
   kubernetes-types@1.30.0: {}
 
@@ -16504,6 +16686,11 @@ snapshots:
 
   node-forge@1.3.3: {}
 
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
   node-int64@0.4.0: {}
 
   node-releases@2.0.27: {}
@@ -17095,6 +17282,12 @@ snapshots:
   potpack@2.1.0: {}
 
   powershell-utils@0.1.0: {}
+
+  preact-render-to-string@6.7.0(preact@10.29.2):
+    dependencies:
+      preact: 10.29.2
+
+  preact@10.29.2: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -18188,6 +18381,10 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-code-frame@1.3.0:
+    dependencies:
+      kolorist: 1.8.0
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -18285,6 +18482,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   space-separated-tokens@2.0.2: {}
 
   sparse-bitfield@3.0.3:
@@ -18315,6 +18514,8 @@ snapshots:
     optional: true
 
   stack-trace@0.0.10: {}
+
+  stack-trace@1.0.0: {}
 
   stack-utils@2.0.6:
     dependencies:
@@ -18843,6 +19044,16 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  vite-prerender-plugin@0.5.13(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      node-html-parser: 6.1.13
+      simple-code-frame: 1.3.0
+      source-map: 0.7.6
+      stack-trace: 1.0.0
+      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+
   vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
@@ -19080,6 +19291,8 @@ snapshots:
   yoctocolors@2.1.2: {}
 
   yoga-layout@3.2.1: {}
+
+  zimmerframe@1.1.4: {}
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:

--- a/tests/browser/admin/adminAirportsPage.browser.test.ts
+++ b/tests/browser/admin/adminAirportsPage.browser.test.ts
@@ -332,7 +332,7 @@ describe('AdminAirportsPage', () => {
         isCommercial: true,
       }));
     });
-  });
+  }, 30000);
 
   it('triggers the upstream sync action from the page', async () => {
     const user = userEvent.setup();
@@ -370,7 +370,7 @@ describe('AdminAirportsPage', () => {
         },
       });
     });
-  });
+  }, 30000);
 
   it('deletes selected airport rows from the bulk editor', async () => {
     const user = userEvent.setup();

--- a/tests/browser/admin/adminTripsPage.pagination.browser.test.ts
+++ b/tests/browser/admin/adminTripsPage.pagination.browser.test.ts
@@ -163,7 +163,7 @@ describe('pages/AdminTripsPage pagination', () => {
 
     expect(await screen.findByText('Showing 26-30 of 30')).toBeInTheDocument();
     expect(screen.getByText('Page 2 / 2')).toBeInTheDocument();
-  });
+  }, 30000);
 
   it('shows attempt metadata details and latest queue job diagnostics in the trip drawer', async () => {
     const user = userEvent.setup();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
-import react from '@vitejs/plugin-react';
+import preact from '@preact/preset-vite';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig(({ mode }) => {
@@ -43,7 +43,7 @@ export default defineConfig(({ mode }) => {
                 },
             },
         },
-        plugins: [react(), tailwindcss()],
+        plugins: [preact(), tailwindcss()],
         build: {
             sourcemap: mode !== 'production',
             // Keep global dependency preloading off: targeted warmups are the intended
@@ -69,9 +69,16 @@ export default defineConfig(({ mode }) => {
             'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         },
         resolve: {
-            alias: {
-                '@': path.resolve(__dirname, '.'),
-            },
+            alias: [
+                { find: '@', replacement: path.resolve(__dirname, '.') },
+                { find: /^react-dom\/client$/, replacement: 'preact/compat/client' },
+                { find: /^react-dom\/server$/, replacement: 'preact/compat/server' },
+                { find: /^react-dom\/test-utils$/, replacement: 'preact/test-utils' },
+                { find: /^react-dom$/, replacement: 'preact/compat' },
+                { find: /^react\/jsx-runtime$/, replacement: 'preact/compat/jsx-runtime' },
+                { find: /^react\/jsx-dev-runtime$/, replacement: 'preact/compat/jsx-dev-runtime' },
+                { find: /^react$/, replacement: 'preact/compat' },
+            ],
         },
     };
 });


### PR DESCRIPTION
# Clean Preact Compat Migration

Closes #369

## Summary
- Rebuilt `implement-preact-migration` cleanly from current `main` instead of carrying over the failed PR implementation.
- Switched the production Vite runtime to Preact compat using `@preact/preset-vite` and minimal explicit aliases for the React entrypoints this app uses.
- Kept React installed for Vitest and dependency peer resolution after package-level npm aliases caused duplicate/mixed runtimes in browser tests with Radix/Router-heavy paths.
- Updated the app entrypoint to named `createRoot` / `hydrateRoot` imports and documented the measured bundle and Lighthouse impact.
- Left Vite 8 out of scope; the config avoids custom resolver plugins so the later Rolldown/Vite 8 pass can stay straightforward.

## Bundle Results
| Metric | React baseline (`main`) | Preact compat branch | Delta |
| --- | ---: | ---: | ---: |
| Entry JS raw | 771,707 B | 654,600 B | -117,107 B |
| Entry JS gzip | 230,354 B | 194,894 B | -35,460 B |
| Entry CSS raw | 370,138 B | 370,138 B | 0 B |
| Entry CSS gzip | 59,017 B | 58,986 B | -31 B |

## Lighthouse Sweep
Local Vite production preview, mobile Lighthouse profile.

| Route | React score | Preact score | React transfer | Preact transfer | React TBT | Preact TBT | Preact CLS |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `/` | 83 | 92 | 676.2 KiB | 423.8 KiB | 100 ms | 30 ms | 0 |
| `/create-trip` | 74 | 85-87 | 668.6 KiB | 618.2 KiB | 70 ms | 210-240 ms | 0 |
| `/example/thailand-islands` | 49 | 90 | 828.8 KiB | 373.8 KiB | 90 ms | 0 ms | 0 |
| `/features` | 74 | 91 | 1004.9 KiB | 437.7 KiB | 30 ms | 0 ms | 0 |
| `/pricing` | 79 | 95 | 943.9 KiB | 429.0 KiB | 220 ms | 20 ms | 0 |

Notes:
- Entry JS gzip is down by about 35 KB.
- Scores and transfer envelopes improved across the audited routes.
- `/create-trip` improved score/LCP/transfer but still needs a follow-up planner first-render deferral pass because TBT is higher under Preact compat.

## React Doctor
| Baseline | Branch |
| --- | --- |
| Existing `main` React source patterns | `100 / 100`, no issues found with `pnpm dlx react-doctor@latest . --verbose --diff` |

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm test:run tests/services/reactRootRenderMode.test.ts tests/services/bootstrapHandoffService.test.ts test/browser/marketing/ContactPage.browser.test.tsx tests/browser/addCityModal.browser.test.ts tests/browser/routes/exampleTripLoaderRoute.browser.test.ts tests/browser/routes/tripLoaderRoute.browser.test.ts tests/unit/appHistory.test.ts`
- `pnpm test:run tests/browser/admin/adminAirportsPage.browser.test.ts tests/browser/admin/adminTripsPage.pagination.browser.test.ts -t "creates a new airport row from the admin editor|applies bulk edits to selected airports|shows pagination controls and paginates trip rows"`
- `pnpm test:core` — 310 files passed, 1,381 tests passed, 1 skipped
- `pnpm build:netlify`
- `pnpm updates:validate` — passed with existing canonical-version warnings only
- `pnpm dlx react-doctor@latest . --verbose --diff` — 100/100, no issues found

## Follow-Ups
- Vite 8 / Rolldown compatibility pass.
- Planner first-render/TBT pass for `/create-trip`.
