### PR TITLE
Harden Paddle discount lookup against voucher enumeration

### DIFF
--- a/content/updates/2026-07-02-voucher-lookup-hardening.md
+++ b/content/updates/2026-07-02-voucher-lookup-hardening.md
@@ -1,0 +1,18 @@
+---
+id: rel-2026-07-02-voucher-lookup-hardening
+version: v0.127.0
+title: "Harden checkout voucher lookup"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Hardened the checkout voucher lookup against automated code guessing."
+---
+
+## Changes
+- [ ] [Internal] 🛡️ Added per-IP, per-code, and per-user token-bucket rate limiting to the public Paddle voucher lookup edge function.
+- [ ] [Internal] 🔎 Voucher lookups now validate code charset/length and tier allowlist before any Paddle API call.
+- [ ] [Internal] 🤐 Negative voucher lookups return a single uniform response (with a small constant delay), removing the discount-catalog oracle; description-based matching was removed entirely.
+- [ ] [Internal] 📦 Minimized the voucher lookup response to the fields the checkout UI renders (no more discount descriptions or recurrence metadata).
+- [ ] [Internal] 🪪 Signed-in checkout visitors now send their Supabase session token so lookups are additionally rate limited per verified user.

--- a/netlify/edge-functions/paddle-discount-lookup.ts
+++ b/netlify/edge-functions/paddle-discount-lookup.ts
@@ -4,17 +4,37 @@ import {
   resolvePriceIdForTier,
 } from '../edge-lib/paddle-billing.ts';
 import {
+  authorizeBillingUser,
   fetchPaddleJson,
+  getAuthToken,
   getPaddleApiConfig,
+  getSupabaseAnonConfig,
   json,
   resolvePaddleApiBaseUrl,
   asTrimmedString,
 } from '../edge-lib/paddle-request.ts';
+import {
+  createTokenBucketLimiter,
+  normalizeVoucherCode,
+  shapeDiscountLookupData,
+  RATE_LIMITED_MESSAGE,
+  UNIFORM_INVALID_VOUCHER_MESSAGE,
+} from '../edge-lib/discount-lookup-guard.ts';
 import { extractServiceError } from '../edge-lib/paddle-webhook-sync.ts';
 
 type CheckoutTierKey = Extract<PlanTierKey, 'tier_mid' | 'tier_premium'>;
 type PaddleDiscountRecord = Record<string, unknown>;
-type PaddleDiscountMatch = { discount: PaddleDiscountRecord; matchedBy: 'code' | 'description' } | null;
+
+// Per-isolate token buckets. Not globally durable, but they cap the voucher
+// enumeration rate any single edge isolate will serve.
+const ipLimiter = createTokenBucketLimiter({ capacity: 10, refillIntervalMs: 60_000 });
+const codeLimiter = createTokenBucketLimiter({ capacity: 20, refillIntervalMs: 60_000 });
+const userLimiter = createTokenBucketLimiter({ capacity: 15, refillIntervalMs: 60_000 });
+
+/** Constant delay before negative responses to blunt high-speed enumeration. */
+const NEGATIVE_RESPONSE_DELAY_MS = 150;
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 const parseTierKey = (value: unknown): CheckoutTierKey | null => {
   if (value === 'tier_mid') return 'tier_mid';
@@ -41,22 +61,16 @@ const normalizeCode = (value: unknown): string | null => {
   return normalized ? normalized.toUpperCase() : null;
 };
 
-const findMatchingDiscount = (
+/**
+ * Matches by exact redeemable checkout code only. Matching against discount
+ * descriptions (a previous "diagnostics" behavior) allowed unauthenticated
+ * callers to enumerate internal discount descriptions and must not return.
+ */
+const findDiscountByCode = (
   discounts: PaddleDiscountRecord[],
   code: string,
-): PaddleDiscountMatch => {
-  const exactCodeMatch = discounts.find((candidate) => normalizeCode(candidate.code) === code);
-  if (exactCodeMatch) {
-    return { discount: exactCodeMatch, matchedBy: 'code' };
-  }
-
-  const descriptionMatch = discounts.find((candidate) => normalizeCode(candidate.description) === code);
-  if (descriptionMatch) {
-    return { discount: descriptionMatch, matchedBy: 'description' };
-  }
-
-  return null;
-};
+): PaddleDiscountRecord | null =>
+  discounts.find((candidate) => normalizeCode(candidate.code) === code) || null;
 
 const isCheckoutEnabled = (discount: PaddleDiscountRecord): boolean =>
   discount.enabled_for_checkout !== false;
@@ -154,16 +168,24 @@ const listDiscounts = async (
     : [];
 };
 
+const rateLimited = (): Response =>
+  json(429, { ok: false, error: RATE_LIMITED_MESSAGE });
+
+const resolveClientIp = (request: Request, context?: { ip?: string }): string =>
+  asTrimmedString(context?.ip)
+    || asTrimmedString(request.headers.get('x-nf-client-connection-ip'))
+    || 'unknown';
+
 export const __paddleDiscountLookupInternals = {
   buildEstimate,
   getRestrictionIds,
   isDiscountApplicableToTarget,
   normalizeCode,
   parseTierKey,
-  findMatchingDiscount,
+  findDiscountByCode,
 };
 
-export default async (request: Request): Promise<Response> => {
+export default async (request: Request, context?: { ip?: string }): Promise<Response> => {
   if (request.method !== 'GET') {
     return json(405, { ok: false, error: 'Method not allowed.' });
   }
@@ -184,11 +206,36 @@ export default async (request: Request): Promise<Response> => {
     });
   }
 
+  // Strict input validation before any network work: uppercase alphanumeric
+  // voucher codes (max 32 chars) and an allowlisted checkout tier only.
   const url = new URL(request.url);
-  const code = normalizeCode(url.searchParams.get('code'));
+  const code = normalizeVoucherCode(url.searchParams.get('code'));
   const tierKey = parseTierKey(url.searchParams.get('tier'));
   if (!code || !tierKey) {
     return json(400, { ok: false, error: 'A voucher code and supported tier key are required.' });
+  }
+
+  // Rate limit per client IP and per candidate code before touching Paddle.
+  const clientIp = resolveClientIp(request, context);
+  if (!ipLimiter.tryConsume(`ip:${clientIp}`)) {
+    return rateLimited();
+  }
+  if (!codeLimiter.tryConsume(`code:${code}`)) {
+    return rateLimited();
+  }
+
+  // Checkout also serves anonymous visitors, so authentication cannot be
+  // required here. But when the client does send a Supabase session token,
+  // verify it and rate limit on the user id as an additional key.
+  const authToken = getAuthToken(request);
+  if (authToken) {
+    const supabaseConfig = getSupabaseAnonConfig();
+    if (supabaseConfig) {
+      const authorization = await authorizeBillingUser(supabaseConfig, authToken).catch(() => null);
+      if (authorization?.ok && !userLimiter.tryConsume(`user:${authorization.user.userId}`)) {
+        return rateLimited();
+      }
+    }
   }
 
   const targetPriceId = resolvePriceIdForTier(tierKey, paddleConfig.priceMap);
@@ -202,20 +249,14 @@ export default async (request: Request): Promise<Response> => {
       listDiscounts(baseUrl, paddleConfig.apiKey),
       loadPriceDetail(baseUrl, paddleConfig.apiKey, targetPriceId),
     ]);
-    const match = findMatchingDiscount(discounts, code);
-    const discount = match?.discount;
+    const discount = findDiscountByCode(discounts, code);
 
-    if (!discount) {
-      return json(404, { ok: false, error: 'Voucher code not found or not available for checkout.' });
-    }
-    if (!isDiscountActive(discount)) {
-      return json(409, { ok: false, error: 'This Paddle discount exists, but it is not active right now.' });
-    }
-    if (match?.matchedBy === 'description' && !normalizeCode(discount.code)) {
-      return json(409, { ok: false, error: 'This Paddle discount exists, but it does not expose a redeemable checkout code yet.' });
-    }
-    if (!isCheckoutEnabled(discount)) {
-      return json(409, { ok: false, error: 'This Paddle discount exists, but it is not enabled for checkout.' });
+    // Uniform negative response: "not found", "inactive", and "not enabled
+    // for checkout" are indistinguishable so the endpoint cannot be used as
+    // an oracle for the Paddle discount catalog.
+    if (!discount || !isDiscountActive(discount) || !isCheckoutEnabled(discount)) {
+      await delay(NEGATIVE_RESPONSE_DELAY_MS);
+      return json(404, { ok: false, error: UNIFORM_INVALID_VOUCHER_MESSAGE });
     }
 
     const applicableToTier = isDiscountApplicableToTarget(discount, targetPriceId, priceDetail.productId);
@@ -225,17 +266,14 @@ export default async (request: Request): Promise<Response> => {
 
     return json(200, {
       ok: true,
-      data: {
+      data: shapeDiscountLookupData({
         code,
         type: asTrimmedString(discount.type),
         amount: asInteger(discount.amount),
         currencyCode: asTrimmedString(discount.currency_code) || priceDetail.currencyCode,
-        description: asTrimmedString(discount.description),
-        appliesToAllRecurring: discount.recur !== false,
-        maximumRecurringIntervals: asInteger(discount.maximum_recurring_intervals),
         applicableToTier,
         estimate,
-      },
+      }),
     });
   } catch (error) {
     return json(502, {

--- a/netlify/edge-lib/discount-lookup-guard.ts
+++ b/netlify/edge-lib/discount-lookup-guard.ts
@@ -1,0 +1,139 @@
+/**
+ * Hardening helpers for the public Paddle voucher lookup endpoint.
+ *
+ * The lookup is reachable without authentication (guests can apply vouchers at
+ * checkout), so it needs strict input validation, per-key token-bucket rate
+ * limiting, uniform negative responses, and a minimized success payload to
+ * prevent high-speed voucher-code enumeration against the Paddle account.
+ */
+
+/** Paddle checkout codes are short alphanumeric identifiers; allow `-`/`_` too. */
+export const VOUCHER_CODE_PATTERN = /^[A-Z0-9][A-Z0-9_-]{2,31}$/;
+
+/**
+ * Normalizes a raw voucher-code input to uppercase and validates it against a
+ * strict charset/length allowlist. Returns `null` for anything suspicious so
+ * callers can reject early without touching the Paddle API.
+ */
+export const normalizeVoucherCode = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toUpperCase();
+  if (!normalized || normalized.length > 32) return null;
+  return VOUCHER_CODE_PATTERN.test(normalized) ? normalized : null;
+};
+
+/** Single message used for every negative lookup outcome (not found, inactive,
+ * checkout-disabled, description-only) so responses are indistinguishable. */
+export const UNIFORM_INVALID_VOUCHER_MESSAGE = 'Voucher code not found or not available for checkout.';
+
+export const RATE_LIMITED_MESSAGE = 'Too many voucher lookups. Please wait a moment and try again.';
+
+export interface TokenBucketLimiterOptions {
+  /** Maximum burst size (tokens available when idle). */
+  capacity: number;
+  /** Time for a fully drained bucket to refill completely, in ms. */
+  refillIntervalMs: number;
+  /** Cap on tracked keys to bound isolate memory. */
+  maxKeys?: number;
+}
+
+export interface TokenBucketLimiter {
+  /** Consumes one token for `key`. Returns `false` when the bucket is empty. */
+  tryConsume: (key: string, nowMs?: number) => boolean;
+  /** Number of currently tracked keys (for tests/diagnostics). */
+  size: () => number;
+}
+
+interface BucketState {
+  tokens: number;
+  updatedAtMs: number;
+}
+
+/**
+ * In-memory token bucket limiter (per edge isolate). Not globally durable, but
+ * it removes the "unlimited unauthenticated requests" property and caps the
+ * enumeration rate any single isolate will serve.
+ */
+export const createTokenBucketLimiter = (
+  options: TokenBucketLimiterOptions,
+): TokenBucketLimiter => {
+  const capacity = Math.max(1, Math.floor(options.capacity));
+  const refillIntervalMs = Math.max(1, Math.floor(options.refillIntervalMs));
+  const maxKeys = Math.max(1, Math.floor(options.maxKeys ?? 5000));
+  const refillPerMs = capacity / refillIntervalMs;
+  const buckets = new Map<string, BucketState>();
+
+  const prune = (nowMs: number): void => {
+    if (buckets.size <= maxKeys) return;
+    for (const [key, state] of buckets) {
+      const elapsed = Math.max(0, nowMs - state.updatedAtMs);
+      if (state.tokens + elapsed * refillPerMs >= capacity) {
+        buckets.delete(key);
+      }
+      if (buckets.size <= maxKeys) return;
+    }
+    // Still over budget (sustained attack across many keys): drop oldest entries.
+    for (const key of buckets.keys()) {
+      buckets.delete(key);
+      if (buckets.size <= maxKeys) return;
+    }
+  };
+
+  return {
+    tryConsume: (key: string, nowMs: number = Date.now()): boolean => {
+      const state = buckets.get(key);
+      let tokens = capacity;
+      if (state) {
+        const elapsed = Math.max(0, nowMs - state.updatedAtMs);
+        tokens = Math.min(capacity, state.tokens + elapsed * refillPerMs);
+      } else {
+        prune(nowMs);
+      }
+      if (tokens < 1) {
+        buckets.set(key, { tokens, updatedAtMs: nowMs });
+        return false;
+      }
+      buckets.set(key, { tokens: tokens - 1, updatedAtMs: nowMs });
+      return true;
+    },
+    size: () => buckets.size,
+  };
+};
+
+export interface DiscountLookupEstimate {
+  originalAmount: number;
+  discountedAmount: number;
+  savingsAmount: number;
+  currencyCode: string;
+}
+
+export interface DiscountLookupData {
+  code: string;
+  type: string | null;
+  amount: number | null;
+  currencyCode: string | null;
+  applicableToTier: boolean;
+  estimate: DiscountLookupEstimate | null;
+}
+
+/**
+ * Shapes the success payload down to exactly the fields the checkout UI
+ * consumes (badge + savings estimate). Internal Paddle metadata such as the
+ * discount description, recurrence settings, ids, or restriction lists must
+ * never be exposed to unauthenticated callers.
+ */
+export const shapeDiscountLookupData = (input: {
+  code: string;
+  type: unknown;
+  amount: unknown;
+  currencyCode: unknown;
+  applicableToTier: boolean;
+  estimate: DiscountLookupEstimate | null;
+}): DiscountLookupData => ({
+  code: input.code,
+  type: typeof input.type === 'string' && input.type.trim() ? input.type.trim() : null,
+  amount: typeof input.amount === 'number' && Number.isFinite(input.amount) ? Math.trunc(input.amount) : null,
+  currencyCode: typeof input.currencyCode === 'string' && input.currencyCode.trim() ? input.currencyCode.trim() : null,
+  applicableToTier: input.applicableToTier === true,
+  estimate: input.applicableToTier === true ? input.estimate : null,
+});

--- a/services/billingService.ts
+++ b/services/billingService.ts
@@ -164,9 +164,6 @@ interface BillingDiscountLookupResponse {
     type?: string | null;
     amount?: number | null;
     currencyCode?: string | null;
-    description?: string | null;
-    appliesToAllRecurring?: boolean;
-    maximumRecurringIntervals?: number | null;
     applicableToTier?: boolean;
     estimate?: {
       originalAmount?: number | null;
@@ -285,9 +282,6 @@ export interface BillingDiscountLookup {
   type: string | null;
   amount: number | null;
   currencyCode: string | null;
-  description: string | null;
-  appliesToAllRecurring: boolean;
-  maximumRecurringIntervals: number | null;
   applicableToTier: boolean;
   estimate: {
     originalAmount: number | null;
@@ -751,12 +745,25 @@ export const lookupPaddleDiscount = async (
     throw new Error('A voucher code is required.');
   }
 
+  // Voucher lookup also works for anonymous checkout visitors, but when a
+  // session is available we attach it so the edge function can verify the
+  // Supabase JWT and rate limit per user in addition to per IP.
+  let accessToken: string | null = null;
+  if (DB_ENABLED) {
+    try {
+      accessToken = await dbGetAccessToken();
+    } catch {
+      accessToken = null;
+    }
+  }
+
   const response = await fetch(
     `/api/billing/paddle/discount-lookup?code=${encodeURIComponent(normalizedCode)}&tier=${encodeURIComponent(tierKey)}`,
     {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
       },
     },
   );
@@ -784,9 +791,6 @@ export const lookupPaddleDiscount = async (
     type: data.type ?? null,
     amount: typeof data.amount === 'number' ? data.amount : null,
     currencyCode: data.currencyCode ?? null,
-    description: data.description ?? null,
-    appliesToAllRecurring: data.appliesToAllRecurring === true,
-    maximumRecurringIntervals: typeof data.maximumRecurringIntervals === 'number' ? data.maximumRecurringIntervals : null,
     applicableToTier: data.applicableToTier !== false,
     estimate: data.estimate
       ? {

--- a/tests/browser/checkoutPage.browser.test.ts
+++ b/tests/browser/checkoutPage.browser.test.ts
@@ -74,9 +74,6 @@ const mocks = vi.hoisted(() => ({
     type: 'percentage',
     amount: 20,
     currencyCode: 'USD',
-    description: 'Spring 20% off',
-    appliesToAllRecurring: true,
-    maximumRecurringIntervals: null,
     applicableToTier: true,
     estimate: {
       originalAmount: 900,
@@ -705,9 +702,6 @@ describe('pages/CheckoutPage', () => {
       type: 'percentage',
       amount: 50,
       currencyCode: 'USD',
-      description: 'VIP 50% off',
-      appliesToAllRecurring: true,
-      maximumRecurringIntervals: null,
       applicableToTier: true,
       estimate: {
         originalAmount: 900,

--- a/tests/browser/pricingPage.browser.test.ts
+++ b/tests/browser/pricingPage.browser.test.ts
@@ -64,9 +64,6 @@ const mocks = vi.hoisted(() => ({
     type: 'percentage',
     amount: 20,
     currencyCode: 'USD',
-    description: 'Spring 20% off',
-    appliesToAllRecurring: true,
-    maximumRecurringIntervals: null,
     applicableToTier: true,
     estimate: {
       originalAmount: 900,

--- a/tests/unit/billingService.test.ts
+++ b/tests/unit/billingService.test.ts
@@ -265,9 +265,6 @@ describe('billingService startPaddleCheckoutSession', () => {
         type: 'percentage',
         amount: 20,
         currencyCode: 'USD',
-        description: 'Spring 20% off',
-        appliesToAllRecurring: true,
-        maximumRecurringIntervals: null,
         applicableToTier: true,
         estimate: {
           originalAmount: 900,
@@ -283,9 +280,6 @@ describe('billingService startPaddleCheckoutSession', () => {
       type: 'percentage',
       amount: 20,
       currencyCode: 'USD',
-      description: 'Spring 20% off',
-      appliesToAllRecurring: true,
-      maximumRecurringIntervals: null,
       applicableToTier: true,
       estimate: {
         originalAmount: 900,

--- a/tests/unit/discountLookupGuard.test.ts
+++ b/tests/unit/discountLookupGuard.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTokenBucketLimiter,
+  normalizeVoucherCode,
+  shapeDiscountLookupData,
+  RATE_LIMITED_MESSAGE,
+  UNIFORM_INVALID_VOUCHER_MESSAGE,
+} from '../../netlify/edge-lib/discount-lookup-guard';
+
+describe('normalizeVoucherCode', () => {
+  it('uppercases and trims valid voucher codes', () => {
+    expect(normalizeVoucherCode(' spring20 ')).toBe('SPRING20');
+    expect(normalizeVoucherCode('WELCOME-10')).toBe('WELCOME-10');
+    expect(normalizeVoucherCode('summer_2026')).toBe('SUMMER_2026');
+  });
+
+  it('rejects non-string, empty, too-short, and too-long inputs', () => {
+    expect(normalizeVoucherCode(null)).toBeNull();
+    expect(normalizeVoucherCode(undefined)).toBeNull();
+    expect(normalizeVoucherCode(42)).toBeNull();
+    expect(normalizeVoucherCode('')).toBeNull();
+    expect(normalizeVoucherCode('AB')).toBeNull();
+    expect(normalizeVoucherCode('X'.repeat(33))).toBeNull();
+    expect(normalizeVoucherCode('X'.repeat(32))).toBe('X'.repeat(32));
+  });
+
+  it('rejects codes with characters outside the allowlist', () => {
+    expect(normalizeVoucherCode('SPRING 20')).toBeNull();
+    expect(normalizeVoucherCode('CODE%')).toBeNull();
+    expect(normalizeVoucherCode('CODE*')).toBeNull();
+    expect(normalizeVoucherCode('<script>')).toBeNull();
+    expect(normalizeVoucherCode('-LEADINGDASH')).toBeNull();
+  });
+});
+
+describe('createTokenBucketLimiter', () => {
+  it('allows bursts up to capacity and then rejects', () => {
+    const limiter = createTokenBucketLimiter({ capacity: 3, refillIntervalMs: 60_000 });
+    const now = 1_000_000;
+    expect(limiter.tryConsume('ip:1.2.3.4', now)).toBe(true);
+    expect(limiter.tryConsume('ip:1.2.3.4', now)).toBe(true);
+    expect(limiter.tryConsume('ip:1.2.3.4', now)).toBe(true);
+    expect(limiter.tryConsume('ip:1.2.3.4', now)).toBe(false);
+    expect(limiter.tryConsume('ip:1.2.3.4', now + 1_000)).toBe(false);
+  });
+
+  it('tracks keys independently', () => {
+    const limiter = createTokenBucketLimiter({ capacity: 1, refillIntervalMs: 60_000 });
+    const now = 5_000;
+    expect(limiter.tryConsume('ip:1.1.1.1', now)).toBe(true);
+    expect(limiter.tryConsume('ip:1.1.1.1', now)).toBe(false);
+    expect(limiter.tryConsume('ip:2.2.2.2', now)).toBe(true);
+    expect(limiter.tryConsume('code:SPRING20', now)).toBe(true);
+  });
+
+  it('refills tokens over time', () => {
+    const limiter = createTokenBucketLimiter({ capacity: 2, refillIntervalMs: 60_000 });
+    const start = 0;
+    expect(limiter.tryConsume('k', start)).toBe(true);
+    expect(limiter.tryConsume('k', start)).toBe(true);
+    expect(limiter.tryConsume('k', start)).toBe(false);
+    // Half the refill interval restores half the capacity (1 token here).
+    expect(limiter.tryConsume('k', start + 30_000)).toBe(true);
+    expect(limiter.tryConsume('k', start + 30_000)).toBe(false);
+    // A full interval later the bucket is full again.
+    expect(limiter.tryConsume('k', start + 90_001)).toBe(true);
+    expect(limiter.tryConsume('k', start + 90_001)).toBe(true);
+    expect(limiter.tryConsume('k', start + 90_001)).toBe(false);
+  });
+
+  it('bounds the number of tracked keys', () => {
+    const limiter = createTokenBucketLimiter({ capacity: 1, refillIntervalMs: 1_000, maxKeys: 10 });
+    for (let index = 0; index < 200; index += 1) {
+      limiter.tryConsume(`ip:10.0.0.${index}`, index * 5);
+    }
+    expect(limiter.size()).toBeLessThanOrEqual(11);
+  });
+});
+
+describe('shapeDiscountLookupData', () => {
+  it('keeps only the fields the checkout UI consumes', () => {
+    const shaped = shapeDiscountLookupData({
+      code: 'SPRING20',
+      type: 'percentage',
+      amount: 20,
+      currencyCode: 'USD',
+      applicableToTier: true,
+      estimate: {
+        originalAmount: 900,
+        discountedAmount: 720,
+        savingsAmount: 180,
+        currencyCode: 'USD',
+      },
+    });
+
+    expect(shaped).toEqual({
+      code: 'SPRING20',
+      type: 'percentage',
+      amount: 20,
+      currencyCode: 'USD',
+      applicableToTier: true,
+      estimate: {
+        originalAmount: 900,
+        discountedAmount: 720,
+        savingsAmount: 180,
+        currencyCode: 'USD',
+      },
+    });
+    // Regression: internal Paddle metadata must never leak to the client.
+    expect(Object.keys(shaped).sort()).toEqual([
+      'amount',
+      'applicableToTier',
+      'code',
+      'currencyCode',
+      'estimate',
+      'type',
+    ]);
+    expect(shaped).not.toHaveProperty('description');
+    expect(shaped).not.toHaveProperty('maximumRecurringIntervals');
+    expect(shaped).not.toHaveProperty('appliesToAllRecurring');
+  });
+
+  it('sanitizes malformed values and drops estimates for non-applicable tiers', () => {
+    expect(shapeDiscountLookupData({
+      code: 'FLAT5',
+      type: '  ',
+      amount: Number.NaN,
+      currencyCode: '',
+      applicableToTier: false,
+      estimate: {
+        originalAmount: 900,
+        discountedAmount: 400,
+        savingsAmount: 500,
+        currencyCode: 'USD',
+      },
+    })).toEqual({
+      code: 'FLAT5',
+      type: null,
+      amount: null,
+      currencyCode: null,
+      applicableToTier: false,
+      estimate: null,
+    });
+  });
+});
+
+describe('uniform messaging', () => {
+  it('exposes stable uniform copy for negative and throttled responses', () => {
+    expect(UNIFORM_INVALID_VOUCHER_MESSAGE).toBe('Voucher code not found or not available for checkout.');
+    expect(RATE_LIMITED_MESSAGE).toContain('Too many voucher lookups');
+  });
+});

--- a/tests/unit/paddleDiscountLookupEdge.test.ts
+++ b/tests/unit/paddleDiscountLookupEdge.test.ts
@@ -28,32 +28,36 @@ describe('paddle discount lookup edge internals', () => {
     }, 'pri_mid', 'pro_mid')).toBe(false);
   });
 
-  it('matches discounts by code first and then by description for diagnostics', () => {
-    expect(__paddleDiscountLookupInternals.findMatchingDiscount([
+  it('matches discounts by exact redeemable code only', () => {
+    expect(__paddleDiscountLookupInternals.findDiscountByCode([
       {
         code: 'SPRING20',
         description: 'Spring 20',
       },
     ], 'SPRING20')).toEqual({
-      discount: {
-        code: 'SPRING20',
-        description: 'Spring 20',
-      },
-      matchedBy: 'code',
+      code: 'SPRING20',
+      description: 'Spring 20',
     });
+  });
 
-    expect(__paddleDiscountLookupInternals.findMatchingDiscount([
+  it('regression: never matches discounts by description (enumeration oracle)', () => {
+    // Previously the lookup fell back to matching the code against discount
+    // descriptions, letting unauthenticated callers enumerate internal
+    // discount descriptions. Description-only records must not match.
+    expect(__paddleDiscountLookupInternals.findDiscountByCode([
       {
         code: null,
         description: 'CHRISISTCOOL',
       },
-    ], 'CHRISISTCOOL')).toEqual({
-      discount: {
-        code: null,
-        description: 'CHRISISTCOOL',
+      {
+        code: 'OTHER10',
+        description: 'SPRINGSALE',
       },
-      matchedBy: 'description',
-    });
+    ], 'CHRISISTCOOL')).toBeNull();
+
+    expect(__paddleDiscountLookupInternals.findDiscountByCode([
+      { code: 'OTHER10', description: 'SPRINGSALE' },
+    ], 'SPRINGSALE')).toBeNull();
   });
 
   it('builds percentage and flat estimates from Paddle discount values', () => {


### PR DESCRIPTION

Fixes #381

## Problem

`GET /api/billing/paddle/discount-lookup` (`netlify/edge-functions/paddle-discount-lookup.ts`) was an unauthenticated, rate-unlimited voucher oracle: distinguishable 404/409 responses, matching against internal discount *descriptions*, and a response payload exposing full discount metadata. This enabled high-speed enumeration of live Paddle voucher codes and quota abuse of the Paddle API.

## Approach

Checkout serves anonymous visitors (login/register is rendered inline on `pages/CheckoutPage.tsx`), so hard authentication is not viable. Instead the endpoint is hardened defense-in-depth:

- **Rate limiting** — new `netlify/edge-lib/discount-lookup-guard.ts` provides a testable token-bucket limiter (per edge isolate). The handler limits per client IP (10/min), per candidate code (20/min), and — when a verified Supabase session token is present — per user id (15/min), all before any Paddle API call.
- **Strict input validation** — voucher codes must match `^[A-Z0-9][A-Z0-9_-]{2,31}$` after uppercasing; the tier param keeps its existing `tier_mid`/`tier_premium` allowlist. Anything else is rejected with a uniform 400 before network work.
- **Uniform negative responses** — not-found, inactive, and checkout-disabled codes now all return the same 404 body with a small constant delay (150 ms). Description-based matching is removed entirely (regression-tested).
- **Minimized payload** — the success response is shaped (`shapeDiscountLookupData`) to exactly what the checkout UI renders: `code`, `type`, `amount`, `currencyCode`, `applicableToTier`, `estimate`. `description`, `appliesToAllRecurring`, and `maximumRecurringIntervals` are no longer exposed; the client types/parsing were trimmed to match.
- **Optional JWT verification** — `lookupPaddleDiscount` in `services/billingService.ts` now attaches the Supabase access token when a session exists; the edge function verifies it via the existing `authorizeBillingUser` helper and uses the user id as an additional rate-limit key. Anonymous lookups continue to work.

## Changes

- `netlify/edge-lib/discount-lookup-guard.ts` (new): `normalizeVoucherCode`, `createTokenBucketLimiter`, `shapeDiscountLookupData`, uniform message constants.
- `netlify/edge-functions/paddle-discount-lookup.ts`: rate limiting, strict validation, uniform negative responses, exact-code-only matching, minimized payload, optional JWT verification.
- `services/billingService.ts`: send session token when available; trim `BillingDiscountLookup` to consumed fields.
- `tests/unit/discountLookupGuard.test.ts` (new): validation, token-bucket (burst/refill/key-bounding), response shaping, uniform copy.
- `tests/unit/paddleDiscountLookupEdge.test.ts`: regression test that description-only discounts never match.
- `tests/unit/billingService.test.ts`, `tests/browser/*.browser.test.ts`: mocks updated for the trimmed payload.
- `content/updates/2026-07-02-voucher-lookup-hardening.md`: draft release note (internal items).

## Tests

- `vitest run tests/unit/discountLookupGuard.test.ts tests/unit/paddleDiscountLookupEdge.test.ts tests/unit/billingService.test.ts` — 26 passed.
- `pnpm edge:validate` — passed.
- `pnpm updates:validate` — passed (pre-existing canonical-version warning only).
- `pnpm test:core` — 313 files, 1399 passed / 1 skipped.

## Notes / limitations

- The limiter is in-memory per edge isolate — acceptable now; the guard module isolates a future swap to a durable shared store if needed.
- Release note kept as `status: draft` per repo convention while the PR is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)