### PR TITLE
Gate undo/redo history navigation and version-snapshot persistence on edit permission

### DIFF
--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -2190,6 +2190,7 @@ const useTripViewRender = ({
         locationPathname: location.pathname,
         currentUrl,
         isExamplePreview,
+        canEdit,
         navigate,
         suppressCommitRef,
         stripHistoryPrefix,

--- a/components/tripview/useTripHistoryController.ts
+++ b/components/tripview/useTripHistoryController.ts
@@ -28,6 +28,7 @@ interface UseTripHistoryControllerOptions {
     locationPathname: string;
     currentUrl: string;
     isExamplePreview: boolean;
+    canEdit: boolean;
     navigate: NavigateFunction;
     suppressCommitRef: MutableRefObject<boolean>;
     stripHistoryPrefix: (label: string) => string;
@@ -49,6 +50,7 @@ export const useTripHistoryController = ({
     locationPathname,
     currentUrl,
     isExamplePreview,
+    canEdit,
     navigate,
     suppressCommitRef,
     stripHistoryPrefix,
@@ -104,6 +106,7 @@ export const useTripHistoryController = ({
     }, [getHistoryIndex, resolvedHistoryEntries]);
 
     const navigateHistory = useCallback((action: HistoryAction, options?: { silent?: boolean }) => {
+        if (!canEdit) return false;
         const target = getHistoryEntryForAction(action);
         if (!target) {
             if (!options?.silent) {
@@ -128,7 +131,7 @@ export const useTripHistoryController = ({
             });
         }
         return true;
-    }, [getHistoryEntryForAction, navigate, showToast, stripHistoryPrefix, suppressCommitRef]);
+    }, [canEdit, getHistoryEntryForAction, navigate, showToast, stripHistoryPrefix, suppressCommitRef]);
 
     const formatHistoryTime = useCallback((timestamp: number) => {
         const diffMs = Date.now() - timestamp;
@@ -179,7 +182,7 @@ export const useTripHistoryController = ({
     }, [isExamplePreview, refreshHistory, tripId]);
 
     useEffect(() => {
-        if (isExamplePreview || typeof window === 'undefined') return;
+        if (!canEdit || isExamplePreview || typeof window === 'undefined') return;
 
         const handleKeyDown = (event: KeyboardEvent) => {
             const target = event.target as HTMLElement | null;
@@ -204,7 +207,7 @@ export const useTripHistoryController = ({
 
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [isExamplePreview, navigateHistory]);
+    }, [canEdit, isExamplePreview, navigateHistory]);
 
     useEffect(() => {
         if (isExamplePreview || typeof window === 'undefined') return;

--- a/content/updates/2026-07-02-readonly-undo-guard.md
+++ b/content/updates/2026-07-02-readonly-undo-guard.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-07-02-readonly-undo-guard
+version: v0.0.0
+title: "Read-only trips ignore undo shortcuts"
+date: 2026-07-02
+published_at: 2026-07-02T12:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Shared view-only trips no longer react to undo or redo shortcuts."
+---
+
+## Changes
+- [x] [Fixed] 🔒 Shared view-only trips no longer react to undo and redo keyboard shortcuts.
+- [ ] [Internal] Version snapshot loads no longer persist trips to local storage when access is resolved as view-only.

--- a/routes/TripLoaderRoute.tsx
+++ b/routes/TripLoaderRoute.tsx
@@ -150,6 +150,8 @@ export const TripLoaderRoute: React.FC<TripLoaderRouteProps> = ({
     const { snapshot: connectivitySnapshot } = useConnectivityStatus();
     const lastLoadRef = useRef<string | null>(null);
     const lastRouteTargetRef = useRef<string | null>(null);
+    const lastTripIdRef = useRef<string | null>(null);
+    const latestTripAccessRef = useRef<DbTripAccess | null>(null);
     const latestViewSettingsRef = useRef<IViewSettings | undefined>(undefined);
     const hasInSessionViewOverrideRef = useRef(false);
     const versionId = useMemo(() => {
@@ -169,6 +171,9 @@ export const TripLoaderRoute: React.FC<TripLoaderRouteProps> = ({
     const updateRouteState = useCallback((patch: TripLoaderRouteStatePatch) => {
         if (hasRouteStatePatchKey(patch, 'viewSettings')) {
             latestViewSettingsRef.current = patch.viewSettings;
+        }
+        if (hasRouteStatePatchKey(patch, 'tripAccess')) {
+            latestTripAccessRef.current = patch.tripAccess ?? null;
         }
         setRouteState((current) => {
             const nextViewSettings = hasRouteStatePatchKey(patch, 'viewSettings')
@@ -196,6 +201,8 @@ export const TripLoaderRoute: React.FC<TripLoaderRouteProps> = ({
         const routeTargetKey = `${tripId}:${versionId || ''}`;
         const didRouteTargetChange = lastRouteTargetRef.current !== routeTargetKey;
         lastRouteTargetRef.current = routeTargetKey;
+        const didTripChange = lastTripIdRef.current !== tripId;
+        lastTripIdRef.current = tripId;
 
         const load = async () => {
             const connectivityState = connectivitySnapshot.state;
@@ -209,9 +216,24 @@ export const TripLoaderRoute: React.FC<TripLoaderRouteProps> = ({
             // for the same route target so late loader responses cannot snap UI
             // controls (e.g. timeline mode) back to stale defaults.
             if (didRouteTargetChange) {
-                updateRouteState({ viewSettings: undefined, tripAccess: null });
+                // Keep known access metadata when only the version changes within
+                // the same trip so read-only shares stay read-only while version
+                // browsing; a different trip id must re-resolve access from scratch.
+                if (didTripChange) {
+                    updateRouteState({ viewSettings: undefined, tripAccess: null });
+                } else {
+                    updateRouteState({ viewSettings: undefined });
+                }
                 hasInSessionViewOverrideRef.current = false;
             }
+
+            // Version snapshots must never be persisted to local storage from a
+            // context that cannot edit the trip (view-only share / admin fallback).
+            // Unknown access (owner-local or offline flows) keeps persisting.
+            const canPersistSnapshotLocally = () => {
+                const source = latestTripAccessRef.current?.source;
+                return !source || source === 'owner';
+            };
 
             const resolveEffectiveView = (resolvedView?: IViewSettings, fallbackView?: IViewSettings) => {
                 if (!didRouteTargetChange && hasInSessionViewOverrideRef.current) {
@@ -243,7 +265,9 @@ export const TripLoaderRoute: React.FC<TripLoaderRouteProps> = ({
                 const localEntry = findHistoryEntryByUrl(tripId, buildTripUrl(tripId, versionId));
                 if (localEntry?.snapshot?.trip) {
                     const normalizedLocalSnapshotTrip = normalizeTripForRouteLoad(localEntry.snapshot.trip);
-                    saveTrip(normalizedLocalSnapshotTrip, { preserveUpdatedAt: true });
+                    if (canPersistSnapshotLocally()) {
+                        saveTrip(normalizedLocalSnapshotTrip, { preserveUpdatedAt: true });
+                    }
                     localResolvedTrip = normalizedLocalSnapshotTrip;
                     localResolvedView = resolveEffectiveView(localEntry.snapshot.view, normalizedLocalSnapshotTrip.defaultView);
                     updateRouteState({ viewSettings: localResolvedView });
@@ -285,7 +309,9 @@ export const TripLoaderRoute: React.FC<TripLoaderRouteProps> = ({
                     const version = await dbGetTripVersion(tripId, versionId);
                     if (version?.trip) {
                         const normalizedVersionTrip = normalizeTripForRouteLoad(version.trip);
-                        saveTrip(normalizedVersionTrip, { preserveUpdatedAt: true });
+                        if (canPersistSnapshotLocally()) {
+                            saveTrip(normalizedVersionTrip, { preserveUpdatedAt: true });
+                        }
                         const resolvedView = resolveEffectiveView(version.view, normalizedVersionTrip.defaultView);
                         const localUpdatedAt = localResolvedTrip?.updatedAt ?? 0;
                         const dbUpdatedAt = normalizedVersionTrip.updatedAt ?? 0;

--- a/tests/browser/tripview/useTripHistoryController.browser.test.ts
+++ b/tests/browser/tripview/useTripHistoryController.browser.test.ts
@@ -32,6 +32,7 @@ describe('components/tripview/useTripHistoryController', () => {
       locationPathname: '/trip/trip-1',
       currentUrl: '/trip/trip-1',
       isExamplePreview: false,
+      canEdit: true,
       navigate,
       suppressCommitRef,
       stripHistoryPrefix: (label) => label,
@@ -58,6 +59,7 @@ describe('components/tripview/useTripHistoryController', () => {
       locationPathname: '/trip/trip-1',
       currentUrl: '/trip/trip-1',
       isExamplePreview: false,
+      canEdit: true,
       navigate,
       suppressCommitRef,
       stripHistoryPrefix: (label) => label,
@@ -94,6 +96,7 @@ describe('components/tripview/useTripHistoryController', () => {
       locationPathname: '/trip/trip-1',
       currentUrl: '/trip/trip-1',
       isExamplePreview: false,
+      canEdit: true,
       navigate,
       suppressCommitRef,
       stripHistoryPrefix: (label) => label.replace(/^Data:\s*/i, ''),
@@ -130,6 +133,7 @@ describe('components/tripview/useTripHistoryController', () => {
       locationPathname: '/trip/trip-1',
       currentUrl: '/trip/trip-1',
       isExamplePreview: false,
+      canEdit: true,
       navigate,
       suppressCommitRef,
       stripHistoryPrefix: (label) => label.replace(/^Data:\s*/i, ''),
@@ -159,6 +163,7 @@ describe('components/tripview/useTripHistoryController', () => {
       locationPathname: '/trip/trip-1',
       currentUrl: '/trip/trip-1',
       isExamplePreview: false,
+      canEdit: true,
       navigate,
       suppressCommitRef,
       stripHistoryPrefix: (label) => label,
@@ -175,5 +180,120 @@ describe('components/tripview/useTripHistoryController', () => {
       iconVariant: 'undo',
       disableDefaultUndo: true,
     });
+  });
+
+  it('navigates history via Cmd+Z keyboard shortcut when editing is allowed', () => {
+    const navigate = vi.fn();
+    const showToast = vi.fn();
+    const suppressCommitRef = { current: false };
+    historyServiceMocks.getHistoryEntries.mockReturnValue([
+      {
+        id: 'history-1',
+        tripId: 'trip-1',
+        url: '/trip/trip-1?version=v1',
+        label: 'Data: Removed activity "Museum"',
+        ts: Date.now() - 1_000,
+      },
+    ]);
+
+    renderHook(() => useTripHistoryController({
+      tripId: 'trip-1',
+      tripUpdatedAt: Date.now(),
+      locationPathname: '/trip/trip-1',
+      currentUrl: '/trip/trip-1',
+      isExamplePreview: false,
+      canEdit: true,
+      navigate,
+      suppressCommitRef,
+      stripHistoryPrefix: (label) => label.replace(/^Data:\s*/i, ''),
+      showToast,
+    }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', metaKey: true, bubbles: true }));
+    });
+
+    expect(navigate).toHaveBeenCalledWith('/trip/trip-1?version=v1', { replace: true });
+    expect(showToast).toHaveBeenCalledWith('Removed activity "Museum"', {
+      tone: 'neutral',
+      title: 'Undo',
+      iconVariant: 'undo',
+      disableDefaultUndo: true,
+    });
+  });
+
+  it('ignores Cmd+Z / Cmd+Shift+Z in read-only views (no navigation, toast, or history state change)', () => {
+    const navigate = vi.fn();
+    const showToast = vi.fn();
+    const suppressCommitRef = { current: false };
+    historyServiceMocks.getHistoryEntries.mockReturnValue([
+      {
+        id: 'history-1',
+        tripId: 'trip-1',
+        url: '/trip/trip-1?version=v1',
+        label: 'Data: Removed activity "Museum"',
+        ts: Date.now() - 1_000,
+      },
+    ]);
+
+    renderHook(() => useTripHistoryController({
+      tripId: 'trip-1',
+      tripUpdatedAt: Date.now(),
+      locationPathname: '/s/share-1',
+      currentUrl: '/s/share-1',
+      isExamplePreview: false,
+      canEdit: false,
+      navigate,
+      suppressCommitRef,
+      stripHistoryPrefix: (label) => label.replace(/^Data:\s*/i, ''),
+      showToast,
+    }));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', metaKey: true, bubbles: true }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', metaKey: true, shiftKey: true, bubbles: true }));
+    });
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(showToast).not.toHaveBeenCalled();
+    expect(suppressCommitRef.current).toBe(false);
+  });
+
+  it('blocks programmatic navigateHistory calls in read-only views', () => {
+    const navigate = vi.fn();
+    const showToast = vi.fn();
+    const suppressCommitRef = { current: false };
+    historyServiceMocks.getHistoryEntries.mockReturnValue([
+      {
+        id: 'history-1',
+        tripId: 'trip-1',
+        url: '/trip/trip-1?version=v1',
+        label: 'Data: Removed activity "Museum"',
+        ts: Date.now() - 1_000,
+      },
+    ]);
+
+    const { result } = renderHook(() => useTripHistoryController({
+      tripId: 'trip-1',
+      tripUpdatedAt: Date.now(),
+      locationPathname: '/s/share-1',
+      currentUrl: '/s/share-1',
+      isExamplePreview: false,
+      canEdit: false,
+      navigate,
+      suppressCommitRef,
+      stripHistoryPrefix: (label) => label,
+      showToast,
+    }));
+
+    let didNavigate = true;
+    act(() => {
+      didNavigate = result.current.navigateHistory('undo');
+    });
+
+    expect(didNavigate).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(showToast).not.toHaveBeenCalled();
+    expect(suppressCommitRef.current).toBe(false);
   });
 });


### PR DESCRIPTION

Fixes #390

## Problem

In a view-only shared trip (`public_read` share or admin fallback without override), the global Cmd+Z / Cmd+Shift+Z / Ctrl+Y handler in `useTripHistoryController` still navigated history entries and showed "Undo"/"Redo" toasts. Worse, the version-load path in `TripLoaderRoute` called `saveTrip(...)` on the loaded snapshot, mutating the viewer's local storage from a read-only context.

## Changes

- `components/tripview/useTripHistoryController.ts`
  - New required `canEdit` option.
  - The keyboard undo/redo effect no longer registers its `keydown` listener at all when `!canEdit` (per repo effect-hygiene guidance), so browser-native shortcut behavior is untouched in read-only views.
  - `navigateHistory` returns `false` early when `!canEdit`, guarding every API surface (keyboard, `navigateHistoryRef`, toast undo actions).
- `components/TripView.tsx`
  - Passes the existing `canEdit` flag (readOnly prop + expiry/archive/admin-override state) into the controller.
- `routes/TripLoaderRoute.tsx`
  - `tripAccess` is now preserved when only the version query changes within the same trip (previously it was reset to `null` on every route-target change, dropping read-only metadata exactly when version loads ran; it still resets when the trip id changes).
  - Version-snapshot `saveTrip(...)` calls (local history snapshot and `dbGetTripVersion` result) are skipped when the last known access source is not `owner`. Unknown access (fresh owner-local loads, offline flows) keeps persisting, so legitimate owner version browsing is unchanged — the gate only activates once access has been resolved as `public_read`/`admin_fallback`.

## Tests

- `tests/browser/tripview/useTripHistoryController.browser.test.ts`
  - New: read-only view ignores Cmd+Z and Cmd+Shift+Z (no navigation, no toast, no `suppressCommitRef` flip).
  - New: programmatic `navigateHistory` is blocked in read-only views.
  - New: editable view still navigates history via Cmd+Z with the expected undo toast.
  - Existing cases updated to pass `canEdit: true`.
- `pnpm test:core` run locally.

## Release note

One draft entry under `content/updates/` per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)