### PR TITLE
Fix: cascade city deletion to linked travel segments and activities

### DIFF
--- a/components/tripview/useTripItemMutationHandlers.ts
+++ b/components/tripview/useTripItemMutationHandlers.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, type Dispatch, type SetStateAction } from 'react';
 
 import type { ITrip, ITimelineItem } from '../../types';
-import { getActivityColorByTypes, normalizeActivityTypes } from '../../utils';
+import { getActivityColorByTypes, normalizeActivityTypes, removeTimelineItemWithLinkedItems } from '../../utils';
 import { stripHistoryPrefix } from './useTripHistoryPresentation';
 
 interface AddActivityState {
@@ -71,7 +71,9 @@ export const useTripItemMutationHandlers = ({
         }
 
         const previousItems = trip.items;
-        const nextItems = previousItems.filter((candidate) => candidate.id !== id);
+        // Deleting a city also removes its positionally linked travel segments
+        // and activities so no orphaned items remain on the timeline.
+        const nextItems = removeTimelineItemWithLinkedItems(previousItems, id);
         handleUpdateItems(nextItems, { suppressCommitToast: true });
 
         if (item) {

--- a/content/updates/2026-07-02-delete-city-orphaned-travel-fix.md
+++ b/content/updates/2026-07-02-delete-city-orphaned-travel-fix.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-07-02-delete-city-orphaned-travel-fix
+version: v0.0.0
+title: "Cleaner timeline when removing a stop"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: true
+in_app_hours: 24
+summary: "Removing a city from your trip now also cleans up its transfers and activities."
+---
+
+## Changes
+- [x] [Fixed] 🧹 Removing a stop from your trip no longer leaves broken transfer entries or leftover activities behind.
+- [ ] [Internal] Added `removeTimelineItemWithLinkedItems` util that cascades city deletion to positionally linked travel segments and activities, with regression tests; strategy-based gap handling (DeleteCityModal) remains a follow-up.

--- a/tests/browser/tripview/useTripItemMutationHandlers.browser.test.ts
+++ b/tests/browser/tripview/useTripItemMutationHandlers.browser.test.ts
@@ -58,7 +58,9 @@ describe('components/tripview/useTripItemMutationHandlers', () => {
       result.current.handleDeleteItem(cityItem.id);
     });
 
-    expect(handleUpdateItems).toHaveBeenCalledWith([activityItem], { suppressCommitToast: true });
+    // Deleting a city cascades to its positionally owned items: the activity
+    // starts inside the city's day window, so it is removed together with it.
+    expect(handleUpdateItems).toHaveBeenCalledWith([], { suppressCommitToast: true });
     expect(showToast).toHaveBeenCalledWith('Removed city "Albanian Heritage & Riviera Loop"', expect.objectContaining({
       tone: 'remove',
       title: 'Removed',

--- a/tests/unit/removeTimelineItemWithLinkedItems.test.ts
+++ b/tests/unit/removeTimelineItemWithLinkedItems.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { removeTimelineItemWithLinkedItems } from '../../utils';
+import { makeActivityItem, makeCityItem, makeTravelItem } from '../helpers/tripFixtures';
+import type { ITimelineItem } from '../../types';
+
+const ids = (items: ITimelineItem[]): string[] => items.map((item) => item.id).sort();
+
+// Trip layout: A (days 0-2) --travel-ab--> B (days 2.2-4.2) --travel-bc--> C (days 4.4-6.4)
+const buildTrip = (): ITimelineItem[] => [
+    makeCityItem({ id: 'city-a', title: 'Amsterdam', startDateOffset: 0, duration: 2 }),
+    makeTravelItem('travel-ab', 2, 'Travel to Berlin'),
+    makeCityItem({ id: 'city-b', title: 'Berlin', startDateOffset: 2.2, duration: 2 }),
+    makeTravelItem('travel-bc', 4.2, 'Travel to Copenhagen'),
+    makeCityItem({ id: 'city-c', title: 'Copenhagen', startDateOffset: 4.4, duration: 2 }),
+    makeActivityItem('activity-a', 'Amsterdam', 0.5),
+    makeActivityItem('activity-b', 'Berlin', 2.5),
+    makeActivityItem('activity-c', 'Copenhagen', 4.5),
+];
+
+describe('removeTimelineItemWithLinkedItems', () => {
+    it('removes both adjacent travel segments when deleting a middle city', () => {
+        const next = removeTimelineItemWithLinkedItems(buildTrip(), 'city-b');
+
+        expect(ids(next)).toEqual(['activity-a', 'activity-c', 'city-a', 'city-c'].sort());
+    });
+
+    it('removes the outbound travel segment when deleting the first city', () => {
+        const next = removeTimelineItemWithLinkedItems(buildTrip(), 'city-a');
+
+        expect(ids(next)).toEqual(
+            ['city-b', 'city-c', 'travel-bc', 'activity-b', 'activity-c'].sort()
+        );
+    });
+
+    it('removes the inbound travel segment when deleting the last city', () => {
+        const next = removeTimelineItemWithLinkedItems(buildTrip(), 'city-c');
+
+        expect(ids(next)).toEqual(
+            ['city-a', 'city-b', 'travel-ab', 'activity-a', 'activity-b'].sort()
+        );
+    });
+
+    it('removes activities positionally owned by the deleted city and keeps the others', () => {
+        const next = removeTimelineItemWithLinkedItems(buildTrip(), 'city-b');
+
+        expect(next.some((item) => item.id === 'activity-b')).toBe(false);
+        expect(next.some((item) => item.id === 'activity-a')).toBe(true);
+        expect(next.some((item) => item.id === 'activity-c')).toBe(true);
+    });
+
+    it('removes travel-empty boundary segments as well', () => {
+        const items = buildTrip().map((item) =>
+            item.id === 'travel-ab' ? { ...item, type: 'travel-empty' as const, transportMode: 'na' as const } : item
+        );
+
+        const next = removeTimelineItemWithLinkedItems(items, 'city-b');
+
+        expect(next.some((item) => item.id === 'travel-ab')).toBe(false);
+        expect(next.some((item) => item.id === 'travel-bc')).toBe(false);
+    });
+
+    it('removes all travel items when the last remaining city is deleted', () => {
+        const items = [
+            makeCityItem({ id: 'city-a', title: 'Amsterdam', startDateOffset: 0, duration: 2 }),
+            makeTravelItem('travel-stale', 2, 'Stale travel'),
+        ];
+
+        const next = removeTimelineItemWithLinkedItems(items, 'city-a');
+
+        expect(next).toEqual([]);
+    });
+
+    it('deletes an activity without touching anything else', () => {
+        const next = removeTimelineItemWithLinkedItems(buildTrip(), 'activity-b');
+
+        expect(ids(next)).toEqual(
+            ['city-a', 'city-b', 'city-c', 'travel-ab', 'travel-bc', 'activity-a', 'activity-c'].sort()
+        );
+    });
+
+    it('deletes a travel item without touching anything else', () => {
+        const next = removeTimelineItemWithLinkedItems(buildTrip(), 'travel-ab');
+
+        expect(ids(next)).toEqual(
+            ['city-a', 'city-b', 'city-c', 'travel-bc', 'activity-a', 'activity-b', 'activity-c'].sort()
+        );
+    });
+
+    it('returns the input array unchanged when the id is unknown', () => {
+        const items = buildTrip();
+
+        expect(removeTimelineItemWithLinkedItems(items, 'missing')).toBe(items);
+    });
+});

--- a/utils.ts
+++ b/utils.ts
@@ -657,6 +657,65 @@ const isTravelItem = (item: ITimelineItem): boolean =>
 
 const cityPairKey = (fromId: string, toId: string): string => `${fromId}->${toId}`;
 
+/**
+ * Removes a timeline item. When the removed item is a city, also removes the
+ * items that are positionally linked to it and would otherwise be orphaned:
+ * - the travel segments on its inbound/outbound boundaries (travel items are
+ *   linked to city pairs positionally via `findTravelBetweenCities`),
+ * - the activities whose start offset falls inside the city's day window
+ *   (the same ownership rule `reorderSelectedCities` uses to move activities
+ *   with their city),
+ * - all travel items when the last remaining city is removed (no city pair
+ *   can exist anymore).
+ * Non-city items are removed without side effects.
+ */
+export const removeTimelineItemWithLinkedItems = (
+    items: ITimelineItem[],
+    id: string
+): ITimelineItem[] => {
+    const target = items.find(item => item.id === id);
+    if (!target) return items;
+    if (target.type !== 'city') {
+        return items.filter(item => item.id !== id);
+    }
+
+    const idsToRemove = new Set<string>([id]);
+
+    const cities = items
+        .filter(item => item.type === 'city')
+        .sort((a, b) => a.startDateOffset - b.startDateOffset);
+    const cityIndex = cities.findIndex(city => city.id === id);
+    const previousCity = cityIndex > 0 ? cities[cityIndex - 1] : null;
+    const nextCity = cityIndex >= 0 && cityIndex < cities.length - 1 ? cities[cityIndex + 1] : null;
+
+    if (cities.length <= 1) {
+        items.forEach(item => {
+            if (isTravelItem(item)) idsToRemove.add(item.id);
+        });
+    } else {
+        if (previousCity) {
+            const inboundTravel = findTravelBetweenCities(items, previousCity, target);
+            if (inboundTravel) idsToRemove.add(inboundTravel.id);
+        }
+        if (nextCity) {
+            const outboundTravel = findTravelBetweenCities(items, target, nextCity);
+            if (outboundTravel) idsToRemove.add(outboundTravel.id);
+        }
+    }
+
+    const epsilon = 0.00001;
+    const cityStart = target.startDateOffset;
+    const cityEnd = target.startDateOffset + target.duration;
+    items.forEach(item => {
+        if (item.type !== 'activity') return;
+        if (item.startDateOffset >= (cityStart - epsilon) && item.startDateOffset < (cityEnd - epsilon)) {
+            idsToRemove.add(item.id);
+        }
+    });
+
+    return items.filter(item => !idsToRemove.has(item.id));
+};
+
 export const reorderSelectedCities = (
     items: ITimelineItem[],
     selectedCityIds: string[],


### PR DESCRIPTION

Fixes #389

## Problem

`handleDeleteItem` (`components/tripview/useTripItemMutationHandlers.ts`) removed only the city item itself. Because travel segments are linked to city pairs positionally (`findTravelBetweenCities`) and activities are owned by a city positionally (same day-window rule `reorderSelectedCities` uses), deleting a city left orphaned transfer entries and stranded activities on the timeline.

## Changes

- **`utils.ts`**: new pure helper `removeTimelineItemWithLinkedItems(items, id)`:
  - non-city items: plain single-item removal (behavior unchanged);
  - city items: also removes the inbound/outbound boundary travel segments (resolved via `findTravelBetweenCities` against the previous/next city in timeline order) and the activities whose `startDateOffset` falls inside the city's day window;
  - deleting the last remaining city removes all travel items (no city pair can exist anymore).
- **`components/tripview/useTripItemMutationHandlers.ts`**: `handleDeleteItem` now uses the helper instead of a bare `filter`. The Undo toast still restores the full previous item list (it snapshots `previousItems`).
- **Tests**: `tests/unit/removeTimelineItemWithLinkedItems.test.ts` — A—travel—B—travel—C regression fixtures: deleting B removes both adjacent travel segments; deleting A removes only A→B; deleting C removes only B→C; city-owned activities are removed while others stay; `travel-empty` segments handled; activity/travel deletion unchanged; unknown id is a no-op. Updated `tests/browser/tripview/useTripItemMutationHandlers.browser.test.ts` to the new cascade invariant.
- **Release note**: `content/updates/2026-07-02-delete-city-orphaned-travel-fix.md` (status: draft).

## Intentionally out of scope

`components/DeleteCityModal.tsx` and the `DeleteStrategy` options (`extend-prev` / `extend-next` / `move-rest`, `types.ts:263`) remain unwired dead code, and the deleted city's day gap is intentionally kept. Whether/how to close the gap (extend a neighbor stay vs. pull later items forward) is a product decision — tracked as follow-up work in the linked issue.

## Testing

- `vitest run tests/unit/removeTimelineItemWithLinkedItems.test.ts` — 9/9 passing.
- `pnpm test:core` — full suite passing after updating the one browser test that asserted the old orphan-leaving behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)