### PR TITLE
fix: resolve ReferenceError on slow trip generation

### DIFF
--- a/components/TripView.tsx
+++ b/components/TripView.tsx
@@ -1872,7 +1872,7 @@ const useTripViewRender = ({
         canAdminWrite: adminAccess?.canAdminWrite,
         hasInputSnapshot: Boolean(trip.aiMeta?.generation?.inputSnapshot),
         generationState,
-        latestAttemptOrchestration,
+        latestAttemptOrchestration: latestGenerationAttemptOrchestration,
         isRetryingGeneration,
         pendingAuthQueueRequestId,
     });

--- a/content/updates/2026-07-26-slow-generation-retry-crash.md
+++ b/content/updates/2026-07-26-slow-generation-retry-crash.md
@@ -1,0 +1,17 @@
+---
+id: rel-2026-07-26-slow-generation-retry-crash
+version: v0.158.0
+title: "Slow trip generation no longer breaks the trip view"
+date: 2026-07-26
+published_at: 2026-07-26T08:30:00Z
+status: draft
+notify_in_app: true
+in_app_hours: 24
+summary: "Trips that take unusually long to generate stay usable, with the restart option available instead of a blank screen."
+---
+
+## Changes
+- [x] [Fixed] ⏳ Trips that take longer than expected to generate no longer break the page — the trip view stays open while you wait.
+- [x] [Fixed] 🔁 The option to stop and restart a slow generation now appears reliably instead of crashing the screen.
+- [ ] [Internal] Passed the declared orchestration binding into the abort-and-retry capability check in TripView, fixing a ReferenceError thrown once `isGenerationSlow` became true.
+- [ ] [Internal] Added a regression test asserting the abort-and-retry options object references a declared identifier.

--- a/tests/unit/tripViewRuntimeOrder.test.ts
+++ b/tests/unit/tripViewRuntimeOrder.test.ts
@@ -20,4 +20,18 @@ describe('components/TripView runtime ordering', () => {
         expect(viewportStateIndex).toBeLessThan(paywallHandlerIndex);
         expect(viewportStateIndex).toBeLessThan(pendingAuthHandlerIndex);
     });
+
+    it('passes a declared orchestration binding into the abort-and-retry capability check', () => {
+        const source = readFileSync(
+            resolve(process.cwd(), 'components/TripView.tsx'),
+            'utf8',
+        );
+
+        // Regression: the abort-and-retry options object referenced a bare
+        // `latestAttemptOrchestration`, which threw a ReferenceError as soon as a
+        // generation exceeded the timeout and `isGenerationSlow` became true.
+        expect(source).toContain('const latestGenerationAttemptOrchestration = useMemo(');
+        expect(source).toContain('latestAttemptOrchestration: latestGenerationAttemptOrchestration,');
+        expect(source).not.toMatch(/^\s*latestAttemptOrchestration,\s*$/m);
+    });
 });


### PR DESCRIPTION
## Problem

`ReferenceError: latestAttemptOrchestration is not defined` crashes the trip view whenever a trip plan exceeds the generation timeout.

`components/TripView.tsx` passed a bare `latestAttemptOrchestration` into `canTriggerTripGenerationAbortAndRetry(...)`, but the component declares that value as `latestGenerationAttemptOrchestration`. The options object is only evaluated once `isGenerationSlow` short-circuits to true — i.e. when `generationElapsedMs >= TRIP_GENERATION_TIMEOUT_MS` — which is exactly the reported symptom.

This is a live bug on `main`, not a regression from an open feature branch.

## Fix

One line: pass the declared binding as `latestAttemptOrchestration: latestGenerationAttemptOrchestration`.

## Tests

- Added a regression case to `tests/unit/tripViewRuntimeOrder.test.ts` (same file/style as the existing TripView runtime-reference guard). Verified it fails against the unfixed source and passes with the fix.
- `pnpm test:core`: 328 files, 1544 passed, 1 skipped.
- `pnpm updates:validate`: passes (only pre-existing canonical-version warnings).

## Notes

`tsc --noEmit` does flag this as TS2304, but the repo has many pre-existing type errors so typecheck is not currently a gate. Two other latent `Cannot find name` errors exist and are **not** touched here: `components/admin/AdminShell.tsx:202` and `components/AppDialogProvider.tsx:263`.

Release note added as `content/updates/2026-07-26-slow-generation-retry-crash.md` (`status: draft`, `v0.158.0`) — publish metadata to follow after merge per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)