### PR TITLE
Validate shared trip payloads so broken share links show the share-unavailable page

### DIFF
--- a/content/updates/2026-07-02-share-link-validation.md
+++ b/content/updates/2026-07-02-share-link-validation.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-07-02-share-link-validation
+version: v0.127.0
+title: "Safer shared trip links"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: true
+in_app_hours: 24
+summary: "Broken or tampered shared trip links now show a friendly page instead of an error screen."
+---
+
+## Changes
+- [x] [Fixed] 🔗 Opening a broken or incomplete shared trip link now shows a friendly "trip unavailable" page instead of an error screen.
+- [ ] [Internal] Added shape validation and normalization to shared-trip decode paths (`decompressTrip`, `decompressTripFromUrl`) with regression tests.

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -1,9 +1,15 @@
-import { ITrip } from "../types";
+import { ITimelineItem, ITrip } from "../types";
 import { readLocalStorageItem, writeLocalStorageItem } from "./browserStorageService";
 
 const STORAGE_KEY = 'travelflow_trips_v1';
 
-const normalizeTrip = (trip: unknown): ITrip | null => {
+const isMinimallyValidTripItem = (item: unknown): item is ITimelineItem => {
+    if (!item || typeof item !== 'object') return false;
+    const candidate = item as Partial<ITimelineItem>;
+    return typeof candidate.id === 'string' && typeof candidate.type === 'string';
+};
+
+export const normalizeTrip = (trip: unknown): ITrip | null => {
     if (!trip || typeof trip !== 'object') return null;
     const candidate = trip as Partial<ITrip>;
 
@@ -11,11 +17,13 @@ const normalizeTrip = (trip: unknown): ITrip | null => {
     if (typeof candidate.title !== 'string') return null;
     if (!Array.isArray(candidate.items)) return null;
 
+    const items = candidate.items.filter(isMinimallyValidTripItem);
     const createdAt = typeof candidate.createdAt === 'number' ? candidate.createdAt : Date.now();
     const updatedAt = typeof candidate.updatedAt === 'number' ? candidate.updatedAt : createdAt;
 
     return {
         ...candidate,
+        items,
         createdAt,
         updatedAt,
         isFavorite: Boolean(candidate.isFavorite),

--- a/tests/browser/routes/tripLoaderRoute.browser.test.ts
+++ b/tests/browser/routes/tripLoaderRoute.browser.test.ts
@@ -300,6 +300,32 @@ describe('routes/TripLoaderRoute', () => {
     expect(props.onTripLoaded).not.toHaveBeenCalled();
   });
 
+  it('redirects to share-unavailable when a share payload fails validation (decompressTrip returns null)', async () => {
+    mocks.dbEnabled = true;
+    mocks.connectivityState = 'online';
+    mocks.auth.isAuthenticated = true;
+    mocks.route.tripId = 'N4IgMalformedSharePayload';
+    mocks.route.pathname = '/trip/N4IgMalformedSharePayload';
+    // Malformed payload (e.g. trip without an items array) now resolves to null.
+    mocks.decompressTrip.mockReturnValue(null);
+    mocks.getTripById.mockReturnValue(undefined);
+    mocks.dbGetTrip.mockResolvedValue(null);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    try {
+      const props = makeRouteProps();
+      render(React.createElement(TripLoaderRoute, props));
+
+      await waitFor(() => {
+        expect(mocks.navigate).toHaveBeenCalledWith('/share-unavailable', { replace: true });
+      });
+      expect(props.onTripLoaded).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('keeps local history snapshot view when loading an explicit version url', async () => {
     mocks.dbEnabled = true;
     mocks.route.tripId = 'trip-local-version';

--- a/tests/unit/sharedStateCompression.test.ts
+++ b/tests/unit/sharedStateCompression.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
+import LZString from 'lz-string';
 
-import { compressTrip, decompressTrip } from '../../utils';
-import { makeTrip } from '../helpers/tripFixtures';
+import { compressTrip, decompressTrip, decompressTripFromUrl } from '../../utils';
+import { makeCityItem, makeTrip } from '../helpers/tripFixtures';
+
+const encodePayload = (payload: unknown): string =>
+  LZString.compressToEncodedURIComponent(JSON.stringify(payload));
 
 describe('shared trip compression', () => {
   it('round-trips valid shared trip payloads', () => {
@@ -21,7 +25,12 @@ describe('shared trip compression', () => {
     });
 
     expect(decompressTrip(encoded)).toEqual({
-      trip,
+      trip: expect.objectContaining({
+        id: trip.id,
+        title: 'Compressed trip',
+        items: trip.items,
+        status: 'active',
+      }),
       view: expect.objectContaining({
         mapDockMode: 'floating',
         detailsWidth: 420,
@@ -34,5 +43,95 @@ describe('shared trip compression', () => {
 
     expect(decompressTrip('trip-plain-route-id')).toBeNull();
     expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null for junk lz-string input', () => {
+    expect(decompressTrip('!!!not-a-real-payload###')).toBeNull();
+  });
+
+  it('returns null when the shared payload has no trip items', () => {
+    const { items: _items, ...tripWithoutItems } = makeTrip();
+    const encoded = encodePayload({ trip: tripWithoutItems });
+
+    expect(decompressTrip(encoded)).toBeNull();
+  });
+
+  it('returns null when trip items is not an array', () => {
+    const encoded = encodePayload({ trip: { ...makeTrip(), items: 'not-an-array' } });
+
+    expect(decompressTrip(encoded)).toBeNull();
+  });
+
+  it('returns null when the shared trip is not an object', () => {
+    expect(decompressTrip(encodePayload({ trip: 'nope' }))).toBeNull();
+    expect(decompressTrip(encodePayload('just-a-string'))).toBeNull();
+    expect(decompressTrip(encodePayload(42))).toBeNull();
+  });
+
+  it('drops malformed items but keeps valid ones', () => {
+    const city = makeCityItem({ id: 'city-1', title: 'Lisbon', startDateOffset: 0, duration: 3 });
+    const encoded = encodePayload({
+      trip: { ...makeTrip(), items: [city, { rogue: true }, null, { id: 'no-type' }] },
+    });
+
+    const result = decompressTrip(encoded);
+    expect(result?.trip.items).toEqual([city]);
+  });
+
+  it('applies defaults to partially valid trips (backward-compatible bare trip payload)', () => {
+    const bareTrip = {
+      id: 'trip-bare',
+      title: 'Bare trip',
+      startDate: '2026-05-01',
+      endDate: '2026-05-05',
+      items: [],
+    };
+
+    const result = decompressTrip(encodePayload(bareTrip));
+
+    expect(result?.trip).toMatchObject({
+      id: 'trip-bare',
+      isFavorite: false,
+      status: 'active',
+      tripExpiresAt: null,
+    });
+    expect(typeof result?.trip.createdAt).toBe('number');
+    expect(typeof result?.trip.updatedAt).toBe('number');
+  });
+
+  it('ignores non-object view payloads instead of passing them through', () => {
+    const encoded = encodePayload({ trip: makeTrip(), view: 'broken-view' });
+
+    const result = decompressTrip(encoded);
+    expect(result?.trip.id).toBe('trip-1');
+    expect(result?.view).toBeUndefined();
+  });
+});
+
+describe('decompressTripFromUrl', () => {
+  it('decodes a valid trip payload', () => {
+    const trip = makeTrip({ title: 'Url trip' });
+    const encoded = LZString.compressToEncodedURIComponent(JSON.stringify(trip));
+
+    expect(decompressTripFromUrl(encoded)?.title).toBe('Url trip');
+  });
+
+  it('returns null for payloads without items', () => {
+    const { items: _items, ...tripWithoutItems } = makeTrip();
+    const encoded = LZString.compressToEncodedURIComponent(JSON.stringify(tripWithoutItems));
+
+    expect(decompressTripFromUrl(encoded)).toBeNull();
+  });
+
+  it('returns null when items is not an array', () => {
+    const encoded = LZString.compressToEncodedURIComponent(
+      JSON.stringify({ ...makeTrip(), items: {} }),
+    );
+
+    expect(decompressTripFromUrl(encoded)).toBeNull();
+  });
+
+  it('returns null for junk input', () => {
+    expect(decompressTripFromUrl('%%%junk###')).toBeNull();
   });
 });

--- a/utils.ts
+++ b/utils.ts
@@ -3,6 +3,7 @@ import { ActivityType, AppLanguage, ICoordinates, ITrip, ITimelineItem, IViewSet
 import { normalizeTransportMode } from './shared/transportModes';
 import { DEFAULT_LOCALE, localeToIntlLocale, normalizeLocale } from './config/locales';
 import { getTimelineVisualRange } from './utils/timelineVisualLayout';
+import { normalizeTrip } from './services/storageService';
 
 export const BASE_PIXELS_PER_DAY = 120; // Width of one day column (Base Zoom 1.0)
 export const PIXELS_PER_DAY = BASE_PIXELS_PER_DAY; // Deprecated: Use prop passed from parent for zooming
@@ -889,7 +890,10 @@ export const decompressTripFromUrl = (hash: string): ITrip | null => {
     try {
         const json = LZString.decompressFromEncodedURIComponent(hash);
         if (!json) return null;
-        return JSON.parse(json);
+        // Validate + normalize the payload shape; malformed payloads (missing
+        // id/title, items not an array, malformed items) resolve to null so
+        // callers can fail gracefully instead of crashing the trip view.
+        return normalizeTrip(JSON.parse(json));
     } catch (e) {
         console.error("Failed to decompress trip", e);
         return null;
@@ -1624,15 +1628,24 @@ export const decompressTrip = (encoded: string): ISharedState | null => {
         }
 
         const parsed = JSON.parse(trimmedJson);
+        if (!parsed || typeof parsed !== 'object') return null;
 
         // Backward compatibility: If parsed object has 'id' and 'items', it's just a trip
         if (parsed.id && Array.isArray(parsed.items)) {
-            return { trip: parsed as ITrip };
+            const trip = normalizeTrip(parsed);
+            return trip ? { trip } : null;
         }
 
-        // precise check for ISharedState structure
+        // ISharedState structure: validate + normalize the embedded trip so
+        // malformed share payloads (e.g. missing or non-array `items`) return
+        // null instead of crashing consumers downstream.
         if (parsed.trip) {
-            return parsed as ISharedState;
+            const trip = normalizeTrip(parsed.trip);
+            if (!trip) return null;
+            const view = parsed.view && typeof parsed.view === 'object'
+                ? parsed.view as IViewSettings
+                : undefined;
+            return { trip, view };
         }
 
         return null;


### PR DESCRIPTION

Fixes #388

## Problem

`decompressTrip` (`utils.ts`) only checked `parsed.trip` truthiness before casting to `ISharedState`, and `decompressTripFromUrl` returned raw `JSON.parse` output. A share URL with a structurally invalid payload (e.g. `trip.items` missing or not an array) reached TripView and crashed with `trip.items.filter is not a function` instead of routing to the existing `/share-unavailable` page.

## Changes

- `services/storageService.ts`: exported `normalizeTrip` and extended it to drop timeline items that lack a string `id`/`type` (`isMinimallyValidTripItem`). It continues to require `id`/`title` strings and an `items` array, and to apply defaults (`createdAt`, `updatedAt`, `isFavorite`, `status`, ...).
- `utils.ts` `decompressTrip`: rejects non-object payloads; both the backward-compatible bare-trip branch and the `ISharedState` branch now run the trip through `normalizeTrip` and return `null` on malformed input. Non-object `view` payloads are dropped instead of passed through.
- `utils.ts` `decompressTripFromUrl`: parsed payload is validated/normalized via `normalizeTrip`; malformed input returns `null`.
- Caller behavior: `routes/TripLoaderRoute.tsx` (the only caller of `decompressTrip`) already treats `null` as "not a share payload" and falls back to local/DB lookup, ending at `/share-unavailable` — verified with a new loader test. `decompressTripFromUrl` has no other production callers.

## Tests

- `tests/unit/sharedStateCompression.test.ts`: round-trip still decodes; payload without `items` → null; `items` non-array → null; non-object trip → null; junk lz-string → null; malformed items filtered while valid ones kept; defaults applied to partial bare-trip payloads; non-object `view` ignored; same matrix for `decompressTripFromUrl`.
- `tests/browser/routes/tripLoaderRoute.browser.test.ts`: new test asserting that a share payload failing validation redirects to `/share-unavailable` (replace navigation) without loading a trip.
- `pnpm test:core` green.

## Release note

- `content/updates/2026-07-02-share-link-validation.md` (status: draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)