### PR TITLE
Fix default trip dates shifting one day early in UTC+ timezones

### DIFF
--- a/content/updates/2026-07-02-default-trip-dates-timezone-fix.md
+++ b/content/updates/2026-07-02-default-trip-dates-timezone-fix.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-07-02-default-trip-dates-timezone-fix
+version: v0.127.0
+title: "Correct Suggested Trip Dates in All Timezones"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: true
+in_app_hours: 24
+summary: "Suggested trip start dates now always land on the intended Friday, no matter your timezone."
+---
+
+## Changes
+- [x] [Fixed] 📅 Suggested trip dates in the planner and inspiration ideas now always land on the intended day — travelers east of GMT no longer saw start dates shifted one day earlier.
+- [ ] [Internal] Added `formatLocalIsoDate` to `shared/tripSpan.ts` and used it in `getDefaultTripDates` (utils.ts) and `InspirationsPage.tsx`, replacing `toISOString().split('T')[0]` which converts local midnight to the previous UTC day in UTC+ timezones.
+- [ ] [Internal] `getDefaultTripDates` now accepts an optional `now: Date` parameter for deterministic testing; regression tests in `tests/unit/defaultTripDates.test.ts` run under a forced `Europe/Berlin` timezone.

--- a/pages/InspirationsPage.tsx
+++ b/pages/InspirationsPage.tsx
@@ -31,6 +31,7 @@ import {
 import type { Destination, FestivalEvent as FestivalEventType, WeekendGetaway as WeekendGetawayType, CountryGroup, QuickIdea } from '../data/inspirationsData';
 import { getBlogPostsBySlugs } from '../services/blogService';
 import { buildCreateTripUrl } from '../utils';
+import { formatLocalIsoDate } from '../shared/tripSpan';
 import { resolveDestinationCodes } from '../services/destinationService';
 import { stripLeadingFlagEmoji } from '../utils/flagUtils';
 import { destinationCardMedia, festivalCardMedia } from '../data/inspirationCardMedia';
@@ -54,7 +55,7 @@ const formatFestivalDate = (date: Date): string => {
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 };
 
-const toIso = (d: Date): string => d.toISOString().split('T')[0];
+const toIso = (d: Date): string => formatLocalIsoDate(d);
 
 const addDaysLocal = (d: Date, n: number): Date => {
     const r = new Date(d);

--- a/shared/tripSpan.ts
+++ b/shared/tripSpan.ts
@@ -18,6 +18,18 @@ export interface TripSpanSummary {
     longLabel: string;
 }
 
+/**
+ * Formats a Date as a local `YYYY-MM-DD` string using local calendar components.
+ * Unlike `date.toISOString().split('T')[0]`, this never shifts the date across
+ * the UTC boundary (e.g. local Friday midnight in UTC+2 stays Friday).
+ */
+export const formatLocalIsoDate = (date: Date): string => {
+    const year = date.getFullYear();
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${year}-${month}-${day}`;
+};
+
 const parseLocalDate = (value: string): Date | null => {
     if (!value) return null;
     const parts = value.split('-').map(Number);

--- a/tests/unit/defaultTripDates.test.ts
+++ b/tests/unit/defaultTripDates.test.ts
@@ -1,0 +1,67 @@
+// Force a UTC+ timezone (UTC+1/UTC+2 with DST) before any Date usage so the
+// regression scenario — local midnight serializing as the previous UTC day —
+// is actually reproduced. Node picks up process.env.TZ for subsequent Date calls.
+process.env.TZ = 'Europe/Berlin';
+
+import { describe, expect, it } from 'vitest';
+
+import { formatLocalIsoDate } from '../../shared/tripSpan';
+import { getDefaultTripDates } from '../../utils';
+
+const isUtcPlusTimezone = new Date(2026, 6, 3).getTimezoneOffset() < 0;
+
+describe('shared/tripSpan formatLocalIsoDate', () => {
+    it('formats local calendar components with zero padding', () => {
+        expect(formatLocalIsoDate(new Date(2026, 9, 2))).toBe('2026-10-02');
+        expect(formatLocalIsoDate(new Date(2026, 0, 5))).toBe('2026-01-05');
+    });
+
+    it('does not shift local midnight to the previous UTC day', () => {
+        // Local Friday 2026-07-03 00:00 in a UTC+ timezone is Thursday in UTC,
+        // so toISOString-based formatting would return '2026-07-02'.
+        const localFridayMidnight = new Date(2026, 6, 3, 0, 0, 0);
+        expect(formatLocalIsoDate(localFridayMidnight)).toBe('2026-07-03');
+        // Guard that the forced TZ took effect, so the regression is really exercised.
+        expect(isUtcPlusTimezone).toBe(true);
+        expect(localFridayMidnight.toISOString().split('T')[0]).toBe('2026-07-02');
+    });
+});
+
+describe('getDefaultTripDates', () => {
+    it('returns the upcoming local Friday ~3 months out, not the previous day (UTC+ regression)', () => {
+        // "Now" is Wednesday 2026-04-01. Target month starts Wednesday 2026-07-01,
+        // so the first Friday is 2026-07-03. The old toISOString-based
+        // serialization returned '2026-07-02' (a Thursday) under Europe/Berlin.
+        const { startDate, endDate } = getDefaultTripDates(new Date(2026, 3, 1, 0, 30));
+        expect(startDate).toBe('2026-07-03');
+        expect(endDate).toBe('2026-07-18');
+    });
+
+    it('keeps the start date in the target month when the month starts on a Friday', () => {
+        // Target month May 2026 starts on Friday 2026-05-01; the old code
+        // serialized it as '2026-04-30', landing in the previous month.
+        const { startDate, endDate } = getDefaultTripDates(new Date(2026, 1, 1, 0, 30));
+        expect(startDate).toBe('2026-05-01');
+        expect(endDate).toBe('2026-05-16');
+    });
+
+    it('always starts on a Friday and spans 15 days', () => {
+        for (let month = 0; month < 12; month += 1) {
+            const { startDate, endDate } = getDefaultTripDates(new Date(2026, month, 15));
+            const [sy, sm, sd] = startDate.split('-').map(Number);
+            const start = new Date(sy, sm - 1, sd);
+            expect(start.getDay()).toBe(5);
+            const [ey, em, ed] = endDate.split('-').map(Number);
+            const end = new Date(ey, em - 1, ed);
+            const diffDays = Math.round((end.getTime() - start.getTime()) / 86400000);
+            expect(diffDays).toBe(15);
+        }
+    });
+
+    it('defaults to the current time when no reference date is given', () => {
+        const { startDate, endDate } = getDefaultTripDates();
+        expect(startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(endDate > startDate).toBe(true);
+    });
+});

--- a/utils.ts
+++ b/utils.ts
@@ -1,6 +1,7 @@
 import LZString from 'lz-string';
 import { ActivityType, AppLanguage, ICoordinates, ITrip, ITimelineItem, IViewSettings, ISharedState, MapColorMode, TransportMode, TripPrefillData } from './types';
 import { normalizeTransportMode } from './shared/transportModes';
+import { formatLocalIsoDate } from './shared/tripSpan';
 import { DEFAULT_LOCALE, localeToIntlLocale, normalizeLocale } from './config/locales';
 import { getTimelineVisualRange } from './utils/timelineVisualLayout';
 
@@ -836,24 +837,25 @@ export const reorderSelectedCities = (
     return [...updatedNonTravelItems, ...nonBoundaryTravelItems, ...rebuiltBoundaryTravelItems];
 };
 
-export const getDefaultTripDates = () => {
-    const today = new Date();
+export const getDefaultTripDates = (now: Date = new Date()) => {
     // 3 months in future
-    const target = new Date(today.getFullYear(), today.getMonth() + 3, 1);
-    
+    const target = new Date(now.getFullYear(), now.getMonth() + 3, 1);
+
     // Find next Friday (0=Sun, 5=Fri)
     const day = target.getDay();
     const diff = (5 - day + 7) % 7;
     target.setDate(target.getDate() + diff);
-    
+
     const start = target;
     const end = new Date(start);
     // "Two weeks long, Friday until Saturday" implies ~15/16 days (3 weekends)
-    end.setDate(start.getDate() + 15); 
-    
+    end.setDate(start.getDate() + 15);
+
+    // Format with local calendar components; toISOString() would convert to UTC
+    // and shift local midnight to the previous day in UTC+ timezones.
     return {
-        startDate: start.toISOString().split('T')[0],
-        endDate: end.toISOString().split('T')[0]
+        startDate: formatLocalIsoDate(start),
+        endDate: formatLocalIsoDate(end)
     };
 };
 


### PR DESCRIPTION

Fixes #383

## Problem

`getDefaultTripDates()` (utils.ts) picks an upcoming **local** Friday, then serializes it with `toISOString().split('T')[0]`, which converts to UTC first. For every user in a UTC+ timezone (e.g. Europe/Berlin), local Friday midnight serializes as Thursday's date — the wizard's default start date is a Thursday, the end date shifts too and can land in the previous month. The inspirations page used the same pattern (`toIso`) on local dates when building trip-creation prefill links.

## Changes

- **shared/tripSpan.ts**: new exported `formatLocalIsoDate(date)` helper — formats `YYYY-MM-DD` from local calendar components, never crossing the UTC boundary.
- **utils.ts** `getDefaultTripDates()`: serialize with `formatLocalIsoDate` instead of `toISOString()`; add optional `now: Date = new Date()` parameter for deterministic testing (non-breaking).
- **pages/InspirationsPage.tsx**: `toIso` now delegates to `formatLocalIsoDate` (weekend getaway / festival / monthly-idea links prefilled dates one day early in UTC+ timezones).
- **tests/unit/defaultTripDates.test.ts**: regression tests forcing `process.env.TZ = 'Europe/Berlin'` before any `Date` usage (verified effective — the test asserts `toISOString()` still reproduces the old wrong value). Proves:
  - for a Wednesday "now", the returned `startDate` is the local Friday (`2026-07-03`), not Thursday (`2026-07-02`);
  - a month starting on Friday no longer serializes the start date into the previous month (`2026-05-01`, not `2026-04-30`);
  - start is always a Friday, span is always 15 days.
- **content/updates/2026-07-02-default-trip-dates-timezone-fix.md**: draft release note.

## Deliberately left alone (same grep pattern, out of scope)

- `components/DetailsPanel.tsx:960` — builds a `date_from` query param for external GetYourGuide links from `addDays(new Date(tripStartDate), offset)`. Because `new Date('YYYY-MM-DD')` parses as **UTC** midnight, its `toISOString()` round-trips correctly in most timezones; changing serialization alone could introduce a shift for UTC- users. Deserves its own parse+format cleanup.

## Testing

- `pnpm vitest run tests/unit/defaultTripDates.test.ts tests/unit/tripSpan.test.ts` — 10 passed.
- Regression test also passes with shell `TZ=UTC` (the file forces the UTC+ timezone itself).
- `pnpm test:core` run and results reported in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)