### PR TITLE
Harden trip-map-preview edge function against paid-API quota abuse

### DIFF
--- a/content/updates/2026-07-02-trip-map-preview-hardening.md
+++ b/content/updates/2026-07-02-trip-map-preview-hardening.md
@@ -1,0 +1,18 @@
+---
+id: rel-2026-07-02-trip-map-preview-hardening
+version: v0.0.0
+title: "Trip map preview hardening"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Trip map preview images load faster thanks to stronger caching, with new protections against abusive traffic."
+---
+
+## Changes
+- [x] [Improved] 🗺️ Trip map preview images now load faster on repeat visits thanks to stronger caching.
+- [ ] [Internal] Added strict coordinate validation (count cap, lat/lng range and format checks) to the trip map preview edge function.
+- [ ] [Internal] Added per-IP token-bucket rate limiting with a higher cost for realistic-route previews to protect paid Directions API quota.
+- [ ] [Internal] Added durable CDN caching with an allowlisted query cache key (Netlify-Vary) so junk params cannot bust the preview cache.
+- [ ] [Internal] Extracted reusable preview guard helpers into netlify/edge-lib with Vitest coverage.

--- a/netlify/edge-functions/trip-map-preview.ts
+++ b/netlify/edge-functions/trip-map-preview.ts
@@ -18,8 +18,14 @@
  *   scale      — 1 or 2 (default 2)
  */
 
-import { getMapsApiKeyFromEnv } from "../edge-lib/trip-og-data.ts";
+import { getMapboxAccessTokenFromEnv, getMapsApiKeyFromEnv } from "../edge-lib/trip-og-data.ts";
 import { resolveEdgeMapRuntime } from "../edge-lib/map-runtime.ts";
+import {
+  buildPreviewNetlifyVaryValue,
+  createTokenBucketLimiter,
+  parsePreviewCoords,
+  resolvePreviewClientIp,
+} from "../edge-lib/trip-map-preview-guard.ts";
 
 type MapPreviewStyle = "clean" | "minimal" | "standard" | "dark" | "satellite";
 type RoutePreviewMode = "simple" | "realistic";
@@ -146,16 +152,6 @@ const encodePolyline = (coords: Array<{ lat: number; lng: number }>): string => 
   });
 
   return encoded;
-};
-
-const parseCoords = (value: string): Array<{ lat: number; lng: number }> => {
-  return value
-    .split("|")
-    .map((pair) => {
-      const [lat, lng] = pair.split(",").map(Number);
-      return { lat, lng };
-    })
-    .filter((coord) => Number.isFinite(coord.lat) && Number.isFinite(coord.lng));
 };
 
 const normalizeColor = (value: string | null): string | null => {
@@ -420,18 +416,57 @@ const buildMapboxStaticPreviewUrl = async ({
   return url.toString();
 };
 
-export default async (request: Request) => {
+// One request costs 1 token; a "realistic" route request costs more because it
+// can fan out to up to MAX_REALISTIC_DIRECTION_LEGS paid Directions API calls.
+const RATE_LIMIT_BUCKET_CAPACITY = 40;
+const RATE_LIMIT_REFILL_PER_SECOND = 0.5; // ≈30 simple previews per minute per IP
+const REALISTIC_ROUTE_REQUEST_COST = 5;
+
+const previewRateLimiter = createTokenBucketLimiter({
+  capacity: RATE_LIMIT_BUCKET_CAPACITY,
+  refillPerSecond: RATE_LIMIT_REFILL_PER_SECOND,
+});
+
+const SUCCESS_CACHE_HEADERS: Record<string, string> = {
+  "Cache-Control": "public, max-age=86400, s-maxage=86400",
+  "Netlify-CDN-Cache-Control": "public, durable, s-maxage=604800",
+  "Netlify-Vary": buildPreviewNetlifyVaryValue(),
+};
+
+const badRequest = (message: string): Response =>
+  new Response(message, {
+    status: 400,
+    headers: { "Cache-Control": "no-store" },
+  });
+
+export default async (request: Request, context?: { ip?: string }) => {
   const url = new URL(request.url);
   const mapRuntime = resolveEdgeMapRuntime(request);
   const coordsParam = url.searchParams.get("coords");
 
   if (!coordsParam) {
-    return new Response("Missing 'coords' query parameter", { status: 400 });
+    return badRequest("Missing 'coords' query parameter");
   }
 
-  const coords = parseCoords(coordsParam);
-  if (coords.length < 1) {
-    return new Response("At least one valid coordinate is required", { status: 400 });
+  const parsedCoords = parsePreviewCoords(coordsParam);
+  if (!parsedCoords.ok) {
+    return badRequest(parsedCoords.error);
+  }
+  const coords = parsedCoords.coords;
+
+  const routeMode = parseRouteMode(url.searchParams.get("routeMode"));
+
+  const clientIp = resolvePreviewClientIp(request, context);
+  const requestCost = routeMode === "realistic" ? REALISTIC_ROUTE_REQUEST_COST : 1;
+  const rateDecision = previewRateLimiter.consume(clientIp, requestCost);
+  if (!rateDecision.allowed) {
+    return new Response("Too many map preview requests, slow down", {
+      status: 429,
+      headers: {
+        "Cache-Control": "no-store",
+        "Retry-After": String(rateDecision.retryAfterSeconds),
+      },
+    });
   }
 
   const w = clampInt(Number.parseInt(url.searchParams.get("w") || "680", 10), 240, 1280);
@@ -439,10 +474,9 @@ export default async (request: Request) => {
   const scale = clampInt(Number.parseInt(url.searchParams.get("scale") || "2", 10), 1, 2);
   const requestedStyle = parseStyle(url.searchParams.get("style"));
   const style = getEffectiveStaticMapStyle(requestedStyle);
-  const routeMode = parseRouteMode(url.searchParams.get("routeMode"));
   const colorMode = parseColorMode(url.searchParams.get("colorMode"));
   const googleApiKey = getMapsApiKeyFromEnv();
-  const mapboxToken = Deno.env.get("VITE_MAPBOX_ACCESS_TOKEN") || "";
+  const mapboxToken = getMapboxAccessTokenFromEnv();
 
   const requestedPathColor = normalizeColor(url.searchParams.get("pathColor"));
   const pathColor = colorMode === "trip" ? (requestedPathColor || BRAND_ROUTE_COLOR) : BRAND_ROUTE_COLOR;
@@ -481,7 +515,7 @@ export default async (request: Request) => {
       status: 302,
       headers: {
         Location: mapUrl,
-        "Cache-Control": "public, max-age=86400",
+        ...SUCCESS_CACHE_HEADERS,
       },
     });
   }
@@ -539,7 +573,7 @@ export default async (request: Request) => {
     status: 302,
     headers: {
       Location: mapUrl,
-      "Cache-Control": "public, max-age=86400",
+      ...SUCCESS_CACHE_HEADERS,
     },
   });
 };

--- a/netlify/edge-lib/trip-map-preview-guard.ts
+++ b/netlify/edge-lib/trip-map-preview-guard.ts
@@ -1,0 +1,178 @@
+/**
+ * Abuse guards for the public `/api/trip-map-preview` edge function.
+ *
+ * The endpoint is unauthenticated by design (preview images are loaded from
+ * plain `<img>` tags), but every request can fan out to paid Google
+ * Directions / Static Maps / Mapbox Static API calls. These helpers provide:
+ *
+ * 1. Strict coordinate validation (count cap aligned with the client's
+ *    30-stop limit in `components/profile/tripPreviewUtils.ts`).
+ * 2. A deterministic cache key over the allowlisted preview params so the
+ *    CDN can collapse repeated identical requests.
+ * 3. A small in-memory token-bucket rate limiter (per isolate) keyed by
+ *    client IP.
+ */
+
+export type PreviewLatLng = { lat: number; lng: number };
+
+export type PreviewCoordsParseResult =
+  | { ok: true; coords: PreviewLatLng[] }
+  | { ok: false; error: string };
+
+/** Matches the client-side cap in `buildMiniMapUrl` (`slice(0, 30)`). */
+export const MAX_PREVIEW_COORDS = 30;
+
+/** 30 pairs of "-90.123456,-180.123456|" ≈ 660 chars; generous headroom. */
+export const MAX_PREVIEW_COORDS_PARAM_LENGTH = 1024;
+
+const COORD_PAIR_PATTERN = /^-?\d{1,3}(?:\.\d{1,10})?,-?\d{1,3}(?:\.\d{1,10})?$/;
+
+export const parsePreviewCoords = (value: string): PreviewCoordsParseResult => {
+  if (value.length > MAX_PREVIEW_COORDS_PARAM_LENGTH) {
+    return { ok: false, error: `'coords' exceeds ${MAX_PREVIEW_COORDS_PARAM_LENGTH} characters` };
+  }
+
+  const pairs = value.split("|");
+  if (pairs.length > MAX_PREVIEW_COORDS) {
+    return { ok: false, error: `'coords' supports at most ${MAX_PREVIEW_COORDS} coordinates` };
+  }
+
+  const coords: PreviewLatLng[] = [];
+  for (const pair of pairs) {
+    const trimmed = pair.trim();
+    if (!COORD_PAIR_PATTERN.test(trimmed)) {
+      return { ok: false, error: "'coords' must be pipe-separated lat,lng pairs" };
+    }
+    const [lat, lng] = trimmed.split(",").map(Number);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng) || Math.abs(lat) > 90 || Math.abs(lng) > 180) {
+      return { ok: false, error: "'coords' contains an out-of-range latitude/longitude" };
+    }
+    coords.push({ lat, lng });
+  }
+
+  if (coords.length < 1) {
+    return { ok: false, error: "At least one valid coordinate is required" };
+  }
+
+  return { ok: true, coords };
+};
+
+/**
+ * Query params that affect the generated preview image. Everything else is
+ * noise and must not fragment (or bust) the CDN cache.
+ */
+export const PREVIEW_CACHE_QUERY_PARAMS = [
+  "coords",
+  "style",
+  "routeMode",
+  "colorMode",
+  "pathColor",
+  "legColors",
+  "startMarkerColor",
+  "endMarkerColor",
+  "waypointColor",
+  "language",
+  "w",
+  "h",
+  "scale",
+  "mr",
+] as const;
+
+/** Value for the `Netlify-Vary` response header: cache key = allowlisted query params only. */
+export const buildPreviewNetlifyVaryValue = (): string =>
+  `query=${PREVIEW_CACHE_QUERY_PARAMS.join("|")}`;
+
+/**
+ * Deterministic cache key from normalized params: allowlisted params only,
+ * sorted by name, empty values dropped. Two semantically identical requests
+ * (regardless of param order or junk params) produce the same key.
+ */
+export const buildPreviewCacheKey = (searchParams: URLSearchParams): string => {
+  const normalized = new URLSearchParams();
+  for (const name of [...PREVIEW_CACHE_QUERY_PARAMS].sort()) {
+    const value = searchParams.get(name);
+    if (value !== null && value !== "") {
+      normalized.set(name, value.trim());
+    }
+  }
+  return normalized.toString();
+};
+
+export type TokenBucketLimiterOptions = {
+  /** Maximum burst size (bucket capacity). */
+  capacity: number;
+  /** Tokens restored per second. */
+  refillPerSecond: number;
+  /** Bound on tracked keys before stale entries are pruned. */
+  maxKeys?: number;
+};
+
+export type TokenBucketDecision = {
+  allowed: boolean;
+  /** Seconds until the request would be allowed again (0 when allowed). */
+  retryAfterSeconds: number;
+};
+
+export type TokenBucketLimiter = {
+  consume: (key: string, cost?: number, nowMs?: number) => TokenBucketDecision;
+};
+
+type BucketState = { tokens: number; updatedAtMs: number };
+
+export const createTokenBucketLimiter = (
+  options: TokenBucketLimiterOptions,
+): TokenBucketLimiter => {
+  const { capacity, refillPerSecond, maxKeys = 5000 } = options;
+  const buckets = new Map<string, BucketState>();
+
+  const prune = (nowMs: number): void => {
+    if (buckets.size <= maxKeys) return;
+    const staleBeforeMs = nowMs - (capacity / refillPerSecond) * 1000;
+    for (const [key, state] of buckets) {
+      if (state.updatedAtMs <= staleBeforeMs) buckets.delete(key);
+    }
+    // Hard fallback: drop oldest entries if pruning stale ones was not enough.
+    if (buckets.size > maxKeys) {
+      const overflow = buckets.size - maxKeys;
+      let dropped = 0;
+      for (const key of buckets.keys()) {
+        if (dropped >= overflow) break;
+        buckets.delete(key);
+        dropped += 1;
+      }
+    }
+  };
+
+  return {
+    consume: (key: string, cost = 1, nowMs = Date.now()): TokenBucketDecision => {
+      prune(nowMs);
+      const state = buckets.get(key) ?? { tokens: capacity, updatedAtMs: nowMs };
+      const elapsedSeconds = Math.max(0, (nowMs - state.updatedAtMs) / 1000);
+      const tokens = Math.min(capacity, state.tokens + elapsedSeconds * refillPerSecond);
+
+      if (tokens >= cost) {
+        buckets.set(key, { tokens: tokens - cost, updatedAtMs: nowMs });
+        return { allowed: true, retryAfterSeconds: 0 };
+      }
+
+      buckets.set(key, { tokens, updatedAtMs: nowMs });
+      return {
+        allowed: false,
+        retryAfterSeconds: Math.max(1, Math.ceil((cost - tokens) / refillPerSecond)),
+      };
+    },
+  };
+};
+
+/** Resolves the client IP for rate limiting, preferring Netlify's trusted header. */
+export const resolvePreviewClientIp = (
+  request: Request,
+  context?: { ip?: string },
+): string => {
+  if (context?.ip) return context.ip;
+  const netlifyIp = request.headers.get("x-nf-client-connection-ip");
+  if (netlifyIp) return netlifyIp.trim();
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) return forwardedFor.split(",")[0].trim();
+  return "unknown";
+};

--- a/tests/unit/tripMapPreviewEdge.test.ts
+++ b/tests/unit/tripMapPreviewEdge.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import handler from '../../netlify/edge-functions/trip-map-preview.ts';
+
+let ipCounter = 0;
+const nextIp = (): string => {
+  ipCounter += 1;
+  return `10.0.${Math.floor(ipCounter / 250)}.${ipCounter % 250}`;
+};
+
+const callPreview = (
+  query: string,
+  options?: { ip?: string },
+): Promise<Response> => {
+  const ip = options?.ip ?? nextIp();
+  const request = new Request(`https://travelflow.example/api/trip-map-preview?${query}`, {
+    headers: { 'x-nf-client-connection-ip': ip },
+  });
+  return Promise.resolve(handler(request));
+};
+
+describe('trip-map-preview edge function hardening', () => {
+  beforeEach(() => {
+    const edgeEnv: Record<string, string> = {
+      VITE_GOOGLE_MAPS_API_KEY: 'test-google-key',
+      VITE_MAPBOX_ACCESS_TOKEN: '',
+      VITE_MAP_RUNTIME_PRESET: 'google_all',
+    };
+    vi.stubGlobal('Deno', { env: { get: (name: string) => edgeEnv[name] } });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 500 })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('input validation', () => {
+    it('rejects requests without coords', async () => {
+      const response = await callPreview('style=clean');
+      expect(response.status).toBe(400);
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+    });
+
+    it('rejects malformed coords instead of silently filtering them', async () => {
+      const response = await callPreview('coords=35.68,139.65|garbage');
+      expect(response.status).toBe(400);
+    });
+
+    it('rejects out-of-range coordinates', async () => {
+      const response = await callPreview('coords=95.0,139.65');
+      expect(response.status).toBe(400);
+    });
+
+    it('rejects more coordinates than the product supports (regression: unbounded coords)', async () => {
+      const coords = Array.from({ length: 31 }, (_, index) => `${index % 80}.5,${index % 170}.5`).join('|');
+      const response = await callPreview(`coords=${coords}`);
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain('30');
+    });
+  });
+
+  describe('caching', () => {
+    it('serves valid requests as CDN-cacheable redirects', async () => {
+      const response = await callPreview('coords=35.68,139.65|34.69,135.50&style=clean');
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toContain('maps.googleapis.com/maps/api/staticmap');
+      expect(response.headers.get('Cache-Control')).toContain('public');
+      expect(response.headers.get('Cache-Control')).toContain('s-maxage');
+      expect(response.headers.get('Netlify-CDN-Cache-Control')).toContain('durable');
+      expect(response.headers.get('Netlify-Vary')).toContain('query=');
+      expect(response.headers.get('Netlify-Vary')).toContain('coords');
+    });
+
+    it('does not mark rate-limit or validation errors as cacheable', async () => {
+      const invalid = await callPreview('coords=nope');
+      expect(invalid.headers.get('Cache-Control')).toBe('no-store');
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('returns 429 with Retry-After once a single IP exhausts its budget', async () => {
+      const ip = nextIp();
+      let lastStatus = 0;
+      let rejected: Response | null = null;
+      for (let index = 0; index < 60; index += 1) {
+        const response = await callPreview('coords=35.68,139.65|34.69,135.50', { ip });
+        lastStatus = response.status;
+        if (response.status === 429) {
+          rejected = response;
+          break;
+        }
+        expect(response.status).toBe(302);
+      }
+      expect(lastStatus).toBe(429);
+      expect(Number(rejected?.headers.get('Retry-After'))).toBeGreaterThanOrEqual(1);
+      expect(rejected?.headers.get('Cache-Control')).toBe('no-store');
+    });
+
+    it('does not throttle other client IPs', async () => {
+      const throttledIp = nextIp();
+      for (let index = 0; index < 60; index += 1) {
+        await callPreview('coords=35.68,139.65|34.69,135.50', { ip: throttledIp });
+      }
+      const other = await callPreview('coords=35.68,139.65|34.69,135.50');
+      expect(other.status).toBe(302);
+    });
+
+    it('charges realistic-route requests a higher cost (regression: Directions fan-out abuse)', async () => {
+      const simpleIp = nextIp();
+      const realisticIp = nextIp();
+
+      let simpleAllowed = 0;
+      for (let index = 0; index < 60; index += 1) {
+        const response = await callPreview('coords=35.68,139.65|34.69,135.50', { ip: simpleIp });
+        if (response.status !== 302) break;
+        simpleAllowed += 1;
+      }
+
+      let realisticAllowed = 0;
+      for (let index = 0; index < 60; index += 1) {
+        const response = await callPreview(
+          'coords=35.68,139.65|34.69,135.50&routeMode=realistic',
+          { ip: realisticIp },
+        );
+        if (response.status !== 302) break;
+        realisticAllowed += 1;
+      }
+
+      expect(realisticAllowed).toBeGreaterThan(0);
+      expect(realisticAllowed).toBeLessThan(simpleAllowed);
+    });
+  });
+});

--- a/tests/unit/tripMapPreviewGuard.test.ts
+++ b/tests/unit/tripMapPreviewGuard.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_PREVIEW_COORDS,
+  MAX_PREVIEW_COORDS_PARAM_LENGTH,
+  buildPreviewCacheKey,
+  buildPreviewNetlifyVaryValue,
+  createTokenBucketLimiter,
+  parsePreviewCoords,
+  resolvePreviewClientIp,
+} from '../../netlify/edge-lib/trip-map-preview-guard.ts';
+
+const buildCoordsParam = (count: number): string =>
+  Array.from({ length: count }, (_, index) => `${(index % 80) + 0.5},${(index % 170) + 0.25}`).join('|');
+
+describe('parsePreviewCoords', () => {
+  it('accepts valid pipe-separated lat,lng pairs', () => {
+    const result = parsePreviewCoords('35.68,139.65|34.69,135.50');
+    expect(result).toEqual({
+      ok: true,
+      coords: [
+        { lat: 35.68, lng: 139.65 },
+        { lat: 34.69, lng: 135.5 },
+      ],
+    });
+  });
+
+  it('accepts negative coordinates and boundary values', () => {
+    const result = parsePreviewCoords('-90,-180|90,180');
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects more than the client-side stop cap', () => {
+    const result = parsePreviewCoords(buildCoordsParam(MAX_PREVIEW_COORDS + 1));
+    expect(result).toMatchObject({ ok: false });
+    if (!result.ok) expect(result.error).toContain(`${MAX_PREVIEW_COORDS}`);
+  });
+
+  it('accepts exactly the cap', () => {
+    expect(parsePreviewCoords(buildCoordsParam(MAX_PREVIEW_COORDS)).ok).toBe(true);
+  });
+
+  it('rejects malformed pairs instead of silently filtering them', () => {
+    expect(parsePreviewCoords('35.68,139.65|junk').ok).toBe(false);
+    expect(parsePreviewCoords('35.68').ok).toBe(false);
+    expect(parsePreviewCoords('').ok).toBe(false);
+    expect(parsePreviewCoords('1,2,3').ok).toBe(false);
+    expect(parsePreviewCoords('1e10,20').ok).toBe(false);
+  });
+
+  it('rejects out-of-range latitude and longitude', () => {
+    expect(parsePreviewCoords('91,0').ok).toBe(false);
+    expect(parsePreviewCoords('-91,0').ok).toBe(false);
+    expect(parsePreviewCoords('0,181').ok).toBe(false);
+    expect(parsePreviewCoords('0,-181').ok).toBe(false);
+  });
+
+  it('rejects oversized coords parameters', () => {
+    const oversized = '1,1|'.repeat(Math.ceil(MAX_PREVIEW_COORDS_PARAM_LENGTH / 4) + 1);
+    expect(parsePreviewCoords(oversized).ok).toBe(false);
+  });
+});
+
+describe('buildPreviewCacheKey', () => {
+  it('is deterministic regardless of param order', () => {
+    const a = new URLSearchParams('coords=1,2|3,4&style=clean&w=640&h=360');
+    const b = new URLSearchParams('h=360&w=640&style=clean&coords=1,2|3,4');
+    expect(buildPreviewCacheKey(a)).toBe(buildPreviewCacheKey(b));
+  });
+
+  it('ignores junk params that do not affect the image', () => {
+    const clean = new URLSearchParams('coords=1,2|3,4&style=clean');
+    const noisy = new URLSearchParams('coords=1,2|3,4&style=clean&cachebuster=123&utm_source=x');
+    expect(buildPreviewCacheKey(noisy)).toBe(buildPreviewCacheKey(clean));
+  });
+
+  it('produces different keys for different coords', () => {
+    const a = new URLSearchParams('coords=1,2|3,4');
+    const b = new URLSearchParams('coords=1,2|3,5');
+    expect(buildPreviewCacheKey(a)).not.toBe(buildPreviewCacheKey(b));
+  });
+});
+
+describe('buildPreviewNetlifyVaryValue', () => {
+  it('limits the CDN cache key to the allowlisted query params', () => {
+    const value = buildPreviewNetlifyVaryValue();
+    expect(value.startsWith('query=')).toBe(true);
+    expect(value).toContain('coords');
+    expect(value).toContain('mr');
+    expect(value).not.toContain('cachebuster');
+  });
+});
+
+describe('createTokenBucketLimiter', () => {
+  it('allows a burst up to capacity, then blocks', () => {
+    const limiter = createTokenBucketLimiter({ capacity: 3, refillPerSecond: 1 });
+    const now = 1_000_000;
+    expect(limiter.consume('ip', 1, now).allowed).toBe(true);
+    expect(limiter.consume('ip', 1, now).allowed).toBe(true);
+    expect(limiter.consume('ip', 1, now).allowed).toBe(true);
+    const blocked = limiter.consume('ip', 1, now);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+  });
+
+  it('refills tokens over time', () => {
+    const limiter = createTokenBucketLimiter({ capacity: 2, refillPerSecond: 1 });
+    const now = 1_000_000;
+    limiter.consume('ip', 2, now);
+    expect(limiter.consume('ip', 1, now).allowed).toBe(false);
+    expect(limiter.consume('ip', 1, now + 1_100).allowed).toBe(true);
+  });
+
+  it('supports weighted costs for expensive requests', () => {
+    const limiter = createTokenBucketLimiter({ capacity: 10, refillPerSecond: 0.5 });
+    const now = 1_000_000;
+    expect(limiter.consume('ip', 5, now).allowed).toBe(true);
+    expect(limiter.consume('ip', 5, now).allowed).toBe(true);
+    expect(limiter.consume('ip', 5, now).allowed).toBe(false);
+  });
+
+  it('tracks keys independently', () => {
+    const limiter = createTokenBucketLimiter({ capacity: 1, refillPerSecond: 1 });
+    const now = 1_000_000;
+    expect(limiter.consume('a', 1, now).allowed).toBe(true);
+    expect(limiter.consume('a', 1, now).allowed).toBe(false);
+    expect(limiter.consume('b', 1, now).allowed).toBe(true);
+  });
+
+  it('caps token accumulation at capacity', () => {
+    const limiter = createTokenBucketLimiter({ capacity: 2, refillPerSecond: 100 });
+    const now = 1_000_000;
+    limiter.consume('ip', 1, now);
+    // A long idle period must not allow a burst above capacity.
+    expect(limiter.consume('ip', 2, now + 60_000).allowed).toBe(true);
+    expect(limiter.consume('ip', 1, now + 60_000).allowed).toBe(false);
+  });
+});
+
+describe('resolvePreviewClientIp', () => {
+  it('prefers the edge context ip', () => {
+    const request = new Request('https://example.com/', {
+      headers: { 'x-nf-client-connection-ip': '2.2.2.2' },
+    });
+    expect(resolvePreviewClientIp(request, { ip: '1.1.1.1' })).toBe('1.1.1.1');
+  });
+
+  it('falls back to the Netlify client connection header', () => {
+    const request = new Request('https://example.com/', {
+      headers: { 'x-nf-client-connection-ip': '2.2.2.2', 'x-forwarded-for': '3.3.3.3, 4.4.4.4' },
+    });
+    expect(resolvePreviewClientIp(request)).toBe('2.2.2.2');
+  });
+
+  it('uses the first x-forwarded-for hop as a last resort', () => {
+    const request = new Request('https://example.com/', {
+      headers: { 'x-forwarded-for': '3.3.3.3, 4.4.4.4' },
+    });
+    expect(resolvePreviewClientIp(request)).toBe('3.3.3.3');
+    expect(resolvePreviewClientIp(new Request('https://example.com/'))).toBe('unknown');
+  });
+});


### PR DESCRIPTION

Fixes #382

## Problem

`/api/trip-map-preview` (`netlify/edge-functions/trip-map-preview.ts`) is unauthenticated (preview images load from `<img>` tags on public pages, so it has to be) but had no abuse controls:

- Unbounded attacker-controlled `coords` — any count, no lat/lng range checks, malformed pairs silently filtered.
- `routeMode=realistic` fans out to up to 8 billed Google Directions API calls per request (`MAX_REALISTIC_DIRECTION_LEGS`), plus a billed Static Maps / Mapbox Static redirect on every request.
- Cache key included all query params, so junk params (`&x=1`) bypassed the 24h cache and forced fresh paid API work per request.
- No rate limiting.

Net effect: anyone could burn paid Google/Mapbox quota at scale.

## Fix

1. **Strict input validation** (400 on failure, `Cache-Control: no-store`)
   - Max 30 coordinates — aligned with the real client cap (`routeCoordinates.slice(0, 30)` in `components/profile/tripPreviewUtils.ts`).
   - Per-pair format regex + lat/lng range checks (|lat| ≤ 90, |lng| ≤ 180); malformed pairs are rejected, not silently dropped.
   - Raw `coords` param length cap (1024 chars).

2. **Strong CDN caching**
   - `Cache-Control: public, max-age=86400, s-maxage=86400` and `Netlify-CDN-Cache-Control: public, durable, s-maxage=604800` on the 302 redirects (both Google and Mapbox paths).
   - `Netlify-Vary: query=<allowlist>` restricts the CDN cache key to the params that actually affect the image (`coords`, `style`, `routeMode`, `colorMode`, colors, `language`, `w`, `h`, `scale`, `mr`), so junk params can no longer bust the cache. A deterministic `buildPreviewCacheKey` helper (order-independent, allowlisted, sorted) is exported and unit-tested.

3. **Per-IP rate limiting** (in-memory token bucket per isolate — no durable limiter exists in the codebase yet)
   - 40-token burst, 0.5 tokens/s refill (~30 simple previews/min per IP).
   - `routeMode=realistic` costs 5 tokens because it can trigger up to 8 billed Directions calls.
   - Rejections return 429 with `Retry-After` and `Cache-Control: no-store`.
   - Client IP from Netlify edge context / `x-nf-client-connection-ip`, falling back to `x-forwarded-for`.

4. **Helpers extracted** to `netlify/edge-lib/trip-map-preview-guard.ts` (validation, cache key/vary, token-bucket limiter with bounded key set + stale pruning, client-IP resolution). Also replaced the raw `Deno.env.get` Mapbox token read with the existing `getMapboxAccessTokenFromEnv()` helper.

## Not done (follow-up)

- **HMAC-signed preview URLs**: would fully close the abuse window, but the repo has no existing URL-signing secret pattern (Paddle HMAC verifies Paddle's webhook signatures and is not reusable). Introducing one requires a new env var and a shared client/edge signing scheme — deliberately deferred.
- Durable (Blob/KV-backed) rate limiter shared across edge isolates.
- Google Cloud / Mapbox key restrictions and budget alerts (ops-side defense in depth).

## Tests

- New `tests/unit/tripMapPreviewGuard.test.ts` — 19 tests over the pure helpers (coords validation incl. cap/range/format regressions, cache key determinism and junk-param immunity, token bucket burst/refill/cost/per-key isolation/accumulation cap, client IP resolution).
- New `tests/unit/tripMapPreviewEdge.test.ts` — 9 handler tests: 400s for missing/malformed/out-of-range/over-cap coords (regression for previously unbounded input), cacheable 302 with CDN headers, no-store on errors, 429 + `Retry-After` on per-IP exhaustion, IP isolation, and higher cost for realistic-route requests (regression for Directions fan-out abuse).
- `pnpm vitest run` targeted suites: 35/35 passed (incl. existing `tripPreviewUtils` suites).
- `pnpm edge:validate`: passed.
- `pnpm test:core`: 314/314 test files passed.

## Release note

`content/updates/2026-07-02-trip-map-preview-hardening.md` (status: draft) with one user-visible caching improvement and `[ ] [Internal]` items for the hardening details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)