### PR TITLE
fix: footer + below-fold sections never mount in Safari (IntersectionObserver gate)

### DIFF
--- a/components/marketing/MarketingLayout.tsx
+++ b/components/marketing/MarketingLayout.tsx
@@ -25,29 +25,22 @@ interface MarketingLayoutProps {
 export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children, rootClassName }) => {
     const { openTripManager, prewarmTripManager } = useTripManager();
     const { t } = useTranslation('common');
-    // Footer stays IntersectionObserver-gated (lazy) on both prerender and
-    // client so hydration matches; it mounts just after hydration near scroll.
+    // The footer is lazy-loaded but NOT gated on IntersectionObserver: in
+    // WebKit/Safari the observer never fired here, so the footer never mounted
+    // (missing footer + large empty gap). Mount it once, right after hydration
+    // (idle callback) — reliable across browsers. First render keeps the empty
+    // spacer, matching the prerendered markup for clean hydration.
     const [shouldLoadFooter, setShouldLoadFooter] = useState(false);
     const footerRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
         if (shouldLoadFooter) return;
-        const node = footerRef.current;
-        if (!node || typeof IntersectionObserver === 'undefined') {
-            setShouldLoadFooter(true);
-            return;
-        }
-
-        const observer = new IntersectionObserver((entries) => {
-            if (!entries.some((entry) => entry.isIntersecting)) return;
-            setShouldLoadFooter(true);
-            observer.disconnect();
-        }, { rootMargin: '400px' });
-
-        observer.observe(node);
-
+        const reveal = () => setShouldLoadFooter(true);
+        const ric = window.requestIdleCallback;
+        const handle = ric ? ric(reveal, { timeout: 1500 }) : window.setTimeout(reveal, 200);
         return () => {
-            observer.disconnect();
+            if (ric && window.cancelIdleCallback) window.cancelIdleCallback(handle);
+            else window.clearTimeout(handle);
         };
     }, [shouldLoadFooter]);
 

--- a/content/updates/2026-07-03-fix-webkit-belowfold.md
+++ b/content/updates/2026-07-03-fix-webkit-belowfold.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-07-03-fix-webkit-belowfold
+version: v0.0.0
+title: "Full page content loads in Safari"
+date: 2026-07-03
+published_at: 2026-07-03T12:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Fixes the footer and below-the-hero sections not appearing in Safari, which left a large empty gap on landing pages."
+---
+
+## Changes
+- [x] [Fixed] 🧭 Landing pages now show the footer and all below-the-hero sections in Safari — previously they could stay empty, leaving a large gap under the page.
+- [ ] [Internal] Below-fold marketing sections and the footer were gated on IntersectionObserver, whose callbacks did not fire for these elements in WebKit/Safari, so the lazy content never mounted. Replaced the IO gate with a one-shot idle-callback mount right after hydration (with a setTimeout fallback), which is reliable across browsers and still keeps the hero's first paint unblocked. First render keeps the empty spacers, matching prerendered markup for clean hydration.

--- a/pages/MarketingHomePage.tsx
+++ b/pages/MarketingHomePage.tsx
@@ -24,81 +24,32 @@ const CtaBanner = lazyWithRecovery(
 );
 
 export const MarketingHomePage: React.FC = () => {
-    // Below-fold sections stay IntersectionObserver-gated (lazy) on every
-    // render — prerender and client alike start with the empty spacers, so
-    // hydration matches and they mount just after hydration once scrolled near.
-    // Rendering them eagerly regressed LCP substantially without a real UX win.
-    const [shouldLoadCarousel, setShouldLoadCarousel] = useState(false);
+    // Below-fold sections are lazy-loaded but NOT gated on IntersectionObserver:
+    // in WebKit/Safari the observer callbacks did not fire for these sections,
+    // so the marketing blocks and footer never mounted and the page showed empty
+    // spacers with a large gap. Instead we mount them once, right after hydration
+    // (idle callback) — reliable in every browser and it does not block the
+    // hero's first paint. The first render still shows the empty spacers, which
+    // matches the prerendered markup so hydration stays clean.
+    const [shouldLoadDeferred, setShouldLoadDeferred] = useState(false);
     const carouselSectionRef = useRef<HTMLDivElement | null>(null);
-
-    const [shouldLoadShowcase, setShouldLoadShowcase] = useState(false);
     const showcaseSectionRef = useRef<HTMLDivElement | null>(null);
-
-    const [shouldLoadCta, setShouldLoadCta] = useState(false);
     const ctaSectionRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
-        if (shouldLoadCarousel) return;
-        const node = carouselSectionRef.current;
-        if (!node || typeof IntersectionObserver === 'undefined') {
-            setShouldLoadCarousel(true);
-            return;
-        }
-
-        const observer = new IntersectionObserver((entries) => {
-            if (!entries.some((entry) => entry.isIntersecting)) return;
-            setShouldLoadCarousel(true);
-            observer.disconnect();
-        }, { rootMargin: '100px' });
-
-        observer.observe(node);
-
+        if (shouldLoadDeferred) return;
+        const reveal = () => setShouldLoadDeferred(true);
+        const ric = window.requestIdleCallback;
+        const handle = ric ? ric(reveal, { timeout: 1500 }) : window.setTimeout(reveal, 200);
         return () => {
-            observer.disconnect();
+            if (ric && window.cancelIdleCallback) window.cancelIdleCallback(handle);
+            else window.clearTimeout(handle);
         };
-    }, [shouldLoadCarousel]);
+    }, [shouldLoadDeferred]);
 
-    useEffect(() => {
-        if (shouldLoadShowcase) return;
-        const node = showcaseSectionRef.current;
-        if (!node || typeof IntersectionObserver === 'undefined') {
-            setShouldLoadShowcase(true);
-            return;
-        }
-
-        const observer = new IntersectionObserver((entries) => {
-            if (!entries.some((entry) => entry.isIntersecting)) return;
-            setShouldLoadShowcase(true);
-            observer.disconnect();
-        }, { rootMargin: '200px' });
-
-        observer.observe(node);
-
-        return () => {
-            observer.disconnect();
-        };
-    }, [shouldLoadShowcase]);
-
-    useEffect(() => {
-        if (shouldLoadCta) return;
-        const node = ctaSectionRef.current;
-        if (!node || typeof IntersectionObserver === 'undefined') {
-            setShouldLoadCta(true);
-            return;
-        }
-
-        const observer = new IntersectionObserver((entries) => {
-            if (!entries.some((entry) => entry.isIntersecting)) return;
-            setShouldLoadCta(true);
-            observer.disconnect();
-        }, { rootMargin: '200px' });
-
-        observer.observe(node);
-
-        return () => {
-            observer.disconnect();
-        };
-    }, [shouldLoadCta]);
+    const shouldLoadCarousel = shouldLoadDeferred;
+    const shouldLoadShowcase = shouldLoadDeferred;
+    const shouldLoadCta = shouldLoadDeferred;
 
     return (
         <MarketingLayout>


### PR DESCRIPTION
Part of #408. Fixes landing pages in Safari showing the hero but **no footer and no below-the-hero sections** — a large empty gap. Reproduced in WebKit: after a full scroll the body stayed hero-only (~493 chars) with 4 empty spacers.

## Cause
Below-fold marketing sections (`MarketingHomePage`) and the footer (`MarketingLayout`) were gated behind an `IntersectionObserver`. Its callbacks **do not fire for these elements in WebKit/Safari** even when scrolled into view, so the lazy content never mounted. Chromium was unaffected, which is why headless-Chromium checks passed while real Safari failed.

## Fix
Replaced the IO gate with a one-shot `requestIdleCallback` (`setTimeout` fallback) that mounts the deferred sections + footer **right after hydration** — reliable in every browser, still off the hero's first-paint critical path. First render keeps the empty spacers, matching prerendered markup so hydration stays clean. (`FeaturesBentoGrid`'s IO is only a visual-prefetch enhancement with a scroll fallback, so it's left as-is.)

## Verified (WebKit, no scrolling)
Footer mounts with its links and all below-fold sections render on `/`, `/blog`, `/features`, `/inspirations` — homepage body 493 → 2423 chars. `test:core` 324 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)