### PR TITLE
docs: publish v0.158.0 release note

### DIFF
--- a/content/updates/2026-07-26-slow-generation-retry-crash.md
+++ b/content/updates/2026-07-26-slow-generation-retry-crash.md
@@ -3,8 +3,8 @@ id: rel-2026-07-26-slow-generation-retry-crash
 version: v0.158.0
 title: "Slow trip generation no longer breaks the trip view"
 date: 2026-07-26
-published_at: 2026-07-26T08:30:00Z
-status: draft
+published_at: 2026-07-26T06:47:27Z
+status: published
 notify_in_app: true
 in_app_hours: 24
 summary: "Trips that take unusually long to generate stay usable, with the restart option available instead of a blank screen."


### PR DESCRIPTION
Follow-up to #445, per the release-note rule in CLAUDE.md: the feature PR carried the note as `status: draft`; this flips it to published with the real deploy timestamp.

- `status: draft` → `published`
- `published_at` → `2026-07-26T06:47:27Z` — the actual Netlify production publish time for deploy of `7d2c4b76` (before 23:00 UTC, and strictly after v0.157.0's `2026-07-15T19:42:00Z`)

Docs-only change. `pnpm updates:validate` exits 0 (pre-existing canonical-version warnings on older files only, unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)