### PR TITLE
fix: active-nav underline appears on direct load (preact/compat hydration)

### DIFF
--- a/components/navigation/SiteHeader.tsx
+++ b/components/navigation/SiteHeader.tsx
@@ -65,6 +65,17 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
 }) => {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
     const [pendingLocale, setPendingLocale] = useState<AppLanguage | null>(null);
+    // The active-nav underline is derived after mount, not on the first render.
+    // The prerendered markup has no active link, and preact/compat does NOT
+    // reconcile a className that only differs between the server DOM and the
+    // first client render during hydration — so computing "active" on the first
+    // render leaves the DOM stuck inactive (vnode already says active, so no
+    // later re-render patches it). Rendering inactive first (matching the
+    // server) and flipping `hydrated` in an effect makes the underline a real
+    // post-hydration change that preact applies. Same two-pass pattern the
+    // banners use.
+    const [hydrated, setHydrated] = useState(false);
+    useEffect(() => { setHydrated(true); }, []);
     const routeLocation = useSafeRouteLocation();
     const navigate = useNavigate();
     const { t, i18n } = useTranslation('common');
@@ -179,12 +190,21 @@ export const SiteHeader: React.FC<SiteHeaderProps> = ({
                     <nav className="hidden items-center gap-4 text-sm lg:flex xl:gap-6">
                         {(['features', 'inspirations', 'updates', 'blog', 'pricing'] as const).map((routeKey) => {
                             const path = buildLocalizedMarketingPath(routeKey, activeLocale);
+                            // Inactive on the first render (matches the prerendered markup);
+                            // after `hydrated` flips, derive the active link from the current
+                            // URL. window.location is correct from the first client render and
+                            // react-router updates it synchronously on navigation; referencing
+                            // routeLocation.pathname keeps this recomputing on route changes.
+                            const currentPath = ((hydrated && typeof window !== 'undefined' ? window.location.pathname : routeLocation.pathname) || '/').replace(/\/+$/, '') || '/';
+                            const linkPath = path.replace(/\/+$/, '') || '/';
+                            const isActive = hydrated && (currentPath === linkPath || currentPath.startsWith(`${linkPath}/`));
                             return (
                                 <NavLink
                                     key={routeKey}
                                     to={path}
                                     onClick={() => handleNavClick(routeKey)}
-                                    className={navLinkClass}
+                                    className={navLinkClass({ isActive })}
+                                    aria-current={isActive ? 'page' : undefined}
                                     {...navDebugAttributes(routeKey)}
                                 >
                                     {t(`nav.${routeKey}`)}

--- a/content/updates/2026-07-03-nav-active-underline.md
+++ b/content/updates/2026-07-03-nav-active-underline.md
@@ -1,0 +1,15 @@
+---
+id: rel-2026-07-03-nav-active-underline
+version: v0.0.0
+title: "Current page is highlighted in the nav"
+date: 2026-07-03
+published_at: 2026-07-03T17:00:00Z
+status: draft
+notify_in_app: false
+in_app_hours: 24
+summary: "The active navigation item is now underlined immediately on load, not only after switching pages."
+---
+
+## Changes
+- [x] [Fixed] 🧭 The navigation now highlights the page you're on right away when you open it directly — previously the underline only appeared after switching to another page.
+- [ ] [Internal] The active state was derived on the first render, but preact/compat does not reconcile a className that differs only between the prerendered DOM and the first client render during hydration, so the DOM stayed stuck inactive. Fixed with the two-pass pattern: render inactive first (matching the prerendered markup), then derive the active link from window.location after a hydration flag flips — a real post-hydration change preact applies. Updates correctly on client navigation.


### PR DESCRIPTION
Part of #408. Fixes the active-page nav underline being missing on a direct/prerendered load until the user navigates.

## Root cause (diagnosed)
On the client, `useLocation()` is correct (`/blog`) from the first render — but **preact/compat does not reconcile a className that differs only between the prerendered DOM (inactive) and the first client render during hydration**. The vnode recorded 'active' while the DOM stayed 'inactive', so no later re-render ever patched it. (Every React-level attempt failed for this reason.)

## Fix
Two-pass render, the same pattern the banners already use:
1. Render **inactive on the first render** → matches the prerendered markup, so hydration is clean and the vnode == DOM.
2. Flip a `hydrated` flag in an effect, then derive the active link from `window.location.pathname`. That makes the underline a real inactive→active change **after** hydration, which preact applies.

`window.location` is correct from the first client render and react-router updates it synchronously on navigation, so it also stays correct after client-side nav.

## Verified (Chromium + WebKit)
Active on direct load of `/blog`, `/features`, `/pricing`; and after navigating: Features active, Blog inactive. `test:core` 324 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)