### PR TITLE
fix: reliable cross-browser hydration (preact/compat suspend + first-render mismatch)

### DIFF
--- a/LIGHTHOUSE.md
+++ b/LIGHTHOUSE.md
@@ -53,6 +53,29 @@ following were each shipped as regressions and then fixed, so keep them intact:
    the inline `tf-boot-*` classes; stripping that style block caused a
    full-screen white flash on every page switch.
 
+5. **preact/compat hydration ≠ React 18 hydration — this is the big one.**
+   Under `preact/compat` a component that **suspends during hydration** does NOT
+   retain the prerendered DOM (React 18 does); preact swaps in the Suspense
+   fallback. So two hard rules:
+   - **The first client render must not suspend at/above the root.** i18next runs
+     with `useSuspense: true` and `AppContent` reads 6 namespaces above the
+     route boundary — so `index.tsx` **awaits the app-shell namespaces (bounded
+     timeout) before `hydrateRoot`**. Never let that boundary trip; and the root
+     Suspense fallback is the boot-shell skeleton with `data-tf-handoff-ready`,
+     **never `null`** (a null fallback = intermittent blank page).
+   - **The first client render must be byte-identical to the prerender capture.**
+     A mismatch makes preact tear the subtree down (missing footer/sections,
+     flash). Deferred/lazy content (below-fold marketing sections, footer) must
+     render the SAME way on both sides: they stay empty spacers during capture
+     (`isPrerenderCapture()`) AND on the client's first render, then mount right
+     after hydration via `requestIdleCallback` — **not IntersectionObserver**,
+     whose callbacks did not fire for these elements in WebKit/Safari. Content
+     that IS captured into the HTML (image `<picture>` cards) must instead render
+     eagerly on the client's first render (`isPrerenderedDocument()`), matching
+     the capture.
+   - **Always test in WebKit, not just Chromium.** Several of these bugs
+     reproduced only in Safari's engine (`npx playwright` `webkit`).
+
 ### Latest local audits (2026-07-03, `vite preview`; CDN images 404 locally so real LCP is better)
 | Page | Score | FCP | LCP | TBT | CLS |
 | --- | :---: | :---: | :---: | :---: | :---: |

--- a/components/marketing/MarketingLayout.tsx
+++ b/components/marketing/MarketingLayout.tsx
@@ -5,6 +5,7 @@ import { LanguageSuggestionBanner } from '../navigation/LanguageSuggestionBanner
 import { useTripManager } from '../../contexts/TripManagerContext';
 import { cn } from '../../lib/utils';
 import { loadLazyComponentWithRecovery } from '../../services/lazyImportRecovery';
+import { isPrerenderCapture } from '../../services/prerenderHydrationState';
 import { useTranslation } from 'react-i18next';
 
 const lazyWithRecovery = <TModule extends { default: React.ComponentType<any> },>(
@@ -25,16 +26,18 @@ interface MarketingLayoutProps {
 export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children, rootClassName }) => {
     const { openTripManager, prewarmTripManager } = useTripManager();
     const { t } = useTranslation('common');
-    // The footer is lazy-loaded but NOT gated on IntersectionObserver: in
-    // WebKit/Safari the observer never fired here, so the footer never mounted
-    // (missing footer + large empty gap). Mount it once, right after hydration
-    // (idle callback) — reliable across browsers. First render keeps the empty
-    // spacer, matching the prerendered markup for clean hydration.
+    // The footer is lazy and mounts right after hydration via an idle callback
+    // — NOT gated on IntersectionObserver (its callbacks did not fire in
+    // WebKit/Safari, so the footer never mounted → missing footer + big gap).
+    // First render shows the empty spacer on BOTH the prerender capture and the
+    // client, so hydration matches exactly (no preact/compat teardown). During
+    // capture we hold the spacer (isPrerenderCapture) so the prerendered HTML
+    // stays light; the client fills it on idle just after hydration.
     const [shouldLoadFooter, setShouldLoadFooter] = useState(false);
     const footerRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
-        if (shouldLoadFooter) return;
+        if (shouldLoadFooter || isPrerenderCapture()) return;
         const reveal = () => setShouldLoadFooter(true);
         const ric = window.requestIdleCallback;
         const handle = ric ? ric(reveal, { timeout: 1500 }) : window.setTimeout(reveal, 200);

--- a/content/updates/2026-07-03-fix-hydration-first-render-match.md
+++ b/content/updates/2026-07-03-fix-hydration-first-render-match.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-07-03-fix-hydration-first-render-match
+version: v0.0.0
+title: "Reliable landing-page loads across browsers"
+date: 2026-07-03
+published_at: 2026-07-03T13:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Fixes the intermittent broken landing-page load (missing footer/sections, occasional blank) across Chrome and Safari."
+---
+
+## Changes
+- [x] [Fixed] 🧩 Landing pages now load reliably and completely in every browser — the intermittent broken state (missing footer and below-hero sections, occasional blank page) is resolved, in both Chrome and Safari.
+- [ ] [Internal] Root cause was preact/compat hydration (not React 18): when the first client render suspended (async i18n above the route Suspense boundary) or diverged from the prerendered markup (deferred sections rendered as empty spacers while the capture held full content), preact tore the tree down — blanking to the root `fallback={null}` or dropping the footer. Fixes: (1) await the app-shell i18n namespaces before hydrating (bounded timeout) so the first render never suspends on translations; (2) the root Suspense fallback now renders the boot-shell skeleton (never blank) and carries the handoff marker; (3) deferred marketing sections + footer render as empty spacers on BOTH the prerender capture and the client's first render, then mount right after hydration via an idle callback (never IntersectionObserver, whose callbacks did not fire in WebKit/Safari), so hydration matches exactly and content still appears reliably.
+- [ ] [Internal] Documented preact/compat hydration invariants (first render must match capture and must not suspend at the root) in LIGHTHOUSE.md.

--- a/index.tsx
+++ b/index.tsx
@@ -8,6 +8,7 @@ import { extractLocaleFromPath, isToolRoute } from './config/routes';
 import { hasRenderableHandoffNode } from './services/bootstrapHandoffService';
 import { preloadCriticalRouteModules } from './services/criticalRoutePreload';
 import { shouldHydrateReactRoot } from './services/reactRootRenderMode';
+import { AppBootstrapShell } from './components/bootstrap/AppBootstrapShell';
 
 interface ErrorBoundaryProps {
   children?: ReactNode;
@@ -118,9 +119,21 @@ if (typeof window !== 'undefined') {
   applyDocumentLocale(initialLocale);
 }
 
+// Root fallback must never be blank: under preact/compat a suspend at this
+// boundary replaces the tree with the fallback, so `null` = white screen. We
+// render the marketing boot-shell skeleton and tag it data-tf-handoff-ready so
+// the boot-shell handoff still completes (the shell is never left stuck). In
+// practice the i18n preload below keeps this boundary from tripping at all;
+// this is defense in depth.
+const RootFallback = () => (
+  <div data-tf-handoff-ready="true">
+    <AppBootstrapShell variant="marketing" testId="root-suspense-fallback" />
+  </div>
+);
+
 const appNode = (
   <React.StrictMode>
-    <Suspense fallback={null}>
+    <Suspense fallback={<RootFallback />}>
       <ErrorBoundary>
         <App />
       </ErrorBoundary>
@@ -155,18 +168,34 @@ const mountReactRoot = () => {
   }
 };
 
-// Mount immediately. Hydration reuses the prerendered DOM in place and keeps
-// it on screen while React attaches (verified: no blank flash even while the
-// i18n namespaces are still loading — a suspending subtree retains its
-// server-rendered DOM during hydration). Delaying the mount behind a preload
-// gate was a regression: it left prerendered pages non-interactive for several
-// seconds on cold loads (no nav highlight, no banners, and card images/globe/
-// below-fold sections never upgraded until the gate elapsed). Route modules and
-// the app-shell i18n namespaces are still warmed in the background so hydration
-// settles as soon as they arrive.
+// preact/compat (unlike React 18) does not keep the prerendered DOM on screen
+// when the tree suspends during hydration — it swaps in the Suspense fallback.
+// AppContent calls useTranslation(APP_SHELL_NAMESPACES) with useSuspense above
+// the route-level boundary, so if those namespaces aren't in the i18next store
+// when the first render runs, the whole tree suspends to the root fallback.
+// That was the intermittent blank/partial load. So we await the app-shell
+// namespaces before mounting — a small, same-origin JSON fetch (and preloaded
+// via modulepreload), bounded by a timeout so a slow network can never block
+// the mount. Route modules stay a non-blocking background warmup. The
+// prerendered markup remains visible during this short wait; only interactivity
+// waits, and it needs the same namespaces anyway.
+const MOUNT_I18N_TIMEOUT_MS = 1500;
+
+const warmShellI18nThenMount = async () => {
+  if (typeof window !== 'undefined') {
+    void preloadCriticalRouteModules(window.location.pathname);
+    const locale = document.documentElement.lang || DEFAULT_LOCALE;
+    try {
+      await Promise.race([
+        preloadLocaleNamespaces(locale, APP_SHELL_NAMESPACES),
+        new Promise((resolve) => { window.setTimeout(resolve, MOUNT_I18N_TIMEOUT_MS); }),
+      ]);
+    } catch {
+      // Ignore preload failures — mount anyway; i18n falls back to keys/default.
+    }
+  }
+  mountReactRoot();
+};
+
 setupBootstrapShellHandoff(rootElement);
-if (typeof window !== 'undefined') {
-  void preloadCriticalRouteModules(window.location.pathname);
-  void preloadLocaleNamespaces(document.documentElement.lang || DEFAULT_LOCALE, APP_SHELL_NAMESPACES);
-}
-mountReactRoot();
+void warmShellI18nThenMount();

--- a/pages/MarketingHomePage.tsx
+++ b/pages/MarketingHomePage.tsx
@@ -2,6 +2,7 @@ import React, { Suspense, lazy, useEffect, useRef, useState } from 'react';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
 import { HeroSection } from '../components/marketing/HeroSection';
 import { loadLazyComponentWithRecovery } from '../services/lazyImportRecovery';
+import { isPrerenderCapture } from '../services/prerenderHydrationState';
 
 const lazyWithRecovery = <TModule extends { default: React.ComponentType<any> },>(
     moduleKey: string,
@@ -24,20 +25,20 @@ const CtaBanner = lazyWithRecovery(
 );
 
 export const MarketingHomePage: React.FC = () => {
-    // Below-fold sections are lazy-loaded but NOT gated on IntersectionObserver:
-    // in WebKit/Safari the observer callbacks did not fire for these sections,
-    // so the marketing blocks and footer never mounted and the page showed empty
-    // spacers with a large gap. Instead we mount them once, right after hydration
-    // (idle callback) — reliable in every browser and it does not block the
-    // hero's first paint. The first render still shows the empty spacers, which
-    // matches the prerendered markup so hydration stays clean.
+    // Below-fold sections are lazy and mount right after hydration via an idle
+    // callback — NOT gated on IntersectionObserver (its callbacks did not fire
+    // in WebKit/Safari, so the sections never mounted). The first render shows
+    // empty spacers on BOTH the prerender capture and the client, so hydration
+    // matches exactly (no preact/compat teardown/flash). During capture we hold
+    // the spacers (isPrerenderCapture) instead of letting the idle callback fill
+    // them, which keeps the prerendered HTML light and the hero's LCP fast.
     const [shouldLoadDeferred, setShouldLoadDeferred] = useState(false);
     const carouselSectionRef = useRef<HTMLDivElement | null>(null);
     const showcaseSectionRef = useRef<HTMLDivElement | null>(null);
     const ctaSectionRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
-        if (shouldLoadDeferred) return;
+        if (shouldLoadDeferred || isPrerenderCapture()) return;
         const reveal = () => setShouldLoadDeferred(true);
         const ric = window.requestIdleCallback;
         const handle = ric ? ric(reveal, { timeout: 1500 }) : window.setTimeout(reveal, 200);

--- a/services/prerenderHydrationState.ts
+++ b/services/prerenderHydrationState.ts
@@ -1,25 +1,27 @@
 import { PRERENDERED_ROOT_ATTRIBUTE } from './reactRootRenderMode';
 
+type PrerenderWindow = { __TF_PRERENDER_EAGER__?: boolean };
+
 /**
- * True when the current document was served as a prerendered snapshot (the
- * prerender script tags #root with data-tf-prerendered-root).
- *
- * IntersectionObserver-gated sections (below-fold marketing blocks, the footer)
- * must render eagerly on the FIRST client render of such a page so it matches
- * the prerendered markup — otherwise hydration reconciles full server content
- * against empty client spacers and rebuilds the subtree (visible flash + CLS).
- * The check is synchronous so it can seed useState initializers, and it is
- * evaluated identically during prerender capture (attribute absent → normal
- * lazy/IO behaviour, which the prerender scroll pass trips) and on the client
- * (attribute present → eager), keeping both renders in agreement.
+ * True only while the page is being captured by the prerender script (which
+ * injects this synchronous flag via addInitScript). Never true on a real
+ * client. Used to keep deferred/idle-mounted content in its EMPTY state during
+ * capture, so the prerendered HTML matches the client's first render (which
+ * also starts empty), avoiding a preact/compat hydration mismatch.
+ */
+export const isPrerenderCapture = (): boolean =>
+  typeof window !== 'undefined' && !!(window as unknown as PrerenderWindow).__TF_PRERENDER_EAGER__;
+
+/**
+ * True when the current document was served as a prerendered snapshot: during
+ * capture (via the injected flag) OR on the client that received prerendered
+ * markup (via the data-tf-prerendered-root attribute the script adds). Used by
+ * content that must render eagerly and identically on both sides — e.g. image
+ * cards whose <picture> is captured into the HTML.
  */
 export const isPrerenderedDocument = (): boolean => {
   if (typeof document === 'undefined') return false;
-  // During prerender capture the root is not yet tagged (the script adds the
-  // attribute after capture), so the prerender injects this synchronous flag
-  // via addInitScript. Honouring both keeps the captured markup and the
-  // client's first hydration render in agreement.
-  if ((window as unknown as { __TF_PRERENDER_EAGER__?: boolean }).__TF_PRERENDER_EAGER__) return true;
+  if (isPrerenderCapture()) return true;
   const root = document.getElementById('root');
   return !!root && root.hasAttribute(PRERENDERED_ROOT_ATTRIBUTE);
 };

--- a/tests/unit/prerenderHydrationState.test.ts
+++ b/tests/unit/prerenderHydrationState.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { isPrerenderedDocument } from '../../services/prerenderHydrationState';
+import { isPrerenderCapture, isPrerenderedDocument } from '../../services/prerenderHydrationState';
 import { PRERENDERED_ROOT_ATTRIBUTE } from '../../services/reactRootRenderMode';
 
 const cleanup = () => {
@@ -34,5 +34,20 @@ describe('isPrerenderedDocument', () => {
     root.id = 'root';
     document.body.appendChild(root);
     expect(isPrerenderedDocument()).toBe(true);
+  });
+});
+
+describe('isPrerenderCapture', () => {
+  it('is false on a real client, even a prerendered one (attribute present, no flag)', () => {
+    const root = document.createElement('div');
+    root.id = 'root';
+    root.setAttribute(PRERENDERED_ROOT_ATTRIBUTE, 'true');
+    document.body.appendChild(root);
+    expect(isPrerenderCapture()).toBe(false);
+  });
+
+  it('is true only while the prerender capture flag is set', () => {
+    (window as unknown as { __TF_PRERENDER_EAGER__?: boolean }).__TF_PRERENDER_EAGER__ = true;
+    expect(isPrerenderCapture()).toBe(true);
   });
 });


### PR DESCRIPTION
Part of #408. Fixes the intermittent broken landing-page load — missing footer / below-hero sections, occasional blank — in **both Chrome and Safari** (worse in Safari).

## Root cause
It's a **preact/compat** hydration problem, not React 18. preact/compat does **not** retain the prerendered DOM when the first client render suspends or mismatches — it swaps in the Suspense fallback (blank if `null`) or tears the subtree down. Two triggers:
1. **Suspend on async i18n:** `AppContent` reads 6 i18n namespaces with `useSuspense` **above** the route Suspense boundary. If they aren't loaded when the first render runs, the whole tree suspends to the root `fallback={null}` → **blank** (timing-dependent → intermittent).
2. **First-render mismatch:** deferred sections + footer rendered empty spacers on the client, but the prerender captured them full (the idle callback fired during the long prerender wait) → preact rebuilds the subtree → **missing footer/flash**. The prior IntersectionObserver gate also never fired in WebKit, compounding it.

## Fixes
1. `index.tsx` **awaits the app-shell i18n namespaces before `hydrateRoot`** (bounded 1.5s timeout; route modules stay a background warmup) so the first render never suspends on translations.
2. Root Suspense fallback now renders the **boot-shell skeleton with `data-tf-handoff-ready`**, never `null`.
3. Deferred sections + footer render as **empty spacers on BOTH the prerender capture and the client's first render** (`isPrerenderCapture()` holds them during capture), then mount right after hydration via `requestIdleCallback` — reliable in every browser, and hydration matches exactly.

## Verified
- **Chromium + WebKit**, cold, no scroll, repeated: footer (5 links) + nav highlight present, **0 empty-flash, 0 MIME errors**.
- Lighthouse: Home **82** / Features **81** / Pricing **84** (LCP recovered vs the eager approach).
- `test:core` 324 files pass. preact/compat hydration invariants documented in `LIGHTHOUSE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)