### PR TITLE
fix: landing pages half-hydrate on load (stale prerender hints + missed image loads)

### DIFF
--- a/components/ProgressiveImage.tsx
+++ b/components/ProgressiveImage.tsx
@@ -131,6 +131,19 @@ export const ProgressiveImage: React.FC<ProgressiveImageProps> = ({
                 {avifSrcSet && <source type="image/avif" srcSet={avifSrcSet} sizes={sizes} />}
                 {webpSrcSet && <source type="image/webp" srcSet={webpSrcSet} sizes={sizes} />}
                 <img
+                    ref={(node) => {
+                        // The image can finish loading before hydration attaches
+                        // the onLoad handler (warm CDN cache), so the event never
+                        // fires and the image stays at opacity-0 with only the
+                        // blurhash showing. Reconcile from the DOM on mount: if
+                        // it is already complete, reveal it; if it already failed,
+                        // fall back.
+                        if (!node) return;
+                        if (node.complete) {
+                            if (node.naturalWidth > 0) setIsLoaded(true);
+                            else { setHasError(true); onError?.(); }
+                        }
+                    }}
                     src={resolvedSrc}
                     srcSet={imgSrcSet || undefined}
                     sizes={sizes}

--- a/content/updates/2026-07-03-fix-stale-prerender-hints.md
+++ b/content/updates/2026-07-03-fix-stale-prerender-hints.md
@@ -1,0 +1,19 @@
+---
+id: rel-2026-07-03-fix-stale-prerender-hints
+version: v0.0.0
+title: "Landing pages fully interactive on load"
+date: 2026-07-03
+published_at: 2026-07-03T11:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Fixes landing pages loading in a half-working state (missing images, footer, banners, active nav) until you clicked to another page."
+---
+
+## Changes
+- [x] [Fixed] 🧩 Landing pages now become fully interactive on first load — the active navigation, card images, footer, cookie/language banners and the features globe all appear without needing to click to another page first.
+- [x] [Fixed] 🖼️ Card images always reveal even when they load from cache faster than the page finishes starting up (previously they could stay stuck on the blurred placeholder).
+- [ ] [Internal] Root cause: the prerender step could attach to a stale leftover preview server, baking modulepreload hints that referenced chunk hashes absent from the deployed build; those requests fell through to the SPA-fallback HTML (text/html), failed MIME checks, and broke hydration. Hardened: prerender aborts if its port is occupied, uses --strictPort, and only emits hints for chunks present in the build.
+- [ ] [Internal] Added a build-time safety gate that fails the prerender if any generated page references a JS asset missing from the build (prevents shipping a dangling-chunk regression).
+- [ ] [Internal] Defined distDir in the prerender main() scope (was only in the critical-CSS helper), which had silently disabled the image-CDN proxy during capture.
+- [ ] [Internal] ProgressiveImage reconciles image load state from the DOM on mount (img.complete) so a load event that fires before hydration no longer leaves the image hidden.

--- a/scripts/prerender-routes.mjs
+++ b/scripts/prerender-routes.mjs
@@ -139,6 +139,11 @@ async function inlineCriticalCss() {
 }
 
 async function main() {
+  // Build output directory, used by the image-CDN proxy and the modulepreload
+  // hint existence check below. (Previously only defined inside
+  // inlineCriticalCss(), so these references silently threw at runtime.)
+  const distDir = path.join(projectRoot, 'dist');
+
   if (process.env.TF_INLINE_CRITICAL_CSS === '1') {
     try {
       await inlineCriticalCss();
@@ -150,8 +155,28 @@ async function main() {
   }
 
   console.log('Starting preview server for pre-rendering...');
-  
-  const serverProcess = spawn('pnpm', ['exec', 'vite', 'preview', '--port', String(PORT)], {
+
+  // Abort if something is already listening on our port. Without this a stray
+  // `vite preview` (e.g. left over from manual testing) keeps the port and our
+  // own `vite preview` silently starts on a different one — we would then
+  // prerender against the STALE server's dist, shipping HTML + modulepreload
+  // hints that reference chunk hashes which no longer exist in the deployed
+  // assets (every chunk then falls through to the SPA fallback as text/html,
+  // MIME-errors, and hydration dies). Fail loudly instead.
+  const portAlreadyInUse = await new Promise((resolve) => {
+    const req = http.get(`${BASE_URL}/`, () => resolve(true));
+    req.on('error', () => resolve(false));
+    req.setTimeout(500, () => { req.destroy(); resolve(false); });
+    req.end();
+  });
+  if (portAlreadyInUse) {
+    console.error(`Port ${PORT} is already in use. Refusing to prerender against a foreign server (would ship stale asset hashes). Stop the other process and retry.`);
+    process.exit(1);
+  }
+
+  // --strictPort so our preview owns the port or fails outright — never
+  // silently starts elsewhere while we poll the wrong server.
+  const serverProcess = spawn('pnpm', ['exec', 'vite', 'preview', '--port', String(PORT), '--strictPort'], {
     cwd: projectRoot,
     stdio: 'ignore',
     detached: true
@@ -358,15 +383,28 @@ async function main() {
       // setupBootstrapShellHandoff early-returns when the element is absent).
       const stripResult = stripBootstrapShell(outputHtml);
       outputHtml = stripResult.html;
-      if (!stripResult.removedShell || !stripResult.removedStyle || !stripResult.removedScript) {
+      // Note: the boot-shell <style> is intentionally KEPT (the runtime
+      // navigation shell reuses those classes — see stripBootstrapShell), so we
+      // only assert the shell markup + hide-script were removed.
+      if (!stripResult.removedShell || !stripResult.removedScript) {
         console.warn(
           `WARNING: boot shell strip incomplete for ${route.path} ` +
-          `(shell: ${stripResult.removedShell}, style: ${stripResult.removedStyle}, script: ${stripResult.removedScript})`
+          `(shell: ${stripResult.removedShell}, script: ${stripResult.removedScript})`
         );
       }
 
       // Inject per-route modulepreload hints (entry-first request order).
-      const preloadHrefs = collectModulePreloadHrefs(requestedAssetUrls);
+      // Defense in depth: only hint chunks that actually exist in this build's
+      // dist/assets. A hint to a missing hash resolves to the SPA-fallback HTML
+      // (text/html), which the browser rejects as a module — so a stale hint
+      // would silently break hydration. Dropping unknown hrefs guarantees we
+      // never ship one, even if hint collection ever races the build again.
+      const allPreloadHrefs = collectModulePreloadHrefs(requestedAssetUrls);
+      const preloadHrefs = allPreloadHrefs.filter((href) => fs.existsSync(path.join(distDir, href.replace(/^\/+/, ''))));
+      const droppedHints = allPreloadHrefs.length - preloadHrefs.length;
+      if (droppedHints > 0) {
+        console.warn(`WARNING: dropped ${droppedHints} modulepreload hint(s) for ${route.path} that do not exist in dist/assets (stale build?).`);
+      }
       outputHtml = injectModulePreloadHints(outputHtml, preloadHrefs);
       console.log(`Injected ${preloadHrefs.length} modulepreload hints for ${route.path}`);
 
@@ -390,6 +428,34 @@ async function main() {
   console.log('Pre-rendering complete! Closing browser and server...');
   await browser.close();
   cleanup();
+
+  // Final safety gate: no prerendered page may reference a JS asset that does
+  // not exist in this build. A dangling /assets/*.js reference is served the
+  // SPA-fallback HTML (text/html), rejected as a module, and silently breaks
+  // hydration on production — the exact failure this guard exists to catch.
+  let danglingRefs = 0;
+  const assetRefPattern = /(?:href|src)="(\/assets\/[^"']+\.js)"/g;
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) { walk(full); continue; }
+      if (!entry.name.endsWith('.html')) continue;
+      const html = fs.readFileSync(full, 'utf8');
+      for (const match of html.matchAll(assetRefPattern)) {
+        const ref = match[1];
+        if (!fs.existsSync(path.join(distDir, ref.replace(/^\/+/, '')))) {
+          danglingRefs += 1;
+          console.error(`DANGLING ASSET REF in ${path.relative(distDir, full)}: ${ref}`);
+        }
+      }
+    }
+  };
+  walk(distDir);
+  if (danglingRefs > 0) {
+    console.error(`\nAborting: ${danglingRefs} prerendered asset reference(s) point to files missing from this build.`);
+    process.exit(1);
+  }
+
   process.exit(failedRoutes > 0 ? 1 : 0);
 }
 


### PR DESCRIPTION
Part of #408. Fixes the production regression where landing pages loaded in a broken state — no active-nav underline, card images stuck on blurhash, **missing footer (large gap)**, no language/cookie banners, no features globe — until the user navigated to another page.

## Root cause (found by probing production)
Every JS chunk on the live pages was being served as `text/html` (the SPA fallback), so module scripts failed MIME checks and **hydration silently died**. The deployed `blog.html` had **46/55 modulepreload hints pointing at chunk hashes that don't exist** in the deployed assets.

Why: the prerender step (`scripts/prerender-routes.mjs`) starts a `vite preview` on port 4173, but when a stray preview server (left over from local testing) already held that port, vite quietly started elsewhere while the script kept polling 4173 — so it **prerendered against a stale server's older dist**, baking obsolete asset hashes into the shipped HTML.

## Fixes
- **Prerender can't attach to a foreign server:** abort if the port is already in use, and run `vite preview --strictPort`.
- **Hint existence filter:** only emit modulepreload hints for chunks present in this build.
- **Build-time safety gate:** the prerender now fails if *any* generated page references a JS asset missing from the build — a dangling-chunk regression can never deploy again.
- **`distDir` defined in `main()`** (was only in the critical-CSS helper) — it had silently disabled the image-CDN proxy during capture.
- **ProgressiveImage** reconciles load state from `img.complete` on mount, so an image that finishes loading before hydration still reveals (the 'only blurhash shows' symptom on warm caches).

## Verified
- Clean build: **0 dangling asset refs** across all prerendered pages; blog 5 / inspirations 24 card `<picture>`s.
- Local hydration completes ~210ms with **0 MIME errors**; nav underline, footer, and globe all present after load+scroll.
- `test:core`: 324 files pass. Added tests for the prerender hint/state helpers.

Note (cookie banner): it is intentionally deferred (~4s or first interaction) as a documented LCP optimization, so appearing after a moment/scroll is by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)