### PR TITLE
release: publish update notes for security & trip-tool fix batch (v0.127.0–v0.140.0)

### DIFF
--- a/content/updates/2026-07-02-activity-suggestion-error-feedback.md
+++ b/content/updates/2026-07-02-activity-suggestion-error-feedback.md
@@ -3,8 +3,8 @@ id: rel-2026-07-02-activity-suggestion-error-feedback
 version: v0.127.0
 title: "Clearer feedback for AI activity suggestions"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:30:00Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Activity idea generation now tells you when it fails and lets you retry instantly."

--- a/content/updates/2026-07-02-ai-generation-hardening.md
+++ b/content/updates/2026-07-02-ai-generation-hardening.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-ai-generation-hardening
-version: v0.0.0
+version: v0.128.0
 title: "AI generation endpoint hardening"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:31:00Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Server-side safeguards keep AI trip generation reliable and abuse-resistant."

--- a/content/updates/2026-07-02-default-trip-dates-timezone-fix.md
+++ b/content/updates/2026-07-02-default-trip-dates-timezone-fix.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-default-trip-dates-timezone-fix
-version: v0.127.0
+version: v0.129.0
 title: "Correct Suggested Trip Dates in All Timezones"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:32:00Z
+status: published
 notify_in_app: true
 in_app_hours: 24
 summary: "Suggested trip start dates now always land on the intended Friday, no matter your timezone."

--- a/content/updates/2026-07-02-delete-city-orphaned-travel-fix.md
+++ b/content/updates/2026-07-02-delete-city-orphaned-travel-fix.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-delete-city-orphaned-travel-fix
-version: v0.0.0
+version: v0.130.0
 title: "Cleaner timeline when removing a stop"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:33:00Z
+status: published
 notify_in_app: true
 in_app_hours: 24
 summary: "Removing a city from your trip now also cleans up its transfers and activities."

--- a/content/updates/2026-07-02-flush-pending-commit.md
+++ b/content/updates/2026-07-02-flush-pending-commit.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-flush-pending-commit
-version: v0.0.0
+version: v0.131.0
 title: "Reliable saving when leaving the page"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:34:00Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Your very last edit is no longer lost when you close the tab right after making it."

--- a/content/updates/2026-07-02-offline-sync-conflict-protection.md
+++ b/content/updates/2026-07-02-offline-sync-conflict-protection.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-offline-sync-conflict-protection
-version: v0.127.0
+version: v0.132.0
 title: "Offline sync conflict protection"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:35:00Z
+status: published
 notify_in_app: true
 in_app_hours: 24
 summary: "Edits made on another device are no longer overwritten when offline changes sync back."

--- a/content/updates/2026-07-02-readonly-undo-guard.md
+++ b/content/updates/2026-07-02-readonly-undo-guard.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-readonly-undo-guard
-version: v0.0.0
+version: v0.133.0
 title: "Read-only trips ignore undo shortcuts"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:36:00Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Shared view-only trips no longer react to undo or redo shortcuts."

--- a/content/updates/2026-07-02-reconnect-keeps-recent-edits.md
+++ b/content/updates/2026-07-02-reconnect-keeps-recent-edits.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-reconnect-keeps-recent-edits
-version: v0.0.0
+version: v0.134.0
 title: "Reconnect Keeps Your Recent Edits"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:37:00Z
+status: published
 notify_in_app: true
 in_app_hours: 24
 summary: "Trips edited offline no longer revert to older server data when your connection comes back."

--- a/content/updates/2026-07-02-remove-client-gemini-key.md
+++ b/content/updates/2026-07-02-remove-client-gemini-key.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-remove-client-gemini-key
-version: v0.0.0
+version: v0.135.0
 title: "Keep AI provider keys server-side only"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:38:00Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Removed the browser-side AI provider key path so all AI generation runs through secured server endpoints."

--- a/content/updates/2026-07-02-share-link-validation.md
+++ b/content/updates/2026-07-02-share-link-validation.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-share-link-validation
-version: v0.127.0
+version: v0.136.0
 title: "Safer shared trip links"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:39:00Z
+status: published
 notify_in_app: true
 in_app_hours: 24
 summary: "Broken or tampered shared trip links now show a friendly page instead of an error screen."

--- a/content/updates/2026-07-02-storage-quota-prune-notice.md
+++ b/content/updates/2026-07-02-storage-quota-prune-notice.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-storage-quota-prune-notice
-version: v0.127.0
+version: v0.137.0
 title: "Warning when device storage runs out"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:40:00Z
+status: published
 notify_in_app: true
 in_app_hours: 24
 summary: "You now get a clear warning when older local trips had to be removed because your device storage was full."

--- a/content/updates/2026-07-02-timeline-resize-clamp.md
+++ b/content/updates/2026-07-02-timeline-resize-clamp.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-timeline-resize-clamp
-version: v0.127.0
+version: v0.138.0
 title: "Timeline resize fix"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:41:00Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Resizing a city stay on the timeline now stops cleanly at the neighboring stay."

--- a/content/updates/2026-07-02-trip-map-preview-hardening.md
+++ b/content/updates/2026-07-02-trip-map-preview-hardening.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-trip-map-preview-hardening
-version: v0.0.0
+version: v0.139.0
 title: "Trip map preview hardening"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:42:00Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Trip map preview images load faster thanks to stronger caching, with new protections against abusive traffic."

--- a/content/updates/2026-07-02-voucher-lookup-hardening.md
+++ b/content/updates/2026-07-02-voucher-lookup-hardening.md
@@ -1,10 +1,10 @@
 ---
 id: rel-2026-07-02-voucher-lookup-hardening
-version: v0.127.0
+version: v0.140.0
 title: "Harden checkout voucher lookup"
 date: 2026-07-02
-published_at: 2026-07-02T12:00:00Z
-status: draft
+published_at: 2026-07-02T19:43:00Z
+status: published
 notify_in_app: false
 in_app_hours: 24
 summary: "Hardened the checkout voucher lookup against automated code guessing."


### PR DESCRIPTION
Publishes the 14 draft release notes from the merged fix batch (#393–#406): status → published, canonical gapless versions v0.127.0–v0.140.0 ordered by published_at (per scripts/validate-updates.mjs), timestamps set to merge time (before 23:00 UTC per docs/UPDATE_FORMAT.md).

`pnpm updates:validate`: exit 0 (remaining canonical warnings are pre-existing March entries).

Merging this deploys latest main via Netlify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)