### PR TITLE
fix: below-fold sections + footer as static prerendered markup (guaranteed presence, all browsers)

### DIFF
--- a/components/marketing/MarketingLayout.tsx
+++ b/components/marketing/MarketingLayout.tsx
@@ -5,7 +5,7 @@ import { LanguageSuggestionBanner } from '../navigation/LanguageSuggestionBanner
 import { useTripManager } from '../../contexts/TripManagerContext';
 import { cn } from '../../lib/utils';
 import { loadLazyComponentWithRecovery } from '../../services/lazyImportRecovery';
-import { isPrerenderCapture } from '../../services/prerenderHydrationState';
+import { isPrerenderedDocument } from '../../services/prerenderHydrationState';
 import { useTranslation } from 'react-i18next';
 
 const lazyWithRecovery = <TModule extends { default: React.ComponentType<any> },>(
@@ -33,11 +33,14 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children, root
     // client, so hydration matches exactly (no preact/compat teardown). During
     // capture we hold the spacer (isPrerenderCapture) so the prerendered HTML
     // stays light; the client fills it on idle just after hydration.
-    const [shouldLoadFooter, setShouldLoadFooter] = useState(false);
+    // Eager on prerendered pages so the footer is STATIC markup in the
+    // captured HTML — present even if client hydration is slow/interrupted.
+    // On the SPA fallback it mounts after hydration via the timer below.
+    const [shouldLoadFooter, setShouldLoadFooter] = useState(() => isPrerenderedDocument());
     const footerRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
-        if (shouldLoadFooter || isPrerenderCapture()) return;
+        if (shouldLoadFooter) return;
         let done = false;
         const reveal = () => { if (!done) { done = true; setShouldLoadFooter(true); } };
         // Guaranteed timer: requestIdleCallback is unreliable in WebKit/Safari

--- a/content/updates/2026-07-03-eager-belowfold-static.md
+++ b/content/updates/2026-07-03-eager-belowfold-static.md
@@ -1,0 +1,16 @@
+---
+id: rel-2026-07-03-eager-belowfold-static
+version: v0.0.0
+title: "Footer and sections always present"
+date: 2026-07-03
+published_at: 2026-07-03T15:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "The footer and below-hero sections are now baked into the page so they can never be missing, in any browser."
+---
+
+## Changes
+- [x] [Fixed] 🧱 The footer and below-hero sections are now part of the page's static HTML, so they are always visible immediately — even in Safari and even if the interactive layer is slow to start. This resolves the missing-footer / empty-gap reports for good.
+- [ ] [Internal] Diagnosis showed production WebKit intermittently did not complete client mounting (the SiteFooter chunk was never requested on ~1/4 cold loads), so any approach that mounts below-fold content via client JS could leave it missing. Switched to rendering the deferred sections + footer eagerly on prerendered pages (isPrerenderedDocument), so they are captured as static markup and no longer depend on the client mounting to appear. First render matches capture on both sides (clean hydration); the SPA fallback still mounts them just after hydration via a guaranteed timer.
+- [ ] [Internal] Trade-off: the homepage HTML is larger and LCP rises vs the lazy approach; reviving the critical-CSS inliner is the tracked follow-up to recover it. Reliability was prioritized per the incident.

--- a/pages/MarketingHomePage.tsx
+++ b/pages/MarketingHomePage.tsx
@@ -2,7 +2,7 @@ import React, { Suspense, lazy, useEffect, useRef, useState } from 'react';
 import { MarketingLayout } from '../components/marketing/MarketingLayout';
 import { HeroSection } from '../components/marketing/HeroSection';
 import { loadLazyComponentWithRecovery } from '../services/lazyImportRecovery';
-import { isPrerenderCapture } from '../services/prerenderHydrationState';
+import { isPrerenderedDocument } from '../services/prerenderHydrationState';
 
 const lazyWithRecovery = <TModule extends { default: React.ComponentType<any> },>(
     moduleKey: string,
@@ -32,13 +32,17 @@ export const MarketingHomePage: React.FC = () => {
     // matches exactly (no preact/compat teardown/flash). During capture we hold
     // the spacers (isPrerenderCapture) instead of letting the idle callback fill
     // them, which keeps the prerendered HTML light and the hero's LCP fast.
-    const [shouldLoadDeferred, setShouldLoadDeferred] = useState(false);
+    // Eager on prerendered pages so the sections are STATIC markup in the
+    // captured HTML — present even if client hydration is slow/interrupted
+    // (the robust guarantee). On the SPA fallback they mount after hydration
+    // via the timer below.
+    const [shouldLoadDeferred, setShouldLoadDeferred] = useState(() => isPrerenderedDocument());
     const carouselSectionRef = useRef<HTMLDivElement | null>(null);
     const showcaseSectionRef = useRef<HTMLDivElement | null>(null);
     const ctaSectionRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
-        if (shouldLoadDeferred || isPrerenderCapture()) return;
+        if (shouldLoadDeferred) return;
         let done = false;
         const reveal = () => { if (!done) { done = true; setShouldLoadDeferred(true); } };
         // Guaranteed timer: requestIdleCallback is unreliable in WebKit/Safari


### PR DESCRIPTION
Part of #408. Final fix for the recurring missing-footer / empty-gap / partial-load reports across Chrome and Safari.

## Why the previous fixes weren't enough
Diagnosis on production WebKit: on ~1/4 cold loads the client never completed mounting — the SiteFooter chunk was **never even requested** (no error, just no mount). So *any* approach that relies on client JS to mount below-fold content (IntersectionObserver, idle callback, timer) can leave the footer/sections missing in Safari.

## Fix
Render the below-fold sections + footer **eagerly on prerendered pages** (`useState(() => isPrerenderedDocument())`), so they are captured as **static markup in the HTML**. They are then present from first paint regardless of whether or when client JS runs — the robust guarantee. First render matches the capture on both sides, so preact/compat hydration stays clean; the SPA (non-prerendered) fallback still mounts them just after hydration via the guaranteed timer.

## Verified
WebKit: footer present within 300ms **6/6** on `/` and `/features` (static markup). `test:core` 324 files pass.

## Trade-off (disclosed)
The homepage HTML is larger and LCP rises vs the lazy approach (~71–73 local vs ~82). Reliability was prioritized per the incident; **reviving the critical-CSS inliner is the tracked follow-up** to recover LCP without sacrificing this guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)