### PR TITLE
fix: white flash on page navigation (keep boot-shell styles in prerendered pages)

### DIFF
--- a/content/updates/2026-07-03-fix-nav-white-flash.md
+++ b/content/updates/2026-07-03-fix-nav-white-flash.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-07-03-fix-nav-white-flash
+version: v0.0.0
+title: "No more white flash between pages"
+date: 2026-07-03
+published_at: 2026-07-03T08:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Switching between pages no longer flashes a blank white screen."
+---
+
+## Changes
+- [x] [Fixed] ⚡ Switching between pages no longer flashes a blank white screen while the next page loads.
+- [ ] [Internal] The prerender boot-shell strip removed the inline `<style data-tf-boot-shell-css>` block, but the runtime `AppBootstrapShell` (MarketingRouteLoadingShell Suspense fallback during client-side navigation) reuses those `tf-boot-*` classes and they exist nowhere else — leaving the navigation fallback unstyled (full-screen white). Prerender now keeps the style block and still strips the redundant shell markup + hide-script.
+- [ ] [Internal] Regression coverage in prerenderHtmlUtils asserts the boot-shell style survives while markup/script are removed.

--- a/scripts/prerender-html-utils.mjs
+++ b/scripts/prerender-html-utils.mjs
@@ -59,16 +59,20 @@ export function injectModulePreloadHints(html, hrefs) {
 }
 
 const BOOT_SHELL_ELEMENT_PATTERN = /[ \t]*<div id="app-bootstrap-shell">[\s\S]*?(?=<div id="root")/;
-const BOOT_SHELL_STYLE_PATTERN = /[ \t]*<!--[^>]*boot-shell styles[\s\S]*?-->\s*/i;
-const BOOT_SHELL_STYLE_TAG_PATTERN = /[ \t]*<style[^>]*\bdata-tf-boot-shell-css\b[^>]*>[\s\S]*?<\/style>\s*/;
 const BOOT_SHELL_SCRIPT_COMMENT_PATTERN = /[ \t]*<!--[^>]*boot-shell hide script[\s\S]*?-->\s*/i;
 const BOOT_SHELL_SCRIPT_TAG_PATTERN = /[ \t]*<script[^>]*\bdata-tf-boot-shell-script\b[^>]*>[\s\S]*?<\/script>\s*/;
 
 /**
- * Remove the bootstrap shell markup, its dedicated style block, and the
- * shell hide-script from a prerendered document. Prerendered pages ship real
- * content in #root, so the shell would be hidden instantly anyway — stripping
- * it saves the inline CSS/markup bytes on every prerendered page.
+ * Remove the bootstrap shell markup and the shell hide-script from a
+ * prerendered document. Prerendered pages ship real content in #root, so the
+ * shell markup would be hidden instantly anyway.
+ *
+ * The dedicated boot-shell <style> block is deliberately KEPT: the runtime
+ * `AppBootstrapShell` React component (rendered by `MarketingRouteLoadingShell`
+ * as the Suspense fallback during client-side navigation) reuses the same
+ * `tf-boot-*` classes, and those rules live only in this inline block — not in
+ * the CSS bundle. Stripping it left the navigation fallback unstyled, producing
+ * a full-screen white flash on every page switch. The block is ~2.5KB gzip.
  *
  * @param {string} html
  * @returns {{ html: string, removedShell: boolean, removedStyle: boolean, removedScript: boolean }}
@@ -80,15 +84,6 @@ export function stripBootstrapShell(html) {
   const removedShell = withoutShell !== output;
   output = withoutShell;
 
-  let removedStyle = false;
-  const withoutStyle = output
-    .replace(BOOT_SHELL_STYLE_PATTERN, '')
-    .replace(BOOT_SHELL_STYLE_TAG_PATTERN, (match) => {
-      removedStyle = true;
-      return '';
-    });
-  output = withoutStyle;
-
   let removedScript = false;
   const withoutScript = output
     .replace(BOOT_SHELL_SCRIPT_COMMENT_PATTERN, '')
@@ -98,5 +93,5 @@ export function stripBootstrapShell(html) {
     });
   output = withoutScript;
 
-  return { html: output, removedShell, removedStyle, removedScript };
+  return { html: output, removedShell, removedStyle: false, removedScript };
 }

--- a/tests/unit/prerenderHtmlUtils.test.ts
+++ b/tests/unit/prerenderHtmlUtils.test.ts
@@ -73,17 +73,20 @@ describe('stripBootstrapShell', () => {
   // with index.html (the built dist/index.html preserves these attributes).
   const sourceHtml = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
 
-  it('removes the shell element, its style block, and the hide-script from the template', () => {
+  it('removes the shell element and the hide-script but KEEPS the boot-shell style block', () => {
     const result = stripBootstrapShell(sourceHtml);
 
     expect(result.removedShell).toBe(true);
-    expect(result.removedStyle).toBe(true);
     expect(result.removedScript).toBe(true);
     expect(result.html).not.toContain('id="app-bootstrap-shell"');
-    expect(result.html).not.toContain('tf-boot-shell');
-    expect(result.html).not.toContain('data-tf-boot-shell-css');
     expect(result.html).not.toContain('data-tf-boot-shell-script');
     expect(result.html).not.toContain("data-tf-react-shell-visible', 'true'");
+    // The boot-shell <style> must survive: the runtime AppBootstrapShell
+    // (Suspense fallback during client-side navigation) reuses these classes
+    // and they exist nowhere else. Stripping it caused a white nav flash.
+    expect(result.removedStyle).toBe(false);
+    expect(result.html).toContain('data-tf-boot-shell-css');
+    expect(result.html).toContain('tf-boot-shell');
   });
 
   it('keeps the root container, entry script, and non-shell styles intact', () => {


### PR DESCRIPTION
## Bug
After #410, switching between pages flashed a full-screen **white** screen while the next route chunk loaded.

## Cause
#410 stripped the inline `<style data-tf-boot-shell-css>` block from prerendered pages to save bytes. But the runtime `AppBootstrapShell` — rendered by `MarketingRouteLoadingShell` as the **Suspense fallback during client-side navigation** — reuses the same `tf-boot-*` classes, and those rules exist **only** in that inline block (not in the CSS bundle). So the navigation fallback rendered unstyled = full-screen white. (`spa.html` kept the styles, which is why it was inconsistent.)

## Fix
Prerender keeps the boot-shell `<style>` block (~2.5KB gzip) and still strips the genuinely-redundant shell markup div + hide-script. All of #410's other wins (modulepreload hints, static font preloads, `spa.html` fallback) are unchanged.

## Verification
Throttled headless-browser navigation (`/` → `/pricing`): the fallback now paints `rgb(248,250,252)` (slate-50, the marketing surface) matching the page — no white flash. Regression test in `prerenderHtmlUtils` asserts the style block survives while markup/script are stripped. Built artifact confirmed: 30 modulepreload hints retained, shell markup + hide-script removed, boot-shell CSS present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)