### PR TITLE
fix: guarantee deferred footer/section mount in Safari (rIC unreliable)

### DIFF
--- a/components/marketing/MarketingLayout.tsx
+++ b/components/marketing/MarketingLayout.tsx
@@ -38,12 +38,19 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children, root
 
     useEffect(() => {
         if (shouldLoadFooter || isPrerenderCapture()) return;
-        const reveal = () => setShouldLoadFooter(true);
-        const ric = window.requestIdleCallback;
-        const handle = ric ? ric(reveal, { timeout: 1500 }) : window.setTimeout(reveal, 200);
+        let done = false;
+        const reveal = () => { if (!done) { done = true; setShouldLoadFooter(true); } };
+        // Guaranteed timer: requestIdleCallback is unreliable in WebKit/Safari
+        // (throttled even with a timeout), which left the footer/sections
+        // unmounted there. A plain setTimeout fires in every browser just after
+        // the hero has painted; rIC is only an optional earlier fast-path.
+        const timer = window.setTimeout(reveal, 250);
+        const ricId = typeof window.requestIdleCallback === 'function'
+            ? window.requestIdleCallback(reveal, { timeout: 250 })
+            : undefined;
         return () => {
-            if (ric && window.cancelIdleCallback) window.cancelIdleCallback(handle);
-            else window.clearTimeout(handle);
+            window.clearTimeout(timer);
+            if (ricId !== undefined && window.cancelIdleCallback) window.cancelIdleCallback(ricId);
         };
     }, [shouldLoadFooter]);
 

--- a/content/updates/2026-07-03-reliable-deferred-mount.md
+++ b/content/updates/2026-07-03-reliable-deferred-mount.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-07-03-reliable-deferred-mount
+version: v0.0.0
+title: "Footer reliably appears in Safari"
+date: 2026-07-03
+published_at: 2026-07-03T14:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "Ensures the footer and below-hero sections always mount in Safari, not just most of the time."
+---
+
+## Changes
+- [x] [Fixed] 🧭 The footer and below-hero sections now appear reliably on every load in Safari (previously they occasionally stayed missing on heavier pages).
+- [ ] [Internal] The deferred-section/footer mount used requestIdleCallback, which WebKit/Safari throttles unreliably even with a timeout, so on heavier pages (home, features) the content sometimes never mounted. Replaced with a guaranteed setTimeout (rIC kept only as an optional earlier fast-path); reveal is idempotent.

--- a/pages/MarketingHomePage.tsx
+++ b/pages/MarketingHomePage.tsx
@@ -39,12 +39,19 @@ export const MarketingHomePage: React.FC = () => {
 
     useEffect(() => {
         if (shouldLoadDeferred || isPrerenderCapture()) return;
-        const reveal = () => setShouldLoadDeferred(true);
-        const ric = window.requestIdleCallback;
-        const handle = ric ? ric(reveal, { timeout: 1500 }) : window.setTimeout(reveal, 200);
+        let done = false;
+        const reveal = () => { if (!done) { done = true; setShouldLoadDeferred(true); } };
+        // Guaranteed timer: requestIdleCallback is unreliable in WebKit/Safari
+        // (throttled even with a timeout), which left the footer/sections
+        // unmounted there. A plain setTimeout fires in every browser just after
+        // the hero has painted; rIC is only an optional earlier fast-path.
+        const timer = window.setTimeout(reveal, 250);
+        const ricId = typeof window.requestIdleCallback === 'function'
+            ? window.requestIdleCallback(reveal, { timeout: 250 })
+            : undefined;
         return () => {
-            if (ric && window.cancelIdleCallback) window.cancelIdleCallback(handle);
-            else window.clearTimeout(handle);
+            window.clearTimeout(timer);
+            if (ricId !== undefined && window.cancelIdleCallback) window.cancelIdleCallback(ricId);
         };
     }, [shouldLoadDeferred]);
 


### PR DESCRIPTION
Part of #408. Follow-up to #417.

After #417, WebKit still occasionally failed to mount the footer + below-hero sections on heavier pages (home, features) — because the deferred mount used `requestIdleCallback`, which WebKit/Safari throttles unreliably even with a `{timeout}`. In testing: blog 0/6 missing, but home/features ~1/3 missing.

**Fix:** replace rIC with a guaranteed `window.setTimeout(250ms)` (fires in every browser just after the hero paints); rIC kept only as an optional earlier fast-path, and `reveal` is idempotent so whichever fires first wins.

**Verified (WebKit, cold, no scroll, 6 runs each):** `/` and `/features` footer present 6/6 (was ~4/6). test:core 324 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)