### PR TITLE
Flush pending debounced trip commit on unmount and pagehide

### DIFF
--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -63,6 +63,7 @@ import { buildQueuedTripGenerationRetryToastOptions } from './tripview/tripGener
 import { useTripItemMutationHandlers } from './tripview/useTripItemMutationHandlers';
 import { useTripItemUpdateHandlers } from './tripview/useTripItemUpdateHandlers';
 import { useTripLiveUpdate, type PendingTripCommitState } from './tripview/useTripLiveUpdate';
+import { useTripCommitFlush } from './tripview/useTripCommitFlush';
 import { useTripRouteStatusState } from './tripview/useTripRouteStatusState';
 import { useTripResizeControls } from './tripview/useTripResizeControls';
 import { useTripShareActions } from './tripview/useTripShareActions';
@@ -2452,6 +2453,23 @@ const useTripViewRender = ({
         showSavedToastForLabel,
         trip,
     ]);
+
+    const commitPendingNow = useCallback((payload: PendingTripCommitState, label: string) => {
+        if (!onCommitState) return;
+        debugHistory('Flushing pending commit', { label });
+        onCommitState(payload.trip, payload.view, {
+            replace: false,
+            label,
+            adminOverride: isAdminFallbackView && adminOverrideEnabled,
+        });
+    }, [adminOverrideEnabled, debugHistory, isAdminFallbackView, onCommitState]);
+
+    useTripCommitFlush({
+        commitTimerRef,
+        pendingCommitRef,
+        pendingHistoryLabelRef,
+        commitNow: commitPendingNow,
+    });
 
     useEffect(() => {
         const prev = prevViewRef.current;

--- a/components/tripview/useTripCommitFlush.ts
+++ b/components/tripview/useTripCommitFlush.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
+
+import { enqueueTripCommit } from '../../services/offlineChangeQueue';
+import type { PendingTripCommitState } from './useTripLiveUpdate';
+
+export type PendingCommitFlushReason = 'unmount' | 'pagehide';
+
+interface UseTripCommitFlushOptions {
+    commitTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
+    pendingCommitRef: MutableRefObject<PendingTripCommitState | null>;
+    pendingHistoryLabelRef: MutableRefObject<string | null>;
+    /**
+     * Runs the regular commit path (`onCommitState`) for a flushed payload.
+     * Used when the page keeps running (SPA unmount/navigation).
+     */
+    commitNow: (payload: PendingTripCommitState, label: string) => void;
+}
+
+/**
+ * Guarantees a debounced trip commit scheduled by `scheduleCommit` cannot be
+ * lost when the component unmounts or the page is torn down mid-debounce.
+ *
+ * - `unmount` (SPA navigation, page stays alive): the pending payload is
+ *   committed immediately through the normal `onCommitState` path, which owns
+ *   history entries and resilient offline fallback.
+ * - `pagehide` / `visibilitychange -> hidden` (tab close, navigation away,
+ *   mobile backgrounding): async work started here can be silently killed by
+ *   the browser, so the payload is persisted synchronously to the offline
+ *   change queue (localStorage). `tripSyncManager` replays it right away if
+ *   the page survives (bfcache restore, tab switch) or on the next load if it
+ *   does not — including the version-history entry with the original label.
+ */
+export const useTripCommitFlush = ({
+    commitTimerRef,
+    pendingCommitRef,
+    pendingHistoryLabelRef,
+    commitNow,
+}: UseTripCommitFlushOptions) => {
+    const flushPendingCommit = useCallback((reason: PendingCommitFlushReason) => {
+        const payload = pendingCommitRef.current;
+        if (!payload) return;
+
+        if (commitTimerRef.current) {
+            clearTimeout(commitTimerRef.current);
+            commitTimerRef.current = null;
+        }
+        pendingCommitRef.current = null;
+        const label = pendingHistoryLabelRef.current || 'Data: Updated trip';
+        pendingHistoryLabelRef.current = null;
+
+        if (reason === 'pagehide') {
+            // Synchronous localStorage write survives page teardown; a fetch
+            // issued from a pagehide handler is not guaranteed to complete.
+            enqueueTripCommit({
+                tripId: payload.trip.id,
+                tripSnapshot: payload.trip,
+                viewSnapshot: payload.view ?? null,
+                label,
+            });
+            return;
+        }
+
+        commitNow(payload, label);
+    }, [commitNow, commitTimerRef, pendingCommitRef, pendingHistoryLabelRef]);
+
+    // Latch the newest flush implementation so the listener effect can stay
+    // mounted for the component's whole lifetime. Re-running the effect on
+    // every `commitNow` identity change would flush pending commits early via
+    // its cleanup, breaking debounce semantics mid-session.
+    const flushRef = useRef(flushPendingCommit);
+    useEffect(() => {
+        flushRef.current = flushPendingCommit;
+    }, [flushPendingCommit]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return undefined;
+
+        const handlePageHide = () => flushRef.current('pagehide');
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'hidden') flushRef.current('pagehide');
+        };
+
+        window.addEventListener('pagehide', handlePageHide);
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        return () => {
+            window.removeEventListener('pagehide', handlePageHide);
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
+            flushRef.current('unmount');
+        };
+    }, []);
+
+    return { flushPendingCommit };
+};

--- a/content/updates/2026-07-02-flush-pending-commit.md
+++ b/content/updates/2026-07-02-flush-pending-commit.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-07-02-flush-pending-commit
+version: v0.0.0
+title: "Reliable saving when leaving the page"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Your very last edit is no longer lost when you close the tab right after making it."
+---
+
+## Changes
+- [x] [Fixed] 💾 Your last edit is no longer lost when you close the tab or leave the page right after making it — it now syncs to your other devices and appears in the trip history.
+- [ ] [Internal] Added `useTripCommitFlush` hook: flushes the debounced trip commit via `onCommitState` on TripView unmount and persists it synchronously to the offline change queue on `pagehide`/`visibilitychange -> hidden` for replay by `tripSyncManager`.
+- [ ] [Internal] Added jsdom regression tests covering flush-on-unmount (exactly one commit), pagehide/hidden persistence, no-pending no-op, and listener cleanup.

--- a/tests/browser/tripview/useTripCommitFlush.browser.test.ts
+++ b/tests/browser/tripview/useTripCommitFlush.browser.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { MutableRefObject } from 'react';
+
+import { useTripCommitFlush } from '../../../components/tripview/useTripCommitFlush';
+import type { PendingTripCommitState } from '../../../components/tripview/useTripLiveUpdate';
+import type { IViewSettings } from '../../../types';
+import { makeTrip } from '../../helpers/tripFixtures';
+
+const { enqueueTripCommitMock } = vi.hoisted(() => ({
+  enqueueTripCommitMock: vi.fn(),
+}));
+
+vi.mock('../../../services/offlineChangeQueue', () => ({
+  enqueueTripCommit: enqueueTripCommitMock,
+}));
+
+const VIEW_SETTINGS: IViewSettings = {
+  layoutMode: 'vertical',
+  timelineView: 'horizontal',
+  mapStyle: 'standard',
+  zoomLevel: 1,
+};
+
+interface HarnessRefs {
+  commitTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
+  pendingCommitRef: MutableRefObject<PendingTripCommitState | null>;
+  pendingHistoryLabelRef: MutableRefObject<string | null>;
+}
+
+const makeRefs = (): HarnessRefs => ({
+  commitTimerRef: { current: null },
+  pendingCommitRef: { current: null },
+  pendingHistoryLabelRef: { current: null },
+});
+
+const setVisibilityState = (value: DocumentVisibilityState) => {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => value,
+  });
+};
+
+describe('components/tripview/useTripCommitFlush', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    enqueueTripCommitMock.mockClear();
+    setVisibilityState('visible');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flushes a pending commit exactly once through commitNow on unmount', () => {
+    const refs = makeRefs();
+    const commitNow = vi.fn();
+    const debouncedCommit = vi.fn();
+    const trip = makeTrip({ id: 'trip-flush-1' });
+
+    const { unmount } = renderHook(() => useTripCommitFlush({ ...refs, commitNow }));
+
+    refs.pendingCommitRef.current = { trip, view: VIEW_SETTINGS };
+    refs.pendingHistoryLabelRef.current = 'Data: Renamed activity';
+    refs.commitTimerRef.current = setTimeout(debouncedCommit, 700);
+
+    unmount();
+
+    expect(commitNow).toHaveBeenCalledTimes(1);
+    expect(commitNow).toHaveBeenCalledWith(
+      { trip, view: VIEW_SETTINGS },
+      'Data: Renamed activity',
+    );
+    expect(refs.pendingCommitRef.current).toBeNull();
+    expect(refs.pendingHistoryLabelRef.current).toBeNull();
+    expect(refs.commitTimerRef.current).toBeNull();
+
+    // The debounce timer was cancelled, so the regular path cannot fire a second commit.
+    vi.runAllTimers();
+    expect(debouncedCommit).not.toHaveBeenCalled();
+    expect(commitNow).toHaveBeenCalledTimes(1);
+    expect(enqueueTripCommitMock).not.toHaveBeenCalled();
+  });
+
+  it('persists a pending commit synchronously to the offline queue on pagehide', () => {
+    const refs = makeRefs();
+    const commitNow = vi.fn();
+    const debouncedCommit = vi.fn();
+    const trip = makeTrip({ id: 'trip-flush-2' });
+
+    const { unmount } = renderHook(() => useTripCommitFlush({ ...refs, commitNow }));
+
+    refs.pendingCommitRef.current = { trip, view: VIEW_SETTINGS };
+    refs.pendingHistoryLabelRef.current = 'Visual: Moved map';
+    refs.commitTimerRef.current = setTimeout(debouncedCommit, 700);
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(enqueueTripCommitMock).toHaveBeenCalledTimes(1);
+    expect(enqueueTripCommitMock).toHaveBeenCalledWith({
+      tripId: 'trip-flush-2',
+      tripSnapshot: trip,
+      viewSnapshot: VIEW_SETTINGS,
+      label: 'Visual: Moved map',
+    });
+    expect(commitNow).not.toHaveBeenCalled();
+    expect(refs.pendingCommitRef.current).toBeNull();
+
+    vi.runAllTimers();
+    expect(debouncedCommit).not.toHaveBeenCalled();
+
+    // A later unmount finds nothing pending — no double commit.
+    unmount();
+    expect(commitNow).not.toHaveBeenCalled();
+    expect(enqueueTripCommitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists a pending commit when the document becomes hidden', () => {
+    const refs = makeRefs();
+    const commitNow = vi.fn();
+    const trip = makeTrip({ id: 'trip-flush-3' });
+
+    renderHook(() => useTripCommitFlush({ ...refs, commitNow }));
+
+    refs.pendingCommitRef.current = { trip, view: VIEW_SETTINGS };
+
+    setVisibilityState('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(enqueueTripCommitMock).toHaveBeenCalledTimes(1);
+    expect(enqueueTripCommitMock).toHaveBeenCalledWith({
+      tripId: 'trip-flush-3',
+      tripSnapshot: trip,
+      viewSnapshot: VIEW_SETTINGS,
+      label: 'Data: Updated trip',
+    });
+    expect(commitNow).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on pagehide, visibility change, or unmount without a pending commit', () => {
+    const refs = makeRefs();
+    const commitNow = vi.fn();
+
+    const { unmount } = renderHook(() => useTripCommitFlush({ ...refs, commitNow }));
+
+    window.dispatchEvent(new Event('pagehide'));
+    setVisibilityState('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+    unmount();
+
+    expect(commitNow).not.toHaveBeenCalled();
+    expect(enqueueTripCommitMock).not.toHaveBeenCalled();
+  });
+
+  it('removes its listeners on unmount', () => {
+    const refs = makeRefs();
+    const commitNow = vi.fn();
+    const trip = makeTrip({ id: 'trip-flush-4' });
+
+    const { unmount } = renderHook(() => useTripCommitFlush({ ...refs, commitNow }));
+    unmount();
+
+    // Pending state created after unmount must not be picked up by stale listeners.
+    refs.pendingCommitRef.current = { trip, view: VIEW_SETTINGS };
+    window.dispatchEvent(new Event('pagehide'));
+    setVisibilityState('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(enqueueTripCommitMock).not.toHaveBeenCalled();
+    expect(commitNow).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION

Fixes #387

## Problem

`scheduleCommit` in `components/TripView.tsx` debounces the DB commit (upsert + version-history entry via `App.tsx` `handleCommitState`) by 150–700 ms using `pendingCommitRef` + a `setTimeout`. There was no unmount cleanup and no page-teardown flush, so an edit made within the debounce window before closing the tab or navigating away never reached the DB or version history. Local storage saves immediately, which masked the loss on the same device while other devices silently missed the edit.

## Fix

New `components/tripview/useTripCommitFlush.ts`, wired into `TripView` next to `scheduleCommit`:

- **Unmount** (SPA navigation; page keeps running): cancels the debounce timer and flushes the pending payload through the regular `onCommitState` path, which owns local history entries, dedup fingerprinting, and the resilient commit with offline fallback. Exactly one commit fires.
- **`pagehide` + `visibilitychange` → `hidden`** (tab close, hard navigation, mobile backgrounding): a fetch started from these handlers is not guaranteed to complete, so the payload is persisted **synchronously** to the offline change queue (`enqueueTripCommit`, a localStorage write that survives teardown). The existing `tripSyncManager` replays it immediately if the page survives (its queue subscription triggers a sync) or on the next load otherwise — creating the DB upsert **and** the version-history entry with the original pending label, with server-newer conflict backups already handled by the replay path.

### Design decisions

- Chose the offline change queue over firing `onCommitState` during `pagehide` because the async Supabase calls it triggers can be silently killed mid-teardown, and its own failure-fallback enqueue would never run in that case. The queue write is synchronous and the replay path is existing, tested infrastructure.
- `visibilitychange → hidden` routes through the same persist path (not the normal commit) so that on a real tab close — where `hidden` fires *before* `pagehide` — the flush is still synchronous; it also covers mobile tabs killed in the background without a `pagehide`. Trade-off: a tab switch inside the 150–700 ms debounce window commits via queue replay (no saved-toast, which would be invisible anyway in a hidden tab).
- Effect hygiene per CLAUDE.md: the listener effect mounts once and its cleanup removes both listeners and performs the unmount flush; the latest flush implementation is latched in a ref so callback identity changes (e.g. `onCommitState`, admin-override state) cannot re-run the effect and flush early mid-session.

## Tests

- New `tests/browser/tripview/useTripCommitFlush.browser.test.ts` (5 tests):
  - pending commit + unmount → `commitNow` fired exactly once with payload + pending label; timer cancelled; refs cleared; debounced callback never fires
  - pending commit + `pagehide` → persisted to offline queue exactly once; later unmount does not double-commit
  - pending commit + `visibilitychange` to hidden → persisted
  - no pending → pagehide/hidden/unmount are no-ops
  - listeners removed on unmount (no stale flushes)
- `pnpm test:core`: 1392 passed / 1 failed — the known flaky `tests/browser/admin/adminAiWorkerHealthPage.browser.test.ts` pagination test; passes on isolated rerun. No other failures.
- `tsc --noEmit`: no new errors in touched files (the two pre-existing `TripView.tsx` errors are identical on `origin/main`).

## Release note

- `content/updates/2026-07-02-flush-pending-commit.md` (status: draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)