### PR TITLE
perf: un-gate homepage from Supabase auth bootstrap (PR C)

### DIFF
--- a/app/routes/DeferredAppRoutes.tsx
+++ b/app/routes/DeferredAppRoutes.tsx
@@ -71,11 +71,27 @@ const renderWithHandoff = (node: React.ReactElement) => (
     <HandoffReadyBoundary>{node}</HandoffReadyBoundary>
 );
 
+/**
+ * Homepage auth gate that never suspends first paint.
+ *
+ * Anonymous visitors (the common case for `/`) render the marketing homepage
+ * immediately without waiting for the Supabase chunk or `getSession()`.
+ *
+ * While auth bootstrap is still pending, `isAuthenticated` already reflects
+ * the synchronous persisted-session hint (`readPersistedSupabaseSessionHint`)
+ * that AuthContext applies on marketing routes. Visitors with that hint keep
+ * the lightweight non-suspending loading shell instead of flashing the
+ * marketing page, and get the same `/profile` redirect once the real session
+ * settles. If the hint turns out stale, the settled context flips
+ * `isAuthenticated` back and the marketing page renders.
+ */
 const AuthenticatedMarketingHomeRoute: React.FC<{ children: React.ReactElement }> = ({ children }) => {
     const { isLoading, isAuthenticated } = useAuth();
 
-    suspendUntilAuthBootstrapSettles(isLoading);
     if (isAuthenticated) {
+        if (isLoading) {
+            return <MarketingRouteLoadingShell />;
+        }
         return <Navigate to="/profile" replace />;
     }
     return children;

--- a/content/updates/2026-07-02-ungate-homepage-auth.md
+++ b/content/updates/2026-07-02-ungate-homepage-auth.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-07-02-ungate-homepage-auth
+version: v0.141.0
+title: "Faster homepage first paint"
+date: 2026-07-02
+published_at: 2026-07-02T20:30:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "The homepage now appears immediately instead of waiting for sign-in checks to finish."
+---
+
+## Changes
+- [x] [Improved] ⚡ The homepage now shows up right away — it no longer waits for background sign-in checks before appearing.
+- [ ] [Internal] Removed the `suspendUntilAuthBootstrapSettles` Suspense-throw from `AuthenticatedMarketingHomeRoute` in `app/routes/DeferredAppRoutes.tsx`; `/` no longer blocks first paint on the Supabase chunk + `supabase.auth.getSession()`.
+- [ ] [Internal] Signed-in visitors are still redirected to `/profile`: the synchronous persisted-session hint (`readPersistedSupabaseSessionHint`) keeps a lightweight non-suspending loading shell instead of flashing the marketing page until auth settles; stale hints fall back to the marketing page.
+- [ ] [Internal] Regression tests in `tests/browser/routes/deferredAppRoutes.browser.test.ts`: anonymous `/` renders marketing content during auth bootstrap; hint-authenticated visitors keep the shell and land on `/profile` after settle; stale hints recover to the marketing page.

--- a/tests/browser/routes/deferredAppRoutes.browser.test.ts
+++ b/tests/browser/routes/deferredAppRoutes.browser.test.ts
@@ -46,6 +46,10 @@ vi.mock('../../../pages/PricingPage', () => ({
   PricingPage: () => React.createElement('div', { 'data-testid': 'mock-pricing-page' }, 'Pricing page'),
 }));
 
+vi.mock('../../../pages/MarketingHomePage', () => ({
+  MarketingHomePage: () => React.createElement('div', { 'data-testid': 'mock-marketing-home-page' }, 'Marketing home page'),
+}));
+
 import { DeferredAppRoutes } from '../../../app/routes/DeferredAppRoutes';
 
 const LocationProbe: React.FC = () => {
@@ -53,19 +57,20 @@ const LocationProbe: React.FC = () => {
   return React.createElement('div', { 'data-testid': 'location-probe' }, `${location.pathname}${location.search}`);
 };
 
-const renderDeferredRoutes = (initialPath: string) => {
-  return render(
-    React.createElement(
-      MemoryRouter,
-      { initialEntries: [initialPath] },
-      React.createElement(DeferredAppRoutes, {
-        onAppLanguageLoaded: vi.fn(),
-        onTripGenerated: vi.fn(),
-        onOpenManager: vi.fn(),
-      }),
-      React.createElement(LocationProbe)
-    )
+const createDeferredRoutesElement = (initialPath: string) =>
+  React.createElement(
+    MemoryRouter,
+    { initialEntries: [initialPath] },
+    React.createElement(DeferredAppRoutes, {
+      onAppLanguageLoaded: vi.fn(),
+      onTripGenerated: vi.fn(),
+      onOpenManager: vi.fn(),
+    }),
+    React.createElement(LocationProbe)
   );
+
+const renderDeferredRoutes = (initialPath: string) => {
+  return render(createDeferredRoutesElement(initialPath));
 };
 
 describe('app/routes/DeferredAppRoutes root auth gate', () => {
@@ -100,19 +105,55 @@ describe('app/routes/DeferredAppRoutes root auth gate', () => {
     });
   });
 
-  it('shows loading fallback while auth is resolving on root', () => {
+  it('renders the marketing homepage immediately while auth bootstrap is pending (anonymous)', async () => {
     mocks.auth.isLoading = true;
+    mocks.auth.isAuthenticated = false;
 
-    const { getByTestId } = renderDeferredRoutes('/');
-    const fallback = getByTestId('route-loading-shell');
+    const { getByTestId, queryByTestId } = renderDeferredRoutes('/');
 
+    await waitFor(() => {
+      expect(getByTestId('mock-marketing-home-page')).toBeInTheDocument();
+    });
     expect(getByTestId('location-probe').textContent).toBe('/');
-    expect(fallback).toHaveAttribute('data-shell-variant', 'marketing');
-    expect(fallback.textContent).toContain('TravelFlow');
-    expect(fallback.textContent).not.toContain('Create Trip');
-    expect(fallback.querySelector('.tf-boot-nav-skeleton--features')).toBeTruthy();
-    expect(fallback.querySelector('.tf-boot-control-flag')).toBeTruthy();
-    expect(fallback.querySelector('.tf-boot-control-skeleton--cta')).toBeTruthy();
+    expect(queryByTestId('route-loading-shell')).toBeNull();
+  });
+
+  it('holds a non-suspending shell for hint-authenticated visitors, then redirects to /profile once auth settles', async () => {
+    mocks.auth.isLoading = true;
+    mocks.auth.isAuthenticated = true;
+
+    const { getByTestId, queryByTestId, rerender } = renderDeferredRoutes('/');
+
+    const shell = getByTestId('route-loading-shell');
+    expect(getByTestId('location-probe').textContent).toBe('/');
+    expect(shell).toHaveAttribute('data-shell-variant', 'marketing');
+    expect(queryByTestId('mock-marketing-home-page')).toBeNull();
+
+    mocks.auth.isLoading = false;
+    rerender(createDeferredRoutesElement('/'));
+
+    await waitFor(() => {
+      expect(getByTestId('location-probe').textContent).toBe('/profile');
+    });
+  });
+
+  it('falls back to the marketing homepage when a stale auth hint settles as anonymous', async () => {
+    mocks.auth.isLoading = true;
+    mocks.auth.isAuthenticated = true;
+
+    const { getByTestId, queryByTestId, rerender } = renderDeferredRoutes('/');
+
+    expect(getByTestId('route-loading-shell')).toBeInTheDocument();
+
+    mocks.auth.isLoading = false;
+    mocks.auth.isAuthenticated = false;
+    rerender(createDeferredRoutesElement('/'));
+
+    await waitFor(() => {
+      expect(getByTestId('mock-marketing-home-page')).toBeInTheDocument();
+    });
+    expect(getByTestId('location-probe').textContent).toBe('/');
+    expect(queryByTestId('route-loading-shell')).toBeNull();
   });
 
   it('supports public profile routes', async () => {


### PR DESCRIPTION
Part of #408 (root cause 3: `/` is auth-gated).

## Problem

`AuthenticatedMarketingHomeRoute` in `app/routes/DeferredAppRoutes.tsx` called `suspendUntilAuthBootstrapSettles(isLoading)`, throwing a Suspense promise until `AuthContext` finished loading the Supabase chunk and awaiting `supabase.auth.getSession()`. The most static route of the site could not commit its first paint until a lazy chunk + async storage/session read settled — a direct contributor to the 4.4–4.6s homepage LCP.

The gate existed so signed-in users land on `/profile` instead of the marketing homepage, without a flash of the marketing page.

## Fix (least-risky design)

Remove the Suspense-throw from the homepage gate only; keep the redirect behavior via the **already-existing synchronous session hint**:

- **Anonymous visitors (no persisted hint)** — `isAuthenticated` is `false` from the very first render, so the marketing homepage commits immediately. No Supabase wait on the critical path.
- **Probably-authenticated visitors** — `AuthContext` already resolves an optimistic `isAuthenticated` synchronously during bootstrap on marketing routes via `readPersistedSupabaseSessionHint()` (localStorage/session hint, `services/authSessionPersistenceService.ts`). For them the route renders the existing lightweight, non-suspending `MarketingRouteLoadingShell` (no marketing-page flash) and issues the same `<Navigate to="/profile" replace />` once `isLoading` flips to `false`. Redirect target is unchanged.
- **Stale hint** (session expired/invalid) — settled context flips `isAuthenticated` back to `false` and the marketing page renders; no wrong redirect to `/login`.
- **Authenticated but no hint** (edge case) — marketing page shows briefly, then redirects after settle. Accepted tradeoff per #408.

No effect/subscription needed: the redirect is declarative and fires on the context re-render when bootstrap settles.

## Other routes with the same pattern (noted, intentionally unchanged)

- `AuthenticatedRoute` and `AdminRoute` (same file) still call `suspendUntilAuthBootstrapSettles` — appropriate there: `/profile`, `/admin`, etc. are auth-required app routes and are `isAuthBootstrapCriticalPath` paths where AuthContext bootstraps immediately.
- `/login` and all other marketing routes were never wrapped in the gate (only `path === '/'` and its localized variants were); they are unaffected.
- `services/authBootstrapSuspense.ts` is kept as-is for the remaining consumers.

## Tests

`tests/browser/routes/deferredAppRoutes.browser.test.ts` (11 pass):
- Regression: `/` renders marketing homepage content immediately while auth bootstrap is pending (anonymous) — no loading shell, no suspension.
- Hint-authenticated visitor keeps the non-suspending shell on `/`, then lands on `/profile` once auth settles (redirect target preserved).
- Stale hint settles as anonymous → marketing homepage renders, URL stays `/`.
- Existing settled-auth redirect tests (`/` and `/de` → `/profile`) unchanged and passing.

`pnpm test:core`: 323 files, 1519 passed / 1 skipped.

## Release note

Draft entry `content/updates/2026-07-02-ungate-homepage-auth.md` (v0.141.0, `status: draft`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)