### PR TITLE
Harden /api/ai/generate: input clamps, Supabase session verification, rate limiting

### DIFF
--- a/content/updates/2026-07-02-ai-generation-hardening.md
+++ b/content/updates/2026-07-02-ai-generation-hardening.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-07-02-ai-generation-hardening
+version: v0.0.0
+title: "AI generation endpoint hardening"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Server-side safeguards keep AI trip generation reliable and abuse-resistant."
+---
+
+## Changes
+- [ ] [Internal] 🛡️ Added Supabase session verification, per-user/per-IP rate limiting, prompt-length caps, and provider/model allowlist enforcement to the public AI generation edge endpoint to prevent unauthenticated paid-provider quota abuse.
+- [ ] [Internal] 📏 Async generation enqueue now rejects queued payload prompts above the shared prompt-length cap.
+- [ ] [Internal] 🔍 Generation telemetry now records the verified user id and auth mode for each request.

--- a/netlify/edge-functions/ai-generate-enqueue.ts
+++ b/netlify/edge-functions/ai-generate-enqueue.ts
@@ -1,3 +1,5 @@
+import { resolveMaxPromptChars } from "../edge-lib/ai-generate-guard.ts";
+
 const JSON_HEADERS = {
   "Content-Type": "application/json; charset=utf-8",
   "Cache-Control": "no-store",
@@ -112,6 +114,13 @@ const parseEnqueueRequestBody = (value: unknown): {
 
   const payloadValue = record.payload == null ? null : asObject(record.payload);
   if (record.payload != null && !payloadValue) return null;
+
+  // The queued payload prompt is later sent to a paid provider by the worker;
+  // clamp it here with the same cap as the synchronous /api/ai/generate path.
+  if (payloadValue && typeof payloadValue.prompt === "string"
+    && payloadValue.prompt.length > resolveMaxPromptChars()) {
+    return null;
+  }
 
   return {
     tripId,

--- a/netlify/edge-functions/ai-generate.ts
+++ b/netlify/edge-functions/ai-generate.ts
@@ -1,8 +1,14 @@
 import {
-  GEMINI_DEFAULT_MODEL,
   generateProviderItinerary,
   resolveTimeoutMs,
 } from "../edge-lib/ai-provider-runtime.ts";
+import {
+  createTokenBucketRateLimiter,
+  getBearerToken,
+  resolveClientIp,
+  validateGenerateInput,
+  verifySupabaseUser,
+} from "../edge-lib/ai-generate-guard.ts";
 import { persistAiGenerationTelemetry } from "../edge-lib/ai-generation-telemetry.ts";
 import { TRIP_ITINERARY_STRUCTURED_OUTPUT_SCHEMA } from "../../shared/aiTripItinerarySchema.ts";
 
@@ -33,13 +39,19 @@ const JSON_HEADERS = {
 // This clamps overly aggressive env values (for example 5000ms) to a safer floor.
 const EDGE_REQUEST_PROVIDER_TIMEOUT_MS = resolveTimeoutMs("AI_GENERATE_PROVIDER_TIMEOUT_MS", 45_000, 20_000, 120_000);
 
-const json = (status: number, payload: unknown): Response =>
+// Best-effort per-isolate limiters (see ai-generate-guard.ts for caveats).
+// Verified Supabase sessions get a per-user budget; requests without a
+// verifiable session share a stricter per-IP budget.
+const verifiedUserLimiter = createTokenBucketRateLimiter({ capacity: 10, refillPerMinute: 6 });
+const anonymousIpLimiter = createTokenBucketRateLimiter({ capacity: 5, refillPerMinute: 3 });
+
+const json = (status: number, payload: unknown, extraHeaders?: Record<string, string>): Response =>
   new Response(JSON.stringify(payload), {
     status,
-    headers: JSON_HEADERS,
+    headers: { ...JSON_HEADERS, ...extraHeaders },
   });
 
-export default async (request: Request) => {
+export default async (request: Request, context?: { ip?: string }) => {
   if (request.method !== "POST") {
     return json(405, { error: "Method not allowed. Use POST." });
   }
@@ -51,18 +63,45 @@ export default async (request: Request) => {
     return json(400, { error: "Invalid JSON body." });
   }
 
-  const prompt = typeof body?.prompt === "string" ? body.prompt.trim() : "";
-  if (!prompt) {
-    return json(400, { error: "Missing required field: prompt" });
+  const guarded = validateGenerateInput(body);
+  if (!guarded.ok) {
+    return json(guarded.failure.status, {
+      error: guarded.failure.error,
+      code: guarded.failure.code,
+    });
+  }
+  const { prompt, provider, model } = guarded.value;
+
+  const authToken = getBearerToken(request);
+  let verifiedUserId: string | null = null;
+  let verifiedAnonymousSession = false;
+  if (authToken) {
+    const verification = await verifySupabaseUser(authToken);
+    if (verification.ok) {
+      verifiedUserId = verification.userId;
+      verifiedAnonymousSession = verification.isAnonymous;
+    } else if (verification.reason === "invalid") {
+      return json(401, {
+        error: "Invalid or expired Supabase access token.",
+        code: "AUTH_TOKEN_INVALID",
+      });
+    }
+    // reason === "unavailable": auth service/config unreachable — degrade to
+    // per-IP limiting instead of failing legitimate traffic.
   }
 
-  const provider = typeof body?.target?.provider === "string"
-    ? body.target.provider.trim().toLowerCase()
-    : "gemini";
+  const clientIp = resolveClientIp(request, context);
+  const rateDecision = verifiedUserId
+    ? verifiedUserLimiter.take(`user:${verifiedUserId}`)
+    : anonymousIpLimiter.take(`ip:${clientIp}`);
+  if (!rateDecision.allowed) {
+    return json(429, {
+      error: "Too many generation requests. Please retry shortly.",
+      code: "RATE_LIMITED",
+      retryAfterSeconds: rateDecision.retryAfterSeconds,
+    }, { "Retry-After": String(rateDecision.retryAfterSeconds) });
+  }
 
-  const model = typeof body?.target?.model === "string" && body.target.model.trim()
-    ? body.target.model.trim()
-    : GEMINI_DEFAULT_MODEL;
   const requestId = typeof body?.requestId === "string" && body.requestId.trim()
     ? body.requestId.trim()
     : crypto.randomUUID();
@@ -130,6 +169,10 @@ export default async (request: Request) => {
       totalTokens: result.value.meta.usage?.totalTokens,
       metadata: {
         endpoint: "/api/ai/generate",
+        user_id: verifiedUserId,
+        auth: verifiedUserId
+          ? (verifiedAnonymousSession ? "supabase_anonymous" : "supabase_user")
+          : "unverified",
         trip_id: requestContext?.tripId || null,
         attempt_id: requestContext?.attemptId || null,
         flow: requestContext?.flow || null,
@@ -160,6 +203,10 @@ export default async (request: Request) => {
       errorMessage: error instanceof Error ? error.message : "Unknown error",
       metadata: {
         endpoint: "/api/ai/generate",
+        user_id: verifiedUserId,
+        auth: verifiedUserId
+          ? (verifiedAnonymousSession ? "supabase_anonymous" : "supabase_user")
+          : "unverified",
         trip_id: requestContext?.tripId || null,
         attempt_id: requestContext?.attemptId || null,
         flow: requestContext?.flow || null,

--- a/netlify/edge-lib/ai-generate-guard.ts
+++ b/netlify/edge-lib/ai-generate-guard.ts
@@ -1,0 +1,243 @@
+import {
+  ensureModelAllowed,
+  GEMINI_DEFAULT_MODEL,
+  readEnv,
+} from "./ai-provider-runtime.ts";
+
+/**
+ * Request guards for the public /api/ai/generate edge endpoint.
+ *
+ * Every accepted request triggers a paid provider call, so requests are
+ * validated (prompt length cap, provider/model allowlist) and rate limited
+ * before any provider work happens.
+ */
+
+export interface GenerateGuardFailure {
+  status: number;
+  code: string;
+  error: string;
+}
+
+export interface GenerateGuardInput {
+  prompt: string;
+  provider: string;
+  model: string;
+}
+
+export type GenerateGuardResult =
+  | { ok: true; value: GenerateGuardInput }
+  | { ok: false; failure: GenerateGuardFailure };
+
+// Real classic/wizard prompts built by services/aiService.ts top out around
+// ~8k characters even for long multi-week requests. 24k leaves 3x headroom
+// while still blocking megabyte-sized quota-burn payloads.
+export const DEFAULT_MAX_PROMPT_CHARS = 24_000;
+
+const clampInt = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, Math.round(value)));
+
+export const resolveMaxPromptChars = (): number => {
+  const raw = Number(readEnv("AI_GENERATE_MAX_PROMPT_CHARS").trim());
+  if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_MAX_PROMPT_CHARS;
+  return clampInt(raw, 4_000, 120_000);
+};
+
+export const validateGenerateInput = (
+  body: {
+    prompt?: unknown;
+    target?: { provider?: unknown; model?: unknown } | null;
+  } | null | undefined,
+  maxPromptChars = resolveMaxPromptChars(),
+): GenerateGuardResult => {
+  const prompt = typeof body?.prompt === "string" ? body.prompt.trim() : "";
+  if (!prompt) {
+    return {
+      ok: false,
+      failure: {
+        status: 400,
+        code: "PROMPT_REQUIRED",
+        error: "Missing required field: prompt",
+      },
+    };
+  }
+
+  if (prompt.length > maxPromptChars) {
+    return {
+      ok: false,
+      failure: {
+        status: 413,
+        code: "PROMPT_TOO_LONG",
+        error: `Prompt exceeds the maximum allowed length of ${maxPromptChars} characters.`,
+      },
+    };
+  }
+
+  const provider = typeof body?.target?.provider === "string" && body.target.provider.trim()
+    ? body.target.provider.trim().toLowerCase()
+    : "gemini";
+  const model = typeof body?.target?.model === "string" && body.target.model.trim()
+    ? body.target.model.trim()
+    : GEMINI_DEFAULT_MODEL;
+
+  const allowlistError = ensureModelAllowed(provider, model);
+  if (allowlistError) {
+    return {
+      ok: false,
+      failure: {
+        status: 400,
+        code: allowlistError.code,
+        error: allowlistError.error,
+      },
+    };
+  }
+
+  return { ok: true, value: { prompt, provider, model } };
+};
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  retryAfterSeconds: number;
+}
+
+export interface TokenBucketRateLimiter {
+  take: (key: string, nowMs?: number) => RateLimitDecision;
+}
+
+interface BucketState {
+  tokens: number;
+  updatedAtMs: number;
+}
+
+/**
+ * Best-effort in-memory token bucket, keyed per caller (user id or IP).
+ *
+ * NOTE: state lives inside a single edge isolate. Netlify runs many isolates
+ * across regions and recycles them, so this is NOT a durable global limit —
+ * it caps the request rate an attacker can push through any one isolate and
+ * stops naive scripted abuse. A durable (table-backed) limiter can be layered
+ * on later without changing callers.
+ */
+export const createTokenBucketRateLimiter = (options: {
+  capacity: number;
+  refillPerMinute: number;
+  maxKeys?: number;
+}): TokenBucketRateLimiter => {
+  const capacity = Math.max(1, options.capacity);
+  const refillPerMs = Math.max(0.000001, options.refillPerMinute / 60_000);
+  const maxKeys = Math.max(100, options.maxKeys ?? 10_000);
+  const buckets = new Map<string, BucketState>();
+
+  const take = (key: string, nowMs = Date.now()): RateLimitDecision => {
+    const existing = buckets.get(key);
+    let tokens = capacity;
+    if (existing) {
+      const elapsedMs = Math.max(0, nowMs - existing.updatedAtMs);
+      tokens = Math.min(capacity, existing.tokens + elapsedMs * refillPerMs);
+      // Move to the end of the Map so eviction removes the stalest key first.
+      buckets.delete(key);
+    }
+
+    if (tokens < 1) {
+      const missingTokens = 1 - tokens;
+      buckets.set(key, { tokens, updatedAtMs: nowMs });
+      return {
+        allowed: false,
+        retryAfterSeconds: Math.max(1, Math.ceil(missingTokens / refillPerMs / 1_000)),
+      };
+    }
+
+    buckets.set(key, { tokens: tokens - 1, updatedAtMs: nowMs });
+
+    if (buckets.size > maxKeys) {
+      const oldestKey = buckets.keys().next().value;
+      if (typeof oldestKey === "string") {
+        buckets.delete(oldestKey);
+      }
+    }
+
+    return { allowed: true, retryAfterSeconds: 0 };
+  };
+
+  return { take };
+};
+
+export const resolveClientIp = (
+  request: Request,
+  context?: { ip?: string } | null,
+): string => {
+  const contextIp = typeof context?.ip === "string" ? context.ip.trim() : "";
+  if (contextIp) return contextIp;
+
+  const netlifyHeader = (request.headers.get("x-nf-client-connection-ip") || "").trim();
+  if (netlifyHeader) return netlifyHeader;
+
+  const forwardedFor = (request.headers.get("x-forwarded-for") || "").split(",")[0]?.trim() || "";
+  if (forwardedFor) return forwardedFor;
+
+  return "unknown";
+};
+
+export const getBearerToken = (request: Request): string | null => {
+  const raw = request.headers.get("authorization") || "";
+  const match = raw.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  const token = match[1].trim();
+  return token || null;
+};
+
+export type SupabaseUserVerification =
+  | { ok: true; userId: string; isAnonymous: boolean }
+  | { ok: false; reason: "invalid" | "unavailable" };
+
+/**
+ * Verifies a Supabase access token server-side via the auth REST endpoint.
+ * Returns `unavailable` when Supabase env config is missing or the auth
+ * service cannot be reached, so callers can degrade to per-IP limiting
+ * instead of hard-failing legitimate traffic.
+ */
+export const verifySupabaseUser = async (
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SupabaseUserVerification> => {
+  const url = readEnv("VITE_SUPABASE_URL").replace(/\/+$/, "");
+  const anonKey = readEnv("VITE_SUPABASE_ANON_KEY");
+  if (!url || !anonKey) {
+    return { ok: false, reason: "unavailable" };
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImpl(`${url}/auth/v1/user`, {
+      method: "GET",
+      headers: {
+        apikey: anonKey,
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch {
+    return { ok: false, reason: "unavailable" };
+  }
+
+  if (!response.ok) {
+    return { ok: false, reason: "invalid" };
+  }
+
+  let payload: unknown = null;
+  try {
+    payload = await response.json();
+  } catch {
+    return { ok: false, reason: "invalid" };
+  }
+
+  const record = payload && typeof payload === "object" ? payload as Record<string, unknown> : null;
+  const userId = typeof record?.id === "string" ? record.id.trim() : "";
+  if (!userId) {
+    return { ok: false, reason: "invalid" };
+  }
+
+  return {
+    ok: true,
+    userId,
+    isAnonymous: record?.is_anonymous === true,
+  };
+};

--- a/services/aiService.ts
+++ b/services/aiService.ts
@@ -32,6 +32,7 @@ import {
 } from "../utils";
 import { trackEvent } from "./analyticsService";
 import { resolveDestinationName } from "./destinationService";
+import { supabase } from "./supabaseClient";
 
 /**
  * ==============================================================================
@@ -1045,12 +1046,26 @@ const generateItineraryFromPrompt = async (
         }, CLIENT_AI_GENERATION_TIMEOUT_MS)
         : null;
 
+    // Attach the Supabase session token (regular or anonymous session) so the
+    // edge function can verify the caller and apply the per-user rate budget
+    // instead of the stricter shared per-IP budget.
+    let accessToken: string | null = null;
+    if (supabase) {
+        try {
+            const { data } = await supabase.auth.getSession();
+            accessToken = data.session?.access_token || null;
+        } catch {
+            accessToken = null;
+        }
+    }
+
     let edgeResponse: Response;
     try {
         edgeResponse = await fetch('/api/ai/generate', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
+                ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
             },
             body: JSON.stringify(requestBody),
             signal: abortController?.signal,

--- a/tests/unit/aiGenerateEdgeGuard.test.ts
+++ b/tests/unit/aiGenerateEdgeGuard.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchMock = vi.fn();
+const envValues: Record<string, string | undefined> = {};
+
+import handler from '../../netlify/edge-functions/ai-generate.ts';
+
+const buildRequest = (body: unknown, headers: Record<string, string> = {}) =>
+  new Request('https://travelflowapp.netlify.app/api/ai/generate', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+
+describe('netlify/edge-functions/ai-generate hardening (regression)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    for (const key of Object.keys(envValues)) delete envValues[key];
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('Deno', {
+      env: {
+        get: (key: string) => envValues[key],
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects oversized prompts with 413 before any provider call', async () => {
+    const response = await handler(buildRequest({ prompt: 'x'.repeat(200_000) }), { ip: '10.0.0.1' });
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toMatchObject({ code: 'PROMPT_TOO_LONG' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects arbitrary provider/model targets with 400 before any provider call', async () => {
+    const response = await handler(buildRequest({
+      prompt: 'Trip to Japan',
+      target: { provider: 'gemini', model: 'gemini-ultra-unlimited' },
+    }), { ip: '10.0.0.2' });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: 'MODEL_NOT_ALLOWED' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still returns the legacy 400 for a missing prompt', async () => {
+    const response = await handler(buildRequest({}), { ip: '10.0.0.3' });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: 'Missing required field: prompt' });
+  });
+
+  it('rejects invalid Supabase access tokens with 401', async () => {
+    envValues.VITE_SUPABASE_URL = 'https://supabase.example';
+    envValues.VITE_SUPABASE_ANON_KEY = 'anon-key';
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 401 }));
+
+    const response = await handler(buildRequest(
+      { prompt: 'Trip to Japan' },
+      { Authorization: 'Bearer forged-token' },
+    ), { ip: '10.0.0.4' });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ code: 'AUTH_TOKEN_INVALID' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rate limits unauthenticated callers per IP with 429 and Retry-After', async () => {
+    // No provider keys configured: allowed requests fail fast with 500
+    // GEMINI_KEY_MISSING instead of hitting the network.
+    const statuses: number[] = [];
+    let lastResponse: Response | null = null;
+    for (let i = 0; i < 6; i += 1) {
+      lastResponse = await handler(buildRequest({ prompt: 'Trip to Japan' }), { ip: '10.99.0.42' });
+      statuses.push(lastResponse.status);
+    }
+
+    expect(statuses.slice(0, 5)).toEqual([500, 500, 500, 500, 500]);
+    expect(statuses[5]).toBe(429);
+    expect(lastResponse?.headers.get('Retry-After')).toBeTruthy();
+    await expect(lastResponse?.json()).resolves.toMatchObject({ code: 'RATE_LIMITED' });
+    // No outbound provider/auth fetches happened at any point.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not rate limit a fresh IP after another IP is exhausted', async () => {
+    const response = await handler(buildRequest({ prompt: 'Trip to Japan' }), { ip: '10.99.1.7' });
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ code: 'GEMINI_KEY_MISSING' });
+  });
+});

--- a/tests/unit/aiGenerateEnqueue.test.ts
+++ b/tests/unit/aiGenerateEnqueue.test.ts
@@ -156,3 +156,51 @@ describe('netlify/edge-functions/ai-generate-enqueue', () => {
         });
     });
 });
+
+describe('netlify/edge-functions/ai-generate-enqueue prompt cap (regression)', () => {
+    beforeEach(() => {
+        fetchMock.mockReset();
+        envGetMock.mockReset();
+        vi.stubGlobal('fetch', fetchMock);
+        vi.stubGlobal('Deno', {
+            env: {
+                get: (...args: unknown[]) => envGetMock(...args),
+            },
+        });
+        envGetMock.mockImplementation((key: string) => {
+            if (key === 'VITE_SUPABASE_URL') return 'https://supabase.example';
+            if (key === 'VITE_SUPABASE_ANON_KEY') return 'anon-key';
+            if (key === 'TF_ADMIN_API_KEY') return 'admin-key';
+            return '';
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('rejects payloads whose prompt exceeds the generation prompt cap', async () => {
+        const response = await handler(new Request('https://travelflowapp.netlify.app/api/internal/ai/generation-enqueue', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer user-token',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                tripId: 'trip-1',
+                attemptId: 'attempt-1',
+                payload: {
+                    flow: 'classic',
+                    prompt: 'x'.repeat(200_000),
+                },
+            }),
+        }));
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+            ok: false,
+            code: 'ASYNC_ENQUEUE_PAYLOAD_INVALID',
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/aiGenerateGuard.test.ts
+++ b/tests/unit/aiGenerateGuard.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createTokenBucketRateLimiter,
+  DEFAULT_MAX_PROMPT_CHARS,
+  getBearerToken,
+  resolveClientIp,
+  resolveMaxPromptChars,
+  validateGenerateInput,
+  verifySupabaseUser,
+} from '../../netlify/edge-lib/ai-generate-guard.ts';
+
+const stubDenoEnv = (values: Record<string, string | undefined>) => {
+  vi.stubGlobal('Deno', {
+    env: {
+      get: (key: string) => values[key],
+    },
+  });
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('validateGenerateInput', () => {
+  it('rejects a missing prompt with the legacy error message', () => {
+    const result = validateGenerateInput({ prompt: '   ' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.status).toBe(400);
+      expect(result.failure.code).toBe('PROMPT_REQUIRED');
+      expect(result.failure.error).toBe('Missing required field: prompt');
+    }
+  });
+
+  it('rejects oversized prompts with 413 PROMPT_TOO_LONG', () => {
+    const result = validateGenerateInput({ prompt: 'x'.repeat(DEFAULT_MAX_PROMPT_CHARS + 1) });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.status).toBe(413);
+      expect(result.failure.code).toBe('PROMPT_TOO_LONG');
+    }
+  });
+
+  it('accepts a prompt at exactly the cap', () => {
+    const result = validateGenerateInput({ prompt: 'x'.repeat(DEFAULT_MAX_PROMPT_CHARS) });
+    expect(result.ok).toBe(true);
+  });
+
+  it('defaults to gemini and the default model when no target is provided', () => {
+    const result = validateGenerateInput({ prompt: 'Trip to Japan' });
+    expect(result).toMatchObject({
+      ok: true,
+      value: { provider: 'gemini', model: 'gemini-3-pro-preview' },
+    });
+  });
+
+  it('rejects unknown providers', () => {
+    const result = validateGenerateInput({
+      prompt: 'Trip to Japan',
+      target: { provider: 'evilcorp', model: 'anything' },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.status).toBe(400);
+      expect(result.failure.code).toBe('PROVIDER_NOT_SUPPORTED');
+    }
+  });
+
+  it('rejects arbitrary model strings for a supported provider', () => {
+    const result = validateGenerateInput({
+      prompt: 'Trip to Japan',
+      target: { provider: 'openai', model: 'gpt-experimental-unlimited' },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.status).toBe(400);
+      expect(result.failure.code).toBe('MODEL_NOT_ALLOWED');
+    }
+  });
+
+  it('accepts allowlisted provider/model targets and normalizes the provider case', () => {
+    const result = validateGenerateInput({
+      prompt: 'Trip to Japan',
+      target: { provider: 'Anthropic', model: 'claude-haiku-4.5' },
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      value: { provider: 'anthropic', model: 'claude-haiku-4.5' },
+    });
+  });
+});
+
+describe('resolveMaxPromptChars', () => {
+  it('uses the default when no env override is set', () => {
+    stubDenoEnv({});
+    expect(resolveMaxPromptChars()).toBe(DEFAULT_MAX_PROMPT_CHARS);
+  });
+
+  it('clamps env overrides into the sane range', () => {
+    stubDenoEnv({ AI_GENERATE_MAX_PROMPT_CHARS: '10' });
+    expect(resolveMaxPromptChars()).toBe(4_000);
+    stubDenoEnv({ AI_GENERATE_MAX_PROMPT_CHARS: '9999999' });
+    expect(resolveMaxPromptChars()).toBe(120_000);
+    stubDenoEnv({ AI_GENERATE_MAX_PROMPT_CHARS: '30000' });
+    expect(resolveMaxPromptChars()).toBe(30_000);
+  });
+});
+
+describe('createTokenBucketRateLimiter', () => {
+  it('allows a burst up to capacity and then blocks', () => {
+    const limiter = createTokenBucketRateLimiter({ capacity: 3, refillPerMinute: 3 });
+    const now = 1_000_000;
+    expect(limiter.take('ip:1.2.3.4', now).allowed).toBe(true);
+    expect(limiter.take('ip:1.2.3.4', now).allowed).toBe(true);
+    expect(limiter.take('ip:1.2.3.4', now).allowed).toBe(true);
+    const blocked = limiter.take('ip:1.2.3.4', now);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it('tracks keys independently', () => {
+    const limiter = createTokenBucketRateLimiter({ capacity: 1, refillPerMinute: 1 });
+    const now = 1_000_000;
+    expect(limiter.take('ip:a', now).allowed).toBe(true);
+    expect(limiter.take('ip:a', now).allowed).toBe(false);
+    expect(limiter.take('ip:b', now).allowed).toBe(true);
+  });
+
+  it('refills tokens over time', () => {
+    const limiter = createTokenBucketRateLimiter({ capacity: 1, refillPerMinute: 6 });
+    const now = 1_000_000;
+    expect(limiter.take('user:u1', now).allowed).toBe(true);
+    expect(limiter.take('user:u1', now + 1_000).allowed).toBe(false);
+    // 6 tokens per minute → one token every 10s.
+    expect(limiter.take('user:u1', now + 11_000).allowed).toBe(true);
+  });
+
+  it('never exceeds capacity after a long idle period', () => {
+    const limiter = createTokenBucketRateLimiter({ capacity: 2, refillPerMinute: 60 });
+    const now = 1_000_000;
+    expect(limiter.take('k', now).allowed).toBe(true);
+    const later = now + 60 * 60 * 1_000;
+    expect(limiter.take('k', later).allowed).toBe(true);
+    expect(limiter.take('k', later).allowed).toBe(true);
+    expect(limiter.take('k', later).allowed).toBe(false);
+  });
+});
+
+describe('resolveClientIp', () => {
+  it('prefers the Netlify context ip', () => {
+    const request = new Request('https://example.com', {
+      headers: { 'x-nf-client-connection-ip': '9.9.9.9' },
+    });
+    expect(resolveClientIp(request, { ip: '1.1.1.1' })).toBe('1.1.1.1');
+  });
+
+  it('falls back to the Netlify header, then x-forwarded-for, then unknown', () => {
+    const withHeader = new Request('https://example.com', {
+      headers: { 'x-nf-client-connection-ip': '9.9.9.9' },
+    });
+    expect(resolveClientIp(withHeader)).toBe('9.9.9.9');
+
+    const withForwarded = new Request('https://example.com', {
+      headers: { 'x-forwarded-for': '8.8.8.8, 7.7.7.7' },
+    });
+    expect(resolveClientIp(withForwarded)).toBe('8.8.8.8');
+
+    expect(resolveClientIp(new Request('https://example.com'))).toBe('unknown');
+  });
+});
+
+describe('getBearerToken', () => {
+  it('extracts a bearer token case-insensitively', () => {
+    const request = new Request('https://example.com', {
+      headers: { Authorization: 'bearer abc.def.ghi' },
+    });
+    expect(getBearerToken(request)).toBe('abc.def.ghi');
+  });
+
+  it('returns null for missing or malformed headers', () => {
+    expect(getBearerToken(new Request('https://example.com'))).toBeNull();
+    const malformed = new Request('https://example.com', {
+      headers: { Authorization: 'Token abc' },
+    });
+    expect(getBearerToken(malformed)).toBeNull();
+  });
+});
+
+describe('verifySupabaseUser', () => {
+  beforeEach(() => {
+    stubDenoEnv({
+      VITE_SUPABASE_URL: 'https://supabase.example',
+      VITE_SUPABASE_ANON_KEY: 'anon-key',
+    });
+  });
+
+  it('returns the user id and anonymous flag for a valid token', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      id: 'user-123',
+      is_anonymous: true,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+
+    const result = await verifySupabaseUser('valid-token', fetchMock as typeof fetch);
+    expect(result).toEqual({ ok: true, userId: 'user-123', isAnonymous: true });
+    expect(fetchMock).toHaveBeenCalledWith('https://supabase.example/auth/v1/user', expect.objectContaining({
+      headers: expect.objectContaining({
+        apikey: 'anon-key',
+        Authorization: 'Bearer valid-token',
+      }),
+    }));
+  });
+
+  it('marks rejected tokens as invalid', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 401 }));
+    const result = await verifySupabaseUser('expired-token', fetchMock as typeof fetch);
+    expect(result).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  it('degrades to unavailable when Supabase config is missing', async () => {
+    stubDenoEnv({});
+    const fetchMock = vi.fn();
+    const result = await verifySupabaseUser('any-token', fetchMock as typeof fetch);
+    expect(result).toEqual({ ok: false, reason: 'unavailable' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('degrades to unavailable on network failure', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('boom'));
+    const result = await verifySupabaseUser('any-token', fetchMock as typeof fetch);
+    expect(result).toEqual({ ok: false, reason: 'unavailable' });
+  });
+});


### PR DESCRIPTION

Fixes #380

## Problem

`/api/ai/generate` accepted any unauthenticated POST with a `prompt` and triggered a paid provider call (Gemini/OpenAI/Anthropic/OpenRouter) with client-controlled `target.provider`/`target.model`, no rate limiting, and no prompt-length cap — an open financial DoS / quota-burn vector.

## Changes

### New: `netlify/edge-lib/ai-generate-guard.ts` (pure, unit-tested helpers)

- `validateGenerateInput` — requires a prompt (keeps the legacy `Missing required field: prompt` 400), rejects prompts over the cap with **413 `PROMPT_TOO_LONG`**, and enforces the provider/model allowlist (`ensureModelAllowed` from `ai-provider-runtime.ts`) **before** any provider work. Cap defaults to 24,000 chars (~3x headroom over real prompts built by `services/aiService.ts`, measured at ~7.5k for a long multi-week request); overridable via `AI_GENERATE_MAX_PROMPT_CHARS` (clamped 4k–120k).
- `createTokenBucketRateLimiter` — in-memory token bucket keyed per caller with LRU-ish eviction. Documented as **best-effort per edge isolate** (Netlify runs multiple isolates; this caps abuse per isolate and stops naive scripted abuse; a durable table-backed limiter can be layered on later without changing callers — none exists in the codebase today).
- `resolveClientIp` — `context.ip` → `x-nf-client-connection-ip` → first `x-forwarded-for` hop → `"unknown"`.
- `getBearerToken` / `verifySupabaseUser` — server-side token verification against `${VITE_SUPABASE_URL}/auth/v1/user`, returning user id + `is_anonymous`; degrades to `unavailable` (not a hard failure) when Supabase config/network is missing.

### `netlify/edge-functions/ai-generate.ts`

- Validates/clamps input first; forged/expired bearer tokens get **401 `AUTH_TOKEN_INVALID`**.
- Rate limits: verified Supabase sessions get a per-user budget (burst 10, refill 6/min); callers without a verifiable token share a stricter per-IP budget (burst 5, refill 3/min). Exceeding returns **429 `RATE_LIMITED`** with a `Retry-After` header.
- Telemetry now records `user_id` and auth mode (`supabase_user` / `supabase_anonymous` / `unverified`).

### `netlify/edge-functions/ai-generate-enqueue.ts`

- Rejects queued payloads whose `payload.prompt` exceeds the same cap (the background worker later spends provider quota on that prompt). Endpoint was already bearer-authenticated.

### `services/aiService.ts`

- The generate call now attaches the Supabase session access token (regular **or anonymous** session) as `Authorization: Bearer ...`, so real users land in the per-user budget.

## Design decision: anonymous generation stays supported

Trip generation is a product feature for anonymous users: the create-trip CTA calls `ensureDbSession()`, which signs users in anonymously via Supabase. Hard-requiring a non-anonymous login would break that flow. Instead: anonymous Supabase sessions verify like regular ones (per-user budget), and requests with no token at all are not rejected (non-breaking for cached clients) but fall into the stricter per-IP bucket.

## Tests

- `tests/unit/aiGenerateGuard.test.ts` — 21 tests for validation, cap/env clamping, token bucket (burst, refill, key isolation, capacity ceiling), IP resolution, bearer parsing, Supabase verification (valid/invalid/unavailable).
- `tests/unit/aiGenerateEdgeGuard.test.ts` — handler-level regressions: 413 oversized prompt, 400 disallowed model, legacy 400 missing prompt, 401 forged token, 429 per-IP with `Retry-After`, and independent budgets per IP; asserts no outbound provider fetch happens on rejected requests.
- `tests/unit/aiGenerateEnqueue.test.ts` — new regression: oversized `payload.prompt` → 400 with no Supabase call.

## Verification

- Targeted: `vitest run tests/unit/aiGenerateGuard.test.ts tests/unit/aiGenerateEdgeGuard.test.ts tests/unit/aiGenerateEnqueue.test.ts` — 31/31 passed.
- `pnpm edge:validate` — passed.
- `pnpm test:core` — 1415 passed / 1 failed; the failure is a pre-existing flaky admin browser test unrelated to this change (a *different* admin test failed on each of two runs — `adminDataTable`, then `adminAirportsPage.browser` — and both pass in isolation).
- `pnpm updates:validate` — passed (draft release note added under `content/updates/`).

## Release note

`content/updates/2026-07-02-ai-generation-hardening.md` (status: draft, internal-only items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)