### PR TITLE
Fix timeline resize-left clamping against wrong neighboring city

### DIFF
--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -17,6 +17,7 @@ import { normalizeTransportMode } from '../shared/transportModes';
 import { getExampleCityLaneViewTransitionName } from '../shared/viewTransitionNames';
 import { buildRenderedTimelineDaySlots, buildRenderedTimelineMonths } from './tripview/timelineRenderedSlots';
 import { getTimelineVisualCenter, getTimelineVisualRange, getTimelineVisualSpan } from '../utils/timelineVisualLayout';
+import { findPreviousCity } from '../utils/timelineNeighbors';
 
 interface TimelineProps {
   trip: ITrip;
@@ -538,7 +539,7 @@ export const Timeline: React.FC<TimelineProps> = ({
 
         if (Math.abs(currentItem.startDateOffset - newStart) < 0.000001) return;
 
-        const prevCity = newItems.find(i => i.type === 'city' && i.startDateOffset < currentItem.startDateOffset && i.id !== currentItem.id);
+        const prevCity = findPreviousCity(newItems, currentItem.id, currentItem.startDateOffset);
         if (prevCity && currentItem.type === 'city') {
             const prevEnd = prevCity.startDateOffset + prevCity.duration;
             if (newStart < prevEnd) {

--- a/content/updates/2026-07-02-timeline-resize-clamp.md
+++ b/content/updates/2026-07-02-timeline-resize-clamp.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-07-02-timeline-resize-clamp
+version: v0.127.0
+title: "Timeline resize fix"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Resizing a city stay on the timeline now stops cleanly at the neighboring stay."
+---
+
+## Changes
+- [x] [Fixed] 📏 Dragging a city stay's left edge on the timeline no longer lets it overlap the neighboring stay.
+- [ ] [Internal] Resize-left handler clamped against the first earlier city in array order instead of the adjacent one; extracted a pure `findPreviousCity` neighbor lookup (max end among earlier cities) into `utils/timelineNeighbors.ts` with regression tests.

--- a/tests/unit/timelineNeighbors.test.ts
+++ b/tests/unit/timelineNeighbors.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { findPreviousCity, type TimelineNeighborCandidate } from '../../utils/timelineNeighbors';
+
+const city = (
+  id: string,
+  startDateOffset: number,
+  duration: number,
+  type: TimelineNeighborCandidate['type'] = 'city',
+): TimelineNeighborCandidate => ({ id, type, startDateOffset, duration });
+
+describe('findPreviousCity', () => {
+  // Trip layout: A(0-3), B(3-6), C(6-9)
+  const cityA = city('a', 0, 3);
+  const cityB = city('b', 3, 3);
+  const cityC = city('c', 6, 3);
+  const items = [cityA, cityB, cityC];
+
+  it('returns the adjacent previous city, not the first earlier city in array order', () => {
+    expect(findPreviousCity(items, cityC.id, cityC.startDateOffset)).toBe(cityB);
+  });
+
+  it('regression: pre-fix lookup picked city A, allowing C to overlap B', () => {
+    // The old Timeline resize-left handler used Array.prototype.find, which
+    // returns the FIRST city with a smaller startDateOffset in array order.
+    const buggyPrev = items.find(
+      i => i.type === 'city' && i.startDateOffset < cityC.startDateOffset && i.id !== cityC.id,
+    );
+    expect(buggyPrev).toBe(cityA);
+
+    // Clamping against A's end (3) would let C's left edge move to e.g. 4,
+    // overlapping B (3-6). Clamping against the fixed neighbor's end (6) cannot.
+    const buggyClampFloor = buggyPrev!.startDateOffset + buggyPrev!.duration;
+    const draggedStart = 4; // user drags C's left edge into B's stay
+    expect(Math.max(draggedStart, buggyClampFloor)).toBe(4); // pre-fix: overlap allowed
+
+    const fixedPrev = findPreviousCity(items, cityC.id, cityC.startDateOffset)!;
+    const fixedClampFloor = fixedPrev.startDateOffset + fixedPrev.duration;
+    expect(Math.max(draggedStart, fixedClampFloor)).toBe(6); // post-fix: clamped to B's end
+  });
+
+  it('is independent of array order', () => {
+    const shuffled = [cityC, cityB, cityA];
+    expect(findPreviousCity(shuffled, cityC.id, cityC.startDateOffset)).toBe(cityB);
+  });
+
+  it('picks the earlier city with the latest end when earlier stays overlap', () => {
+    const longA = city('a', 0, 5); // ends at 5, later than B's end at 4
+    const shortB = city('b', 2, 2);
+    expect(findPreviousCity([shortB, longA], 'c', 6)).toBe(longA);
+  });
+
+  it('ignores non-city items and the item being resized', () => {
+    const travel = city('t', 5, 0.5, 'travel');
+    const activity = city('x', 5.5, 0.2, 'activity');
+    expect(findPreviousCity([cityA, travel, activity, cityC], cityC.id, cityC.startDateOffset)).toBe(cityA);
+  });
+
+  it('returns null when there is no earlier city', () => {
+    expect(findPreviousCity(items, cityA.id, cityA.startDateOffset)).toBeNull();
+    expect(findPreviousCity([], 'a', 0)).toBeNull();
+  });
+});

--- a/utils/timelineNeighbors.ts
+++ b/utils/timelineNeighbors.ts
@@ -1,0 +1,39 @@
+import type { ITimelineItem } from '../types';
+
+export type TimelineNeighborCandidate = Pick<
+  ITimelineItem,
+  'id' | 'type' | 'startDateOffset' | 'duration'
+>;
+
+/**
+ * Finds the city that directly precedes the given start offset on the timeline.
+ *
+ * Among all cities that start before `currentStartOffset`, the adjacent
+ * neighbor is the one whose stay ends latest (max `startDateOffset + duration`).
+ * Clamping a left-edge resize against that end guarantees the resized city
+ * cannot overlap ANY earlier city, even if earlier stays already overlap each
+ * other. Picking the first match in array order (the previous behavior) or the
+ * max `startDateOffset` alone would clamp against the wrong stay whenever the
+ * array is not sorted or durations differ.
+ */
+export function findPreviousCity<T extends TimelineNeighborCandidate>(
+  items: readonly T[],
+  currentId: string,
+  currentStartOffset: number,
+): T | null {
+  let neighbor: T | null = null;
+  let neighborEnd = Number.NEGATIVE_INFINITY;
+
+  for (const item of items) {
+    if (item.type !== 'city' || item.id === currentId) continue;
+    if (!(item.startDateOffset < currentStartOffset)) continue;
+
+    const end = item.startDateOffset + item.duration;
+    if (end > neighborEnd) {
+      neighborEnd = end;
+      neighbor = item;
+    }
+  }
+
+  return neighbor;
+}


### PR DESCRIPTION

Fixes #384

## Problem

The resize-left drag handler in `components/Timeline.tsx` looked up the "previous city" with `Array.prototype.find(i => i.type === 'city' && i.startDateOffset < currentItem.startDateOffset && ...)`, which returns the **first** city in array order with a smaller start — typically the trip's first city, not the adjacent one. Resizing the left edge of a later city therefore only clamped against that far-away city's end and could silently overlap the true neighbor (e.g. with A(0–3), B(3–6), C(6–9), C's left edge could be dragged to day 4, overlapping B).

## Changes

- **`utils/timelineNeighbors.ts` (new):** pure `findPreviousCity(items, currentId, currentStartOffset)` helper that picks the earlier city with the **latest end** (`max(startDateOffset + duration)`). Clamping against the max end guarantees the resized stay cannot overlap *any* earlier city, independent of array order or pre-existing overlaps.
- **`components/Timeline.tsx`:** resize-left branch now uses `findPreviousCity` instead of the order-dependent `find`. The resize-right path was audited and does not share the flaw — it shifts later items via `shiftLaterItems` rather than clamping against a next-city lookup, so it is unchanged.
- **`tests/unit/timelineNeighbors.test.ts` (new):** regression tests proving the pre-fix lookup returned city A for the A/B/C layout (allowing C to overlap B) and that the fixed lookup clamps to B's end (6); plus array-order independence, overlapping-earlier-stays, non-city filtering, and no-earlier-city cases.
- **`content/updates/2026-07-02-timeline-resize-clamp.md` (new):** draft release note per `docs/UPDATE_FORMAT.md`.

## Testing

- `vitest run tests/unit/timelineNeighbors.test.ts` — 6/6 passed.
- `pnpm test:core` — passed (313 files / 1392 tests). One run showed 2 failures in `tests/browser/routes/exampleTripLoaderRoute.browser.test.ts`; the file passes in isolation and on the other full run — known flaky browser test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)