### PR TITLE
Fix reconnect loader overwriting newer local edits with stale DB trip

### DIFF
--- a/content/updates/2026-07-02-reconnect-keeps-recent-edits.md
+++ b/content/updates/2026-07-02-reconnect-keeps-recent-edits.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-07-02-reconnect-keeps-recent-edits
+version: v0.0.0
+title: "Reconnect Keeps Your Recent Edits"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: true
+in_app_hours: 24
+summary: "Trips edited offline no longer revert to older server data when your connection comes back."
+---
+
+## Changes
+- [x] [Fixed] 📶 Edits made while offline no longer disappear or briefly revert when your internet connection returns — your latest changes stay in place while they sync.
+- [ ] [Internal] Trip loader reconnect refresh now compares local vs server `updatedAt` and treats pending offline queue entries as local-authoritative before adopting/persisting the server trip (`routes/TripLoaderRoute.tsx`).
+- [ ] [Internal] Added `hasQueuedTripCommit(tripId)` helper to `services/offlineChangeQueue.ts` with unit coverage, plus phase-2 regression tests for stale-server reconnect re-runs in `tests/browser/routes/tripLoaderRoute.browser.test.ts`.

--- a/routes/TripLoaderRoute.tsx
+++ b/routes/TripLoaderRoute.tsx
@@ -12,6 +12,7 @@ import {
     type DbTripAccess,
 } from '../services/dbApi';
 import { findHistoryEntryByUrl } from '../services/historyService';
+import { hasQueuedTripCommit } from '../services/offlineChangeQueue';
 import { getTripById, saveTrip } from '../services/storageService';
 import {
     buildTripUrl,
@@ -299,16 +300,40 @@ export const TripLoaderRoute: React.FC<TripLoaderRouteProps> = ({
                 const dbTrip = await dbGetTrip(tripId);
                 if (dbTrip?.trip) {
                     const normalizedDbTrip = normalizeTripForRouteLoad(dbTrip.trip);
+                    // Compare against the freshest local copy, not only a trip
+                    // resolved earlier in this run. On reconnect re-runs the
+                    // local branches are skipped (connectivity is 'online'),
+                    // so localResolvedTrip is null even though localStorage
+                    // may hold newer edits still queued for offline sync.
+                    const localComparisonTrip = localResolvedTrip
+                        ?? (localTrip ? normalizeTripForRouteLoad(localTrip) : null);
+                    const localUpdatedAt = localComparisonTrip?.updatedAt ?? 0;
+                    const dbUpdatedAt = normalizedDbTrip.updatedAt ?? 0;
+                    const isLocalAuthoritative = Boolean(localComparisonTrip)
+                        && (hasQueuedTripCommit(tripId) || localUpdatedAt > dbUpdatedAt);
+
+                    if (isLocalAuthoritative && localComparisonTrip) {
+                        // Keep the newer local copy: do not overwrite
+                        // localStorage or the UI with the stale server trip.
+                        if (!localResolvedTrip) {
+                            const resolvedLocalView = resolveEffectiveView(
+                                versionedLocalHistoryView ?? localComparisonTrip.defaultView,
+                                localComparisonTrip.defaultView
+                            );
+                            updateRouteState({ viewSettings: resolvedLocalView, tripAccess: dbTrip.access });
+                            onTripLoaded(localComparisonTrip, resolvedLocalView);
+                        } else {
+                            updateRouteState({ tripAccess: dbTrip.access });
+                        }
+                        return;
+                    }
+
                     if (dbTrip.access.source === 'owner') {
                         saveTrip(normalizedDbTrip, { preserveUpdatedAt: true });
                     }
                     const resolvedView = resolveEffectiveView(versionedLocalHistoryView ?? dbTrip.view, normalizedDbTrip.defaultView);
-                    const localUpdatedAt = localResolvedTrip?.updatedAt ?? 0;
-                    const dbUpdatedAt = normalizedDbTrip.updatedAt ?? 0;
-                    if (!localResolvedTrip || dbUpdatedAt >= localUpdatedAt) {
-                        updateRouteState({ viewSettings: resolvedView, tripAccess: dbTrip.access });
-                        onTripLoaded(normalizedDbTrip, resolvedView);
-                    }
+                    updateRouteState({ viewSettings: resolvedView, tripAccess: dbTrip.access });
+                    onTripLoaded(normalizedDbTrip, resolvedView);
                     return;
                 }
             }

--- a/services/offlineChangeQueue.ts
+++ b/services/offlineChangeQueue.ts
@@ -137,6 +137,11 @@ export const getQueueSnapshot = (): OfflineQueueSnapshot => {
   };
 };
 
+export const hasQueuedTripCommit = (tripId: string): boolean => {
+  if (!tripId) return false;
+  return readQueue().some((entry) => entry.tripId === tripId);
+};
+
 export const subscribeOfflineQueue = (listener: QueueListener): (() => void) => {
   listeners.add(listener);
   listener(getQueueSnapshot());

--- a/tests/browser/routes/tripLoaderRoute.browser.test.ts
+++ b/tests/browser/routes/tripLoaderRoute.browser.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   getTripById: vi.fn(),
   saveTrip: vi.fn(),
   findHistoryEntryByUrl: vi.fn(),
+  hasQueuedTripCommit: vi.fn(),
   rememberAuthReturnPath: vi.fn(),
   useDbSync: vi.fn(),
   dbGetTrip: vi.fn(),
@@ -79,6 +80,10 @@ vi.mock('../../../services/historyService', () => ({
   findHistoryEntryByUrl: mocks.findHistoryEntryByUrl,
 }));
 
+vi.mock('../../../services/offlineChangeQueue', () => ({
+  hasQueuedTripCommit: mocks.hasQueuedTripCommit,
+}));
+
 vi.mock('../../../services/authNavigationService', () => ({
   buildPathFromLocationParts: ({ pathname, search, hash }: { pathname: string; search: string; hash: string }) => `${pathname}${search}${hash}`,
   rememberAuthReturnPath: mocks.rememberAuthReturnPath,
@@ -131,6 +136,7 @@ describe('routes/TripLoaderRoute', () => {
     mocks.decompressTrip.mockReturnValue(null);
     mocks.getTripById.mockReturnValue(undefined);
     mocks.findHistoryEntryByUrl.mockReturnValue(null);
+    mocks.hasQueuedTripCommit.mockReturnValue(false);
     mocks.dbGetTripVersion.mockResolvedValue(null);
     mocks.dbGetTrip.mockResolvedValue(null);
     mocks.dbUpdateTripShareViewSettings.mockResolvedValue(true);
@@ -404,6 +410,99 @@ describe('routes/TripLoaderRoute', () => {
     await waitFor(() => {
       expect(props.onTripLoaded).toHaveBeenCalledWith(dbTrip, dbTrip.defaultView);
     });
+  });
+
+  it('keeps newer local edits when a reconnect re-run returns a stale DB trip', async () => {
+    mocks.dbEnabled = true;
+    mocks.route.tripId = 'trip-reconnect-stale';
+    mocks.route.pathname = '/trip/trip-reconnect-stale';
+    const localTrip = makeTrip({ id: 'trip-reconnect-stale', title: 'Newer local copy', updatedAt: 3000 });
+    const dbTrip = makeTrip({ id: 'trip-reconnect-stale', title: 'Stale DB copy', updatedAt: 2000 });
+    mocks.getTripById.mockReturnValue(localTrip);
+    mocks.dbGetTrip.mockResolvedValue({
+      trip: dbTrip,
+      view: dbTrip.defaultView,
+      access: {
+        source: 'owner',
+        ownerId: 'user-1',
+        ownerEmail: 'owner@example.com',
+        ownerUsername: 'owner',
+        canAdminWrite: false,
+        updatedAtIso: null,
+      },
+    });
+
+    mocks.connectivityState = 'offline';
+    const props = makeRouteProps();
+    const view = render(React.createElement(TripLoaderRoute, props));
+
+    await waitFor(() => {
+      expect(props.onTripLoaded).toHaveBeenCalledWith(localTrip, localTrip.defaultView);
+    });
+
+    mocks.connectivityState = 'online';
+    view.rerender(React.createElement(TripLoaderRoute, props));
+
+    await waitFor(() => {
+      expect(mocks.dbGetTrip).toHaveBeenCalledWith('trip-reconnect-stale');
+    });
+
+    // Local copy stays authoritative: the stale server trip must not be
+    // adopted by the UI nor persisted over the newer local edits.
+    const loadedTitles = props.onTripLoaded.mock.calls.map(([trip]: [{ title: string }]) => trip.title);
+    expect(loadedTitles).not.toContain('Stale DB copy');
+    expect(props.onTripLoaded).toHaveBeenLastCalledWith(localTrip, localTrip.defaultView);
+    expect(mocks.saveTrip).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Stale DB copy' }),
+      expect.anything()
+    );
+  });
+
+  it('keeps local trip authoritative on reconnect while offline changes are still queued', async () => {
+    mocks.dbEnabled = true;
+    mocks.route.tripId = 'trip-reconnect-queued';
+    mocks.route.pathname = '/trip/trip-reconnect-queued';
+    // DB timestamp is ahead of local, but queued offline changes for this
+    // trip mean local edits have not replayed yet — local must win.
+    const localTrip = makeTrip({ id: 'trip-reconnect-queued', title: 'Queued local copy', updatedAt: 1000 });
+    const dbTrip = makeTrip({ id: 'trip-reconnect-queued', title: 'Server copy', updatedAt: 2000 });
+    mocks.getTripById.mockReturnValue(localTrip);
+    mocks.hasQueuedTripCommit.mockReturnValue(true);
+    mocks.dbGetTrip.mockResolvedValue({
+      trip: dbTrip,
+      view: dbTrip.defaultView,
+      access: {
+        source: 'owner',
+        ownerId: 'user-1',
+        ownerEmail: 'owner@example.com',
+        ownerUsername: 'owner',
+        canAdminWrite: false,
+        updatedAtIso: null,
+      },
+    });
+
+    mocks.connectivityState = 'offline';
+    const props = makeRouteProps();
+    const view = render(React.createElement(TripLoaderRoute, props));
+
+    await waitFor(() => {
+      expect(props.onTripLoaded).toHaveBeenCalledWith(localTrip, localTrip.defaultView);
+    });
+
+    mocks.connectivityState = 'online';
+    view.rerender(React.createElement(TripLoaderRoute, props));
+
+    await waitFor(() => {
+      expect(mocks.dbGetTrip).toHaveBeenCalledWith('trip-reconnect-queued');
+    });
+
+    expect(mocks.hasQueuedTripCommit).toHaveBeenCalledWith('trip-reconnect-queued');
+    const loadedTitles = props.onTripLoaded.mock.calls.map(([trip]: [{ title: string }]) => trip.title);
+    expect(loadedTitles).not.toContain('Server copy');
+    expect(mocks.saveTrip).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Server copy' }),
+      expect.anything()
+    );
   });
 
   it('preserves in-session view settings during reconnect refreshes', async () => {

--- a/tests/unit/offlineChangeQueue.test.ts
+++ b/tests/unit/offlineChangeQueue.test.ts
@@ -8,6 +8,7 @@ import {
   getConflictBackups,
   getLatestConflictBackupForTrip,
   getQueueSnapshot,
+  hasQueuedTripCommit,
   removeQueuedTripCommit,
   storeConflictBackup,
   updateQueuedTripCommit,
@@ -62,6 +63,25 @@ describe('services/offlineChangeQueue', () => {
 
     removeQueuedTripCommit(queued.id);
     expect(getQueueSnapshot().pendingCount).toBe(0);
+  });
+
+  it('reports queued commits per trip id', () => {
+    const trip = makeTrip({ id: 'trip-3', title: 'Pending trip' });
+
+    expect(hasQueuedTripCommit('trip-3')).toBe(false);
+    expect(hasQueuedTripCommit('')).toBe(false);
+
+    enqueueTripCommit({
+      tripId: trip.id,
+      tripSnapshot: trip,
+      label: 'Data: Updated trip',
+    });
+
+    expect(hasQueuedTripCommit('trip-3')).toBe(true);
+    expect(hasQueuedTripCommit('other-trip')).toBe(false);
+
+    clearOfflineQueue();
+    expect(hasQueuedTripCommit('trip-3')).toBe(false);
   });
 
   it('stores server conflict backups and resolves latest per trip', () => {


### PR DESCRIPTION

Fixes #385

## Problem

An offline → online transition re-runs the trip-load effect in `routes/TripLoaderRoute.tsx` (the load key includes the connectivity state). On that re-run the local-trip resolution branch is skipped (it only runs when connectivity is not `online`), so the DB branch unconditionally called `saveTrip(normalizedDbTrip)` and `onTripLoaded(normalizedDbTrip)` — adopting and persisting the stale server copy even when localStorage held newer edits still queued in the offline change queue. The UI and localStorage reverted to stale server state; edits made on top of that state could permanently beat the queued offline edits.

## Fix

- `routes/TripLoaderRoute.tsx`: before adopting/persisting the DB trip, compare the freshest local copy's `updatedAt` against the server trip (mirroring the existing pattern in the version-load branch), and treat pending offline queue entries for the trip as local-authoritative. When local wins, keep the local trip and do not overwrite localStorage; trip access from the DB response is still applied. When the server copy is newer or equal (and nothing is queued), the previous refresh behavior is unchanged.
- `services/offlineChangeQueue.ts`: new `hasQueuedTripCommit(tripId)` helper.

## Tests (phase-2 regression coverage per `docs/TESTING_PHASE2_SCOPE.md`)

- `tests/browser/routes/tripLoaderRoute.browser.test.ts`:
  - New: reconnect re-run with DB trip older than local → local wins, stale server copy neither loaded nor saved.
  - New: reconnect re-run with queued offline changes for the trip (even with server `updatedAt` ahead) → local stays authoritative.
  - Existing: reconnect with newer DB data → DB copy still wins (behavior preserved).
- `tests/unit/offlineChangeQueue.test.ts`: unit coverage for `hasQueuedTripCommit`.

## Release note

- `content/updates/2026-07-02-reconnect-keeps-recent-edits.md` (status: draft).

## Verification

- Targeted: `vitest run tests/browser/routes/tripLoaderRoute.browser.test.ts tests/unit/offlineChangeQueue.test.ts` — 22/22 passed.
- `pnpm test:core` — green (312 files, 1391 passed / 1 skipped). Two earlier runs showed known-flaky browser test timeouts in unrelated admin/checkout suites; a rerun confirmed all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)