### PR TITLE
Fix offline sync replay silently overwriting newer server trips

### DIFF
--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -1809,6 +1809,13 @@ const useTripViewRender = ({
                 });
                 return;
             }
+            if (detail.type === 'sync_conflict_preserved') {
+                showToast(t('connectivity.toast.conflictPreserved'), {
+                    tone: 'neutral',
+                    title: t('connectivity.toast.title'),
+                });
+                return;
+            }
             if (detail.type === 'sync_partial_failure') {
                 const messageKey = detail.failedCount === 1
                     ? 'connectivity.toast.syncPartialFailureOne'

--- a/content/updates/2026-07-02-offline-sync-conflict-protection.md
+++ b/content/updates/2026-07-02-offline-sync-conflict-protection.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-07-02-offline-sync-conflict-protection
+version: v0.127.0
+title: "Offline sync conflict protection"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: true
+in_app_hours: 24
+summary: "Edits made on another device are no longer overwritten when offline changes sync back."
+---
+
+## Changes
+- [x] [Fixed] 🔀 Edits made on another device are no longer silently overwritten when your offline changes sync back — the newer version wins and your offline copy is kept as a backup.
+- [ ] [Internal] Offline replay now skips the remote upsert on conflict, emits a `sync_conflict_preserved` toast event, and guards the local re-save behind an `updatedAt` freshness check.

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -255,6 +255,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "Der Server hatte neuere Änderungen für diese Reise. Deine Offline-Version wurde als Backup behalten.",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -255,6 +255,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "The server had newer changes for this trip. Your offline version was kept as a backup.",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -255,6 +255,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "El servidor tenía cambios más recientes para este viaje. Tu versión sin conexión se guardó como copia de seguridad.",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/locales/fa/common.json
+++ b/locales/fa/common.json
@@ -126,6 +126,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "سرور تغییرات جدیدتری برای این سفر داشت. نسخه آفلاین شما به‌عنوان پشتیبان نگه داشته شد.",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -255,6 +255,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "Le serveur contenait des modifications plus récentes pour ce voyage. Votre version hors ligne a été conservée comme sauvegarde.",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -255,6 +255,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "Il server aveva modifiche più recenti per questo viaggio. La tua versione offline è stata conservata come backup.",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -255,6 +255,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "서버에 이 여행의 더 최신 변경 사항이 있었습니다. 오프라인 버전은 백업으로 보관되었습니다.",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -253,6 +253,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "Serwer miał nowsze zmiany dla tej podróży. Twoja wersja offline została zachowana jako kopia zapasowa.",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -255,6 +255,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "O servidor tinha alterações mais recentes para esta viagem. Sua versão offline foi mantida como backup.",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -255,6 +255,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "На сервере были более новые изменения для этой поездки. Ваша офлайн-версия сохранена как резервная копия.",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/locales/ur/common.json
+++ b/locales/ur/common.json
@@ -126,6 +126,7 @@
       "title": "Sync status",
       "syncCompleted": "Queued trip changes synced successfully.",
       "serverBackupRestored": "Server backup restored for this trip.",
+      "conflictPreserved": "سرور پر اس سفر کے لیے نئی تبدیلیاں موجود تھیں۔ آپ کا آف لائن ورژن بیک اپ کے طور پر محفوظ رکھا گیا۔",
       "syncStartedOne": "Reconnect detected. Replaying {count} queued change.",
       "syncStartedMany": "Reconnect detected. Replaying {count} queued changes.",
       "syncPartialFailureOne": "{count} queued change still failed. You can retry.",

--- a/services/tripSyncManager.ts
+++ b/services/tripSyncManager.ts
@@ -18,7 +18,7 @@ import {
   type ConnectivityState,
 } from './supabaseHealthMonitor';
 import { syncTripsFromDb } from './dbService';
-import { saveTrip } from './storageService';
+import { getTripById, saveTrip } from './storageService';
 
 export const TRIP_SYNC_STATUS_EVENT = 'tf:trip-sync-status';
 export const TRIP_SYNC_TOAST_EVENT = 'tf:trip-sync-toast';
@@ -46,9 +46,10 @@ export interface SyncRunSnapshot {
 }
 
 export interface SyncToastEventDetail {
-  type: 'sync_started' | 'sync_completed' | 'sync_partial_failure';
+  type: 'sync_started' | 'sync_completed' | 'sync_partial_failure' | 'sync_conflict_preserved';
   pendingCount: number;
   failedCount: number;
+  tripId?: string;
 }
 
 type SyncListener = (snapshot: SyncRunSnapshot) => void;
@@ -198,7 +199,20 @@ const isServerTripNewerThanQueued = (serverUpdatedAt: number | undefined, queued
   return serverTs !== null && queuedTs !== null && serverTs > queuedTs;
 };
 
-const replaySingleEntryOnce = async (entry: OfflineTripQueueEntry): Promise<void> => {
+const isQueuedSnapshotStillLatestLocally = (entry: OfflineTripQueueEntry): boolean => {
+  const localTrip = getTripById(entry.tripId);
+  if (!localTrip) return true;
+  const localUpdatedAt = typeof localTrip.updatedAt === 'number' && Number.isFinite(localTrip.updatedAt)
+    ? localTrip.updatedAt
+    : null;
+  const snapshotUpdatedAt = typeof entry.tripSnapshot.updatedAt === 'number' && Number.isFinite(entry.tripSnapshot.updatedAt)
+    ? entry.tripSnapshot.updatedAt
+    : null;
+  if (localUpdatedAt === null || snapshotUpdatedAt === null) return true;
+  return localUpdatedAt <= snapshotUpdatedAt;
+};
+
+const replaySingleEntryOnce = async (entry: OfflineTripQueueEntry): Promise<'applied' | 'conflict'> => {
   const connectivityState = getConnectivitySnapshot().state;
   if (connectivityState !== 'online') {
     throw new Error(`Connectivity is ${connectivityState}`);
@@ -211,12 +225,17 @@ const replaySingleEntryOnce = async (entry: OfflineTripQueueEntry): Promise<void
 
   const serverTrip = await dbGetTrip(entry.tripId);
   if (serverTrip?.trip && isServerTripNewerThanQueued(serverTrip.trip.updatedAt, entry.tripSnapshot.updatedAt)) {
+    // Concurrent edit detected: the server copy is newer than the queued
+    // offline snapshot (edited from another device/tab). Never overwrite the
+    // newer server state with the stale snapshot — keep the queued version as
+    // a conflict backup and surface the conflict instead.
     storeConflictBackup({
       queueEntryId: entry.id,
       tripId: entry.tripId,
       serverTripSnapshot: serverTrip.trip,
       queuedTripSnapshot: entry.tripSnapshot,
     });
+    return 'conflict';
   }
 
   const upsertResult = await dbUpsertTripWithStatus(entry.tripSnapshot, entry.viewSnapshot ?? undefined);
@@ -240,7 +259,13 @@ const replaySingleEntryOnce = async (entry: OfflineTripQueueEntry): Promise<void
     throw new Error('Trip version creation failed during replay');
   }
 
-  saveTrip(entry.tripSnapshot, { preserveUpdatedAt: true });
+  // Only re-persist the queued snapshot locally when it is still the latest
+  // local state. If the user kept editing after the snapshot was enqueued,
+  // re-saving it here would revert those newer local edits on reload.
+  if (isQueuedSnapshotStillLatestLocally(entry)) {
+    saveTrip(entry.tripSnapshot, { preserveUpdatedAt: true });
+  }
+  return 'applied';
 };
 
 const replaySingleEntryWithRetries = async (entry: OfflineTripQueueEntry): Promise<{ success: boolean; attemptsUsed: number; lastError: string | null }> => {
@@ -249,9 +274,18 @@ const replaySingleEntryWithRetries = async (entry: OfflineTripQueueEntry): Promi
 
   while (attemptCount < MAX_REPLAY_ATTEMPTS) {
     try {
-      await replaySingleEntryOnce(entry);
+      const outcome = await replaySingleEntryOnce(entry);
       markConnectivitySuccess('sync_replay_success');
       removeQueuedTripCommit(entry.id);
+      if (outcome === 'conflict') {
+        const queueSnapshot = getQueueSnapshot();
+        emitToastEvent({
+          type: 'sync_conflict_preserved',
+          pendingCount: queueSnapshot.pendingCount,
+          failedCount: queueSnapshot.failedCount,
+          tripId: entry.tripId,
+        });
+      }
       return {
         success: true,
         attemptsUsed: attemptCount + 1,

--- a/tests/unit/tripSyncManager.test.ts
+++ b/tests/unit/tripSyncManager.test.ts
@@ -57,7 +57,13 @@ import {
   getQueueSnapshot,
   updateQueuedTripCommit,
 } from '../../services/offlineChangeQueue';
-import { retrySyncNow, syncQueuedTripsNow } from '../../services/tripSyncManager';
+import { getTripById, saveTrip } from '../../services/storageService';
+import {
+  retrySyncNow,
+  syncQueuedTripsNow,
+  TRIP_SYNC_TOAST_EVENT,
+  type SyncToastEventDetail,
+} from '../../services/tripSyncManager';
 
 describe('services/tripSyncManager', () => {
   beforeEach(() => {
@@ -123,7 +129,7 @@ describe('services/tripSyncManager', () => {
     expect(getQueueSnapshot().pendingCount).toBe(1);
   });
 
-  it('captures server backup and still applies queued client snapshot during sync', async () => {
+  it('does not overwrite a newer server trip, keeps the backup, and emits a conflict signal', async () => {
     const clientTrip = makeTrip({ id: 'trip-conflict', title: 'Client title', updatedAt: 1_000 });
     const serverTrip = makeTrip({ id: 'trip-conflict', title: 'Server title', updatedAt: 2_000 });
 
@@ -141,10 +147,21 @@ describe('services/tripSyncManager', () => {
       access: null,
     });
 
-    await syncQueuedTripsNow();
+    const toastEvents: SyncToastEventDetail[] = [];
+    const captureToast = (event: Event) => {
+      const detail = (event as CustomEvent<SyncToastEventDetail>).detail;
+      if (detail) toastEvents.push(detail);
+    };
+    window.addEventListener(TRIP_SYNC_TOAST_EVENT, captureToast);
 
-    expect(mockState.dbUpsertTripWithStatus).toHaveBeenCalledTimes(1);
-    expect(mockState.dbUpsertTripWithStatus).toHaveBeenCalledWith(clientTrip, undefined);
+    try {
+      await syncQueuedTripsNow();
+    } finally {
+      window.removeEventListener(TRIP_SYNC_TOAST_EVENT, captureToast);
+    }
+
+    expect(mockState.dbUpsertTripWithStatus).not.toHaveBeenCalled();
+    expect(mockState.dbCreateTripVersion).not.toHaveBeenCalled();
     expect(getQueueSnapshot().pendingCount).toBe(0);
 
     const backups = getConflictBackups();
@@ -152,6 +169,67 @@ describe('services/tripSyncManager', () => {
     expect(backups[0].tripId).toBe(clientTrip.id);
     expect(backups[0].serverTripSnapshot.title).toBe('Server title');
     expect(backups[0].queuedTripSnapshot.title).toBe('Client title');
+
+    const conflictSignals = toastEvents.filter((detail) => detail.type === 'sync_conflict_preserved');
+    expect(conflictSignals.length).toBe(1);
+    expect(conflictSignals[0].tripId).toBe('trip-conflict');
+  });
+
+  it('does not revert local storage to the queued snapshot when the user edited after enqueue', async () => {
+    const queuedSnapshot = makeTrip({ id: 'trip-local-newer', title: 'Queued title', updatedAt: 1_000 });
+    const newerLocalTrip = makeTrip({ id: 'trip-local-newer', title: 'Newer local title', updatedAt: 5_000 });
+
+    enqueueTripCommit({
+      tripId: queuedSnapshot.id,
+      tripSnapshot: queuedSnapshot,
+      label: 'Data: Offline edit',
+      queuedAt: 100,
+    });
+
+    saveTrip(newerLocalTrip, { preserveUpdatedAt: true });
+
+    mockState.connectivityState = 'online';
+    await syncQueuedTripsNow();
+
+    expect(mockState.dbUpsertTripWithStatus).toHaveBeenCalledTimes(1);
+    expect(getQueueSnapshot().pendingCount).toBe(0);
+
+    const localTrip = getTripById('trip-local-newer');
+    expect(localTrip?.title).toBe('Newer local title');
+    expect(localTrip?.updatedAt).toBe(5_000);
+  });
+
+  it('replays a non-conflicting entry normally and re-persists the snapshot locally', async () => {
+    const queuedSnapshot = makeTrip({ id: 'trip-normal', title: 'Queued title', updatedAt: 3_000 });
+    const olderServerTrip = makeTrip({ id: 'trip-normal', title: 'Older server title', updatedAt: 1_000 });
+
+    enqueueTripCommit({
+      tripId: queuedSnapshot.id,
+      tripSnapshot: queuedSnapshot,
+      label: 'Data: Offline edit',
+      queuedAt: 100,
+    });
+
+    saveTrip(queuedSnapshot, { preserveUpdatedAt: true });
+
+    mockState.connectivityState = 'online';
+    mockState.dbGetTrip.mockResolvedValue({
+      trip: olderServerTrip,
+      view: olderServerTrip.defaultView,
+      access: null,
+    });
+
+    await syncQueuedTripsNow();
+
+    expect(mockState.dbUpsertTripWithStatus).toHaveBeenCalledTimes(1);
+    expect(mockState.dbUpsertTripWithStatus).toHaveBeenCalledWith(queuedSnapshot, undefined);
+    expect(mockState.dbCreateTripVersion).toHaveBeenCalledTimes(1);
+    expect(getQueueSnapshot().pendingCount).toBe(0);
+    expect(getConflictBackups().length).toBe(0);
+
+    const localTrip = getTripById('trip-normal');
+    expect(localTrip?.title).toBe('Queued title');
+    expect(localTrip?.updatedAt).toBe(3_000);
   });
 
   it('retries failed entries that previously reached max attempts when retried manually', async () => {


### PR DESCRIPTION

Fixes #386

## Problem

`replaySingleEntryOnce` in `services/tripSyncManager.ts` detected a conflict when the server trip was newer than the queued offline snapshot (concurrent edit from another device/tab), stored a hidden localStorage backup — and then upserted the stale snapshot over the server row anyway. Silent last-write-wins: the other device's edits were destroyed on the server with no user-visible signal. Additionally, after every successful replay, `saveTrip(entry.tripSnapshot, { preserveUpdatedAt: true })` unconditionally rewrote local storage with the queued snapshot, reverting (on reload) any edits the user made after the snapshot was enqueued.

## Changes

- **`services/tripSyncManager.ts`:**
  - `replaySingleEntryOnce` now returns `'applied' | 'conflict'`. On a detected conflict (server `updatedAt` newer than the queued snapshot's) it stores the conflict backup as before and **returns early — the stale snapshot is never upserted over the newer server copy** and no redundant trip version is created.
  - Conflict entries are resolved (removed from the queue, counted as processed, `markConnectivitySuccess` still recorded) and a new `sync_conflict_preserved` toast event is emitted via the existing `TRIP_SYNC_TOAST_EVENT` channel, carrying the `tripId`.
  - The post-replay local re-save is now guarded by `isQueuedSnapshotStillLatestLocally`: the snapshot is only re-persisted when the local trip's `updatedAt` is not newer than the snapshot's, so edits made after enqueue survive a reload.
  - `SyncToastEventDetail` gains the `sync_conflict_preserved` type and an optional `tripId`.
- **`components/TripView.tsx`:** the existing sync-toast handler shows a neutral toast for `sync_conflict_preserved` ("The server had newer changes for this trip. Your offline version was kept as a backup."). The existing connectivity trip-strip conflict-backup affordance (`hasConflictBackups` → `getLatestConflictBackupForTrip` banner) continues to surface the backup after the run.
- **`locales/*/common.json` (all 11 active locales):** new `connectivity.toast.conflictPreserved` key.
- **`tests/unit/tripSyncManager.test.ts`:** regression tests: (a) server newer → `dbUpsertTripWithStatus`/`dbCreateTripVersion` NOT called, backup retained, queue drained, one `sync_conflict_preserved` event emitted with the trip id; (b) local edited after enqueue → local storage keeps the newer title/`updatedAt`; (c) normal replay (server older) → upsert + version + local re-save unchanged.
- **`content/updates/2026-07-02-offline-sync-conflict-protection.md` (new, `status: draft`):** release note per `docs/UPDATE_FORMAT.md`.

## Behavior notes / follow-ups

- On conflict the server copy now wins everywhere: the queue entry is resolved without pushing, and the end-of-run `syncTripsFromDb()` pulls the server state down. The offline version remains recoverable in the conflict-backup store (`travelflow_sync_conflict_backups_v1`, both server and queued snapshots retained).
- Follow-up (not in this PR): a dedicated "restore my offline version" action. The existing trip-strip restore action restores the *server* snapshot from the backup — still correct, but now redundant since the server copy is no longer overwritten; the more valuable direction is restoring/merging the preserved `queuedTripSnapshot`. The banner copy (`connectivity.tripStrip.serverBackup`) could also be refreshed to match the new semantics.

## Testing

- `vitest run tests/unit/tripSyncManager.test.ts tests/unit/offlineChangeQueue.test.ts` — 11/11 passed.
- `pnpm i18n:validate` — 11 locales, 12 namespaces validated.
- `pnpm toasts:validate` — passed.
- `pnpm updates:validate` — passed (pre-existing canonical-version warning only).
- `pnpm test:core` — passed (see PR checks note in report for the known flaky browser test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)